### PR TITLE
Lovelace card v0.1.0 — first end-to-end release

### DIFF
--- a/.github/workflows/card.yml
+++ b/.github/workflows/card.yml
@@ -1,0 +1,63 @@
+name: Card
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: ESLint + Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
+
+  typecheck:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
+  test:
+    name: Vitest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  build:
+    name: Vite build (dist must match committed)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Verify dist/ is in sync with source
+        run: |
+          if ! git diff --quiet dist/; then
+            echo "::error::dist/ is out of sync. Run 'npm run build' and commit the result."
+            git diff --stat dist/
+            exit 1
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,12 +16,22 @@ jobs:
       - uses: actions/checkout@v4
       - uses: home-assistant/actions/hassfest@master
 
-  hacs:
-    name: HACS
+  hacs-integration:
+    name: HACS (integration)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: hacs/action@main
         with:
           category: integration
+          ignore: brands
+
+  hacs-plugin:
+    name: HACS (plugin)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: plugin
           ignore: brands

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,5 +37,7 @@ jobs:
           # `images` ignored until v0.2 ships with screenshots/GIFs of the
           # card running on a real dashboard (tracked in a v0.2 issue).
           # The check is a HACS public-listing requirement; custom-repo
-          # installs ignore it.
-          ignore: brands,images
+          # installs ignore it. NB: hacs/action's ignore list is
+          # space-separated (their action.yaml says so verbatim), not
+          # comma-separated like most CI fields.
+          ignore: brands images

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,4 +34,8 @@ jobs:
       - uses: hacs/action@main
         with:
           category: plugin
-          ignore: brands
+          # `images` ignored until v0.2 ships with screenshots/GIFs of the
+          # card running on a real dashboard (tracked in a v0.2 issue).
+          # The check is a HACS public-listing requirement; custom-repo
+          # installs ignore it.
+          ignore: brands,images

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,17 @@ __pycache__/
 *.so
 .Python
 build/
-dist/
 *.egg-info/
 *.egg
 .eggs/
+
+# Node / card build
+node_modules/
+coverage/
+*.tsbuildinfo
+
+# Note: `dist/` is INTENTIONALLY tracked — it holds the built
+# `dist/comfort-band-card.js` bundle that HACS plugin install reads.
 
 # Virtual environments
 .venv/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -10,16 +10,40 @@ Each zone gets its own band, override, and per-profile schedule. A **profile** (
 
 ## Status
 
-**v0.0.2 — headless preview.** The integration is fully functional via Developer Tools and the standard entity UI. There is no Lovelace card yet (Session C).
+**v0.1.0 — first end-to-end release.** Integration + Lovelace card. The integration logic is the same as v0.0.2 — full coordinator, per-zone entities, profile schedules, override timers, legacy importer. New in v0.1.0: a custom Lovelace card with a compact tile and an expanded modal (Now / Schedule / Profiles / Insights tabs).
 
-Every zone defaults to **shadow mode** (`switch.{zone}_enabled = off`): the integration computes the heat/cool/idle decision and updates the `current_action` sensor, but does **not** call `climate.set_hvac_mode`. Flip the switch on per zone when you're ready to cut over.
+Every zone still defaults to **shadow mode** (`switch.{zone}_enabled = off`): the integration computes the heat/cool/idle decision and updates the `current_action` sensor, but does **not** call `climate.set_hvac_mode`. Flip the switch on per zone when you're ready to cut over.
 
 ## Installation
 
-1. In HACS: **Integrations → ⋮ → Custom repositories**.
-2. URL: `https://github.com/dpretty/ha-comfort-band`. Category: **Integration**.
-3. Install. Restart Home Assistant.
-4. **Settings → Devices & Services → Add Integration → Comfort Band**.
+This repo publishes **two HACS items** from one source:
+
+1. **Integration** — the Python side. Adds the `comfort_band` entities and services.
+2. **Lovelace plugin** — the `comfort-band-card` dashboard card.
+
+HACS doesn't auto-detect dual-content repos, so you add the URL **twice** as a Custom Repository:
+
+1. In HACS: **Integrations → ⋮ → Custom repositories** → add `https://github.com/dpretty/ha-comfort-band`, category **Integration** → install → restart HA.
+2. **HACS → Frontend → ⋮ → Custom repositories** → add the same URL, category **Dashboard** → install. The bundle lands at `/hacsfiles/ha-comfort-band/comfort-band-card.js`; HACS adds the resource automatically.
+3. **Settings → Devices & Services → Add Integration → Comfort Band**.
+4. Add `type: custom:comfort-band-card` cards to your dashboard, one per zone.
+
+## The card
+
+```yaml
+type: custom:comfort-band-card
+zone: gym         # required — the zone slug from step 3
+compact: false    # optional — set true for a tile that doesn't expand on tap
+```
+
+Tap the tile → modal with four tabs:
+
+- **Now** — big band gauge, current room temp + action chip, dual-handle slider for manual low/high (drag = start an override), Cancel-override button, 1h/3h/6h duration presets.
+- **Schedule** — 24-hour timeline of the active profile's transitions. Tap empty → add. Tap a point → edit (precise time/low/high + delete). Long-press → delete. All edits persist via `comfort_band.set_schedule` (atomic full-schedule replacement).
+- **Profiles** — list every profile, switch with one tap (fires `comfort_band.set_profile`). Profile create / rename / delete is deferred to v0.2 (needs new services).
+- **Insights** — wraps HA's built-in `history-graph` for the last 24 h of `room_temperature`. v0.2 will replace this with a custom uPlot chart shaded by `current_action`.
+
+Card config can also be edited via the dashboard's visual editor (zone dropdown + compact-mode toggle).
 
 ## Setup walkthrough
 

--- a/card/src/band-gauge.ts
+++ b/card/src/band-gauge.ts
@@ -1,0 +1,98 @@
+/**
+ * `<band-gauge>` — horizontal `[low … room … high]` gauge for a Comfort Band zone.
+ *
+ * Renders a fixed-range track (15–28 °C) with a coloured band stripe between
+ * `low` and `high`, and a circular marker at `room`. The band's colour
+ * reflects `current_action` (red=heating, blue=cooling, grey=idle/unknown).
+ */
+
+import { LitElement, html, css, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { tokens, actionColorVar, asAction } from './styles.js';
+
+const RANGE_MIN = 15;
+const RANGE_MAX = 28;
+const RANGE = RANGE_MAX - RANGE_MIN;
+
+function pct(temp: number): number {
+  if (Number.isNaN(temp) || !Number.isFinite(temp)) return 0;
+  const clamped = Math.max(RANGE_MIN, Math.min(RANGE_MAX, temp));
+  return ((clamped - RANGE_MIN) / RANGE) * 100;
+}
+
+@customElement('band-gauge')
+export class BandGauge extends LitElement {
+  @property({ type: Number }) public low = NaN;
+  @property({ type: Number }) public high = NaN;
+  @property({ type: Number }) public room = NaN;
+  @property({ type: String }) public action: string | null = 'unknown';
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+      }
+      svg {
+        display: block;
+        width: 100%;
+        height: 24px;
+        overflow: visible;
+      }
+      .track {
+        fill: var(--cb-track-bg);
+      }
+      .band {
+        opacity: 0.85;
+      }
+      .marker-ring {
+        fill: var(--ha-card-background, var(--card-background-color, #ffffff));
+        stroke-width: 2;
+      }
+      .label {
+        font-size: 11px;
+        fill: var(--cb-text-secondary);
+        font-family: var(--paper-font-body1_-_font-family, sans-serif);
+      }
+    `,
+  ];
+
+  protected override render() {
+    const action = asAction(this.action);
+    const color = actionColorVar(action);
+
+    const lowKnown = Number.isFinite(this.low);
+    const highKnown = Number.isFinite(this.high);
+    const roomKnown = Number.isFinite(this.room);
+
+    const lowPct = lowKnown ? pct(this.low) : 0;
+    const highPct = highKnown ? pct(this.high) : 100;
+    const bandX = Math.min(lowPct, highPct);
+    const bandWidth = Math.max(0, Math.abs(highPct - lowPct));
+    const roomPct = roomKnown ? pct(this.room) : 50;
+
+    const fmt = (t: number) => (Number.isFinite(t) ? `${t.toFixed(1)}°` : '—');
+
+    const aria = `Comfort band gauge: low ${fmt(this.low)}, room ${fmt(this.room)}, high ${fmt(this.high)}, action ${action}`;
+
+    return html`
+      <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${aria}>
+        ${svg`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
+        ${lowKnown && highKnown
+          ? svg`<rect class="band" x=${bandX} y="9" width=${bandWidth} height="6" rx="3" fill=${color}></rect>`
+          : null}
+        ${roomKnown ? svg`<circle cx=${roomPct} cy="12" r="4.5" fill=${color}></circle>` : null}
+        ${roomKnown
+          ? svg`<circle class="marker-ring" cx=${roomPct} cy="12" r="3" stroke=${color}></circle>`
+          : null}
+      </svg>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'band-gauge': BandGauge;
+  }
+}

--- a/card/src/card-editor.ts
+++ b/card/src/card-editor.ts
@@ -1,0 +1,147 @@
+/**
+ * `<comfort-band-card-editor>` — visual config UI for the dashboard editor.
+ *
+ * Registered globally; HA picks it up via `static getConfigElement()` on
+ * the card class. Renders a zone dropdown (populated from `comfort_band`
+ * device identifiers) plus a "Compact mode" toggle.
+ *
+ * Fires HA's standard `config-changed` event with the merged config so the
+ * dashboard preview re-renders live as the user picks a zone.
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { ComfortBandCardConfig, HomeAssistant } from './types.js';
+import { tokens } from './styles.js';
+
+@customElement('comfort-band-card-editor')
+export class ComfortBandCardEditor extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+  @property({ attribute: false }) public config: ComfortBandCardConfig = {
+    type: 'custom:comfort-band-card',
+    zone: '',
+  };
+
+  public setConfig(config: ComfortBandCardConfig): void {
+    this.config = {
+      type: config.type ?? 'custom:comfort-band-card',
+      zone: config.zone ?? '',
+      ...(config.compact !== undefined ? { compact: config.compact } : {}),
+    };
+  }
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: var(--cb-gap-md);
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+      }
+      select,
+      input[type='checkbox'] {
+        font: inherit;
+      }
+      select {
+        font-size: 14px;
+        padding: 8px;
+        border: 1px solid var(--divider-color, #cccccc);
+        border-radius: 6px;
+        color: var(--cb-text-primary);
+        background: var(--ha-card-background, #ffffff);
+      }
+      .checkbox-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 14px;
+        color: var(--cb-text-primary);
+      }
+      .empty {
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+      }
+    `,
+  ];
+
+  private _availableZones(): string[] {
+    if (!this.hass) return [];
+    const slugs: string[] = [];
+    for (const device of Object.values(this.hass.devices)) {
+      for (const [domain, key] of device.identifiers) {
+        if (domain === 'comfort_band' && key.startsWith('zone:')) {
+          slugs.push(key.slice('zone:'.length));
+        }
+      }
+    }
+    return slugs.sort();
+  }
+
+  private _onZoneChange = (event: Event) => {
+    const zone = (event.target as HTMLSelectElement).value;
+    this._fireConfig({ ...this.config, zone });
+  };
+
+  private _onCompactChange = (event: Event) => {
+    const compact = (event.target as HTMLInputElement).checked;
+    const next = { ...this.config };
+    if (compact) next.compact = true;
+    else delete next.compact;
+    this._fireConfig(next);
+  };
+
+  private _fireConfig(config: ComfortBandCardConfig): void {
+    this.config = config;
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  protected override render() {
+    const zones = this._availableZones();
+    if (zones.length === 0) {
+      return html`<div class="empty">
+        No Comfort Band zones found. Add one via Settings → Devices & Services first.
+      </div>`;
+    }
+
+    return html`
+      <label>
+        Zone
+        <select @change=${this._onZoneChange} .value=${this.config.zone || ''}>
+          ${this.config.zone === ''
+            ? html`<option value="" disabled selected>Select a zone…</option>`
+            : null}
+          ${zones.map(
+            (z) => html` <option value=${z} ?selected=${z === this.config.zone}>${z}</option> `,
+          )}
+        </select>
+      </label>
+      <label class="checkbox-row">
+        <input
+          type="checkbox"
+          .checked=${this.config.compact === true}
+          @change=${this._onCompactChange}
+        />
+        Compact mode (tile only, no expand on tap)
+      </label>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-card-editor': ComfortBandCardEditor;
+  }
+}

--- a/card/src/comfort-band-card.ts
+++ b/card/src/comfort-band-card.ts
@@ -8,8 +8,10 @@
  */
 
 import { LitElement, html, css } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import './tile.js';
+import './modal.js';
+import type { ComfortBandModal } from './modal.js';
 import type { ComfortBandCardConfig, HassEntity, HomeAssistant } from './types.js';
 import type { ZoneEntities } from './helpers.js';
 import { findZoneEntities } from './helpers.js';
@@ -19,6 +21,7 @@ import { tokens } from './styles.js';
 export class ComfortBandCard extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
   @state() private _config?: ComfortBandCardConfig;
+  @query('comfort-band-modal') private _modal?: ComfortBandModal;
 
   public setConfig(config: ComfortBandCardConfig): void {
     if (!config?.zone) {
@@ -77,13 +80,19 @@ export class ComfortBandCard extends LitElement {
         .noExpand=${compact}
         @comfort-band-tile-tap=${this._onTileTap}
       ></comfort-band-tile>
+      ${compact
+        ? null
+        : html`<comfort-band-modal
+            .hass=${this.hass}
+            zone=${zoneSlug}
+            zoneName=${view.zoneName}
+            .entities=${entities}
+          ></comfort-band-modal>`}
     `;
   }
 
   private _onTileTap = () => {
-    // Commit 4 wires this to fire_dom_event for the modal. For now: log-only,
-    // so the click path is observable in dev tools.
-    console.debug('comfort-band-card: tile tap (modal lands in commit 4)');
+    this._modal?.open();
   };
 
   private _buildView(hass: HomeAssistant, entities: ZoneEntities) {

--- a/card/src/comfort-band-card.ts
+++ b/card/src/comfort-band-card.ts
@@ -1,0 +1,116 @@
+/**
+ * `<comfort-band-card>` — main custom element.
+ *
+ * Reads `{ type, zone }` config, resolves the zone's entities by device
+ * identifier (sidesteps post-cutover entity_id chaos), and renders a
+ * `<comfort-band-tile>` populated from live HA states. Tap on the tile
+ * fires `comfort-band-tile-tap`; commit 4 will use that to open the modal.
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import './tile.js';
+import type { ComfortBandCardConfig, HassEntity, HomeAssistant } from './types.js';
+import type { ZoneEntities } from './helpers.js';
+import { findZoneEntities } from './helpers.js';
+import { tokens } from './styles.js';
+
+@customElement('comfort-band-card')
+export class ComfortBandCard extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+  @state() private _config?: ComfortBandCardConfig;
+
+  public setConfig(config: ComfortBandCardConfig): void {
+    if (!config?.zone) {
+      throw new Error('comfort-band-card: `zone` is required');
+    }
+    this._config = config;
+  }
+
+  /** HA's panel/grid uses this to size the card. ~1 row per ~50 px of content. */
+  public getCardSize(): number {
+    return 2;
+  }
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+      }
+      .placeholder {
+        padding: var(--cb-gap-md);
+        border-radius: var(--cb-radius-card);
+        background: var(--ha-card-background, var(--card-background-color, #fff));
+        color: var(--cb-text-secondary);
+        font-family: var(--paper-font-body1_-_font-family, sans-serif);
+        font-size: 13px;
+      }
+    `,
+  ];
+
+  protected override render() {
+    if (!this._config || !this.hass) return html``;
+
+    const zoneSlug = this._config.zone;
+    const entities = findZoneEntities(this.hass, zoneSlug);
+
+    if (entities.deviceId === null) {
+      return html`<div class="placeholder">
+        Comfort Band zone <code>${zoneSlug}</code> not found. Add it via Settings → Devices &
+        Services.
+      </div>`;
+    }
+
+    const compact = this._config.compact === true;
+    const view = this._buildView(this.hass, entities);
+
+    return html`
+      <comfort-band-tile
+        zoneName=${view.zoneName}
+        .roomTemp=${view.roomTemp}
+        .low=${view.low}
+        .high=${view.high}
+        .action=${view.action}
+        .overrideActive=${view.overrideActive}
+        .overrideEnds=${view.overrideEnds}
+        .noExpand=${compact}
+        @comfort-band-tile-tap=${this._onTileTap}
+      ></comfort-band-tile>
+    `;
+  }
+
+  private _onTileTap = () => {
+    // Commit 4 wires this to fire_dom_event for the modal. For now: log-only,
+    // so the click path is observable in dev tools.
+    console.debug('comfort-band-card: tile tap (modal lands in commit 4)');
+  };
+
+  private _buildView(hass: HomeAssistant, entities: ZoneEntities) {
+    const stateOf = (entityId: string | null): HassEntity | undefined =>
+      entityId !== null ? hass.states[entityId] : undefined;
+
+    const numericState = (entityId: string | null): number => {
+      const s = stateOf(entityId);
+      if (!s) return NaN;
+      const n = parseFloat(s.state);
+      return Number.isFinite(n) ? n : NaN;
+    };
+
+    return {
+      zoneName: entities.deviceName ?? this._config!.zone,
+      low: numericState(entities.effectiveLow),
+      high: numericState(entities.effectiveHigh),
+      roomTemp: numericState(entities.roomTemperature),
+      action: stateOf(entities.currentAction)?.state ?? 'unknown',
+      overrideActive: stateOf(entities.overrideActive)?.state === 'on',
+      overrideEnds: stateOf(entities.overrideEnds)?.state ?? null,
+    };
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-card': ComfortBandCard;
+  }
+}

--- a/card/src/comfort-band-card.ts
+++ b/card/src/comfort-band-card.ts
@@ -11,6 +11,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import './tile.js';
 import './modal.js';
+import './card-editor.js';
 import type { ComfortBandModal } from './modal.js';
 import type { ComfortBandCardConfig, HassEntity, HomeAssistant } from './types.js';
 import type { ZoneEntities } from './helpers.js';
@@ -33,6 +34,31 @@ export class ComfortBandCard extends LitElement {
   /** HA's panel/grid uses this to size the card. ~1 row per ~50 px of content. */
   public getCardSize(): number {
     return 2;
+  }
+
+  /** HA dashboard editor: tells HA which custom element to render as the
+   *  visual config UI. Returning the element directly (not a string) is
+   *  the modern API. */
+  public static getConfigElement(): HTMLElement {
+    return document.createElement('comfort-band-card-editor');
+  }
+
+  /** Default config seed when the user adds the card via "Add card" in the
+   *  dashboard editor. Picks the first registered Comfort Band zone, if any. */
+  public static getStubConfig(hass: HomeAssistant | undefined): ComfortBandCardConfig {
+    let zone = '';
+    if (hass) {
+      for (const device of Object.values(hass.devices)) {
+        for (const [domain, key] of device.identifiers) {
+          if (domain === 'comfort_band' && key.startsWith('zone:')) {
+            zone = key.slice('zone:'.length);
+            break;
+          }
+        }
+        if (zone) break;
+      }
+    }
+    return { type: 'custom:comfort-band-card', zone };
   }
 
   public static override styles = [

--- a/card/src/dual-handle-slider.ts
+++ b/card/src/dual-handle-slider.ts
@@ -1,0 +1,245 @@
+/**
+ * `<dual-handle-slider>` — single-track range with two draggable thumbs.
+ *
+ * Used for the manual low/high in the Now tab. Behaviour:
+ *   - Dragging the low thumb writes `low`; clamps to `[min, high - step]`.
+ *   - Dragging the high thumb writes `high`; clamps to `[low + step, max]`.
+ *   - Fires `input` continuously while dragging, `change` on release or
+ *     after a keyboard adjustment. Both events have `detail = {low, high}`.
+ *   - Keyboard: Arrow keys step, Home/End jump to bounds.
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { tokens } from './styles.js';
+
+type Handle = 'low' | 'high';
+
+@customElement('dual-handle-slider')
+export class DualHandleSlider extends LitElement {
+  @property({ type: Number }) public min = 16;
+  @property({ type: Number }) public max = 26;
+  @property({ type: Number }) public step = 0.5;
+  @property({ type: Number }) public low = 19;
+  @property({ type: Number }) public high = 22;
+  @property({ type: String }) public unit = '°';
+
+  @state() private _dragging: Handle | null = null;
+
+  @query('.track') private _track?: HTMLElement;
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+        padding: 16px 12px;
+        --thumb-size: 20px;
+      }
+      .track {
+        position: relative;
+        height: 6px;
+        background: var(--cb-track-bg);
+        border-radius: 3px;
+        cursor: pointer;
+      }
+      .fill {
+        position: absolute;
+        top: 0;
+        height: 100%;
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        opacity: 0.6;
+        border-radius: 3px;
+        pointer-events: none;
+      }
+      .thumb {
+        position: absolute;
+        top: 50%;
+        width: var(--thumb-size);
+        height: var(--thumb-size);
+        margin-left: calc(var(--thumb-size) / -2);
+        margin-top: calc(var(--thumb-size) / -2);
+        background: var(--ha-card-background, #ffffff);
+        border: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        border-radius: 50%;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+        cursor: grab;
+        touch-action: none;
+        transition: transform 0.1s ease;
+      }
+      .thumb:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 3px;
+      }
+      .thumb.dragging {
+        cursor: grabbing;
+        transform: scale(1.15);
+      }
+      .label-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+        margin-top: 14px;
+        font-variant-numeric: tabular-nums;
+      }
+      .value-low,
+      .value-high {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--cb-text-primary);
+      }
+    `,
+  ];
+
+  private _pct(value: number): number {
+    const range = this.max - this.min;
+    if (range <= 0) return 0;
+    return ((value - this.min) / range) * 100;
+  }
+
+  private _snap(value: number): number {
+    const stepped = Math.round((value - this.min) / this.step) * this.step + this.min;
+    return Math.max(this.min, Math.min(this.max, stepped));
+  }
+
+  private _setHandle(handle: Handle, raw: number): boolean {
+    const value = this._snap(raw);
+    if (handle === 'low') {
+      const clamped = Math.min(value, this.high - this.step);
+      if (clamped === this.low) return false;
+      this.low = clamped;
+    } else {
+      const clamped = Math.max(value, this.low + this.step);
+      if (clamped === this.high) return false;
+      this.high = clamped;
+    }
+    return true;
+  }
+
+  private _xToValue(clientX: number): number {
+    const rect = this._track?.getBoundingClientRect();
+    if (!rect || rect.width === 0) return this.min;
+    const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    return this.min + ratio * (this.max - this.min);
+  }
+
+  private _onThumbPointerDown = (event: PointerEvent, handle: Handle) => {
+    event.preventDefault();
+    const target = event.currentTarget as HTMLElement;
+    target.setPointerCapture(event.pointerId);
+    this._dragging = handle;
+
+    const onMove = (ev: PointerEvent) => {
+      if (this._setHandle(handle, this._xToValue(ev.clientX))) {
+        this._fire('input');
+      }
+    };
+    const onUp = (ev: PointerEvent) => {
+      target.releasePointerCapture(ev.pointerId);
+      target.removeEventListener('pointermove', onMove);
+      target.removeEventListener('pointerup', onUp);
+      target.removeEventListener('pointercancel', onUp);
+      this._dragging = null;
+      this._fire('change');
+    };
+    target.addEventListener('pointermove', onMove);
+    target.addEventListener('pointerup', onUp);
+    target.addEventListener('pointercancel', onUp);
+  };
+
+  private _onTrackPointerDown = (event: PointerEvent) => {
+    if ((event.target as HTMLElement).classList.contains('thumb')) return;
+    const value = this._xToValue(event.clientX);
+    const mid = (this.low + this.high) / 2;
+    const handle: Handle = value < mid ? 'low' : 'high';
+    if (this._setHandle(handle, value)) this._fire('change');
+  };
+
+  private _onKeyDown = (event: KeyboardEvent, handle: Handle) => {
+    let delta = 0;
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        delta = -this.step;
+        break;
+      case 'ArrowRight':
+      case 'ArrowUp':
+        delta = this.step;
+        break;
+      case 'Home':
+        event.preventDefault();
+        if (this._setHandle(handle, this.min)) this._fire('change');
+        return;
+      case 'End':
+        event.preventDefault();
+        if (this._setHandle(handle, this.max)) this._fire('change');
+        return;
+      default:
+        return;
+    }
+    event.preventDefault();
+    const current = handle === 'low' ? this.low : this.high;
+    if (this._setHandle(handle, current + delta)) this._fire('change');
+  };
+
+  private _fire(type: 'input' | 'change') {
+    this.dispatchEvent(
+      new CustomEvent(type, {
+        detail: { low: this.low, high: this.high },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private _fmt(value: number): string {
+    return `${value.toFixed(1)}${this.unit}`;
+  }
+
+  protected override render() {
+    const lowPct = this._pct(this.low);
+    const highPct = this._pct(this.high);
+    return html`
+      <div class="track" @pointerdown=${this._onTrackPointerDown}>
+        <div class="fill" style="left:${lowPct}%; width:${highPct - lowPct}%"></div>
+        <div
+          class="thumb ${this._dragging === 'low' ? 'dragging' : ''}"
+          style="left:${lowPct}%"
+          tabindex="0"
+          role="slider"
+          aria-label="Lower bound"
+          aria-valuemin=${this.min}
+          aria-valuemax=${this.high - this.step}
+          aria-valuenow=${this.low}
+          aria-valuetext=${this._fmt(this.low)}
+          @pointerdown=${(e: PointerEvent) => this._onThumbPointerDown(e, 'low')}
+          @keydown=${(e: KeyboardEvent) => this._onKeyDown(e, 'low')}
+        ></div>
+        <div
+          class="thumb ${this._dragging === 'high' ? 'dragging' : ''}"
+          style="left:${highPct}%"
+          tabindex="0"
+          role="slider"
+          aria-label="Upper bound"
+          aria-valuemin=${this.low + this.step}
+          aria-valuemax=${this.max}
+          aria-valuenow=${this.high}
+          aria-valuetext=${this._fmt(this.high)}
+          @pointerdown=${(e: PointerEvent) => this._onThumbPointerDown(e, 'high')}
+          @keydown=${(e: KeyboardEvent) => this._onKeyDown(e, 'high')}
+        ></div>
+      </div>
+      <div class="label-row">
+        <span class="value-low">${this._fmt(this.low)}</span>
+        <span class="value-high">${this._fmt(this.high)}</span>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'dual-handle-slider': DualHandleSlider;
+  }
+}

--- a/card/src/helpers.ts
+++ b/card/src/helpers.ts
@@ -1,0 +1,143 @@
+/**
+ * Entity-registry resolution for a Comfort Band zone.
+ *
+ * The card never assumes entity-id patterns — the cutover left two
+ * conventions in the wild (e.g. `*.gym_hvac_new_*` vs `*.{zone}_*` with
+ * `_2` suffixes for collisions). Instead it resolves entities by:
+ *
+ *   1. Locating the zone's device via `(comfort_band, zone:{slug})` in the
+ *      device registry (set in `entity.py:37`).
+ *   2. Filtering the entity registry by that `device_id`.
+ *   3. Matching each entity's `unique_id` against the deterministic
+ *      `{zone_name}_{translation_key}` pattern set in `entity.py:34`.
+ */
+
+import type { DeviceRegistryEntry, EntityRegistryEntry, HomeAssistant } from './types.js';
+
+const DOMAIN = 'comfort_band';
+
+/** Entity IDs for one zone's full set of platform entities. Any may be `null`
+ *  if the integration hasn't created it yet (or the user has disabled it). */
+export interface ZoneEntities {
+  // Sensors
+  effectiveLow: string | null;
+  effectiveHigh: string | null;
+  roomTemperature: string | null;
+  overrideEnds: string | null;
+  currentAction: string | null;
+  // Binary sensor
+  overrideActive: string | null;
+  // Numbers
+  manualLow: string | null;
+  manualHigh: string | null;
+  overrideHours: string | null;
+  deadbandBelow: string | null;
+  deadbandAbove: string | null;
+  minCycleMinutes: string | null;
+  // Button
+  cancelOverride: string | null;
+  // Switch
+  enabled: string | null;
+  // Device meta (null if device not found)
+  deviceId: string | null;
+  deviceName: string | null;
+}
+
+/** Map from `unique_id` suffix (after the zone-name prefix) to the
+ *  `ZoneEntities` field that holds the resolved entity_id. */
+const KEY_TO_FIELD: Record<string, keyof ZoneEntities> = {
+  effective_low: 'effectiveLow',
+  effective_high: 'effectiveHigh',
+  room_temperature: 'roomTemperature',
+  override_ends: 'overrideEnds',
+  current_action: 'currentAction',
+  override_active: 'overrideActive',
+  manual_low: 'manualLow',
+  manual_high: 'manualHigh',
+  override_hours: 'overrideHours',
+  deadband_below: 'deadbandBelow',
+  deadband_above: 'deadbandAbove',
+  min_cycle_minutes: 'minCycleMinutes',
+  cancel_override: 'cancelOverride',
+  enabled: 'enabled',
+};
+
+function emptyZoneEntities(): ZoneEntities {
+  return {
+    effectiveLow: null,
+    effectiveHigh: null,
+    roomTemperature: null,
+    overrideEnds: null,
+    currentAction: null,
+    overrideActive: null,
+    manualLow: null,
+    manualHigh: null,
+    overrideHours: null,
+    deadbandBelow: null,
+    deadbandAbove: null,
+    minCycleMinutes: null,
+    cancelOverride: null,
+    enabled: null,
+    deviceId: null,
+    deviceName: null,
+  };
+}
+
+function findDeviceByIdentifier(
+  hass: HomeAssistant,
+  identifier: [string, string],
+): DeviceRegistryEntry | null {
+  for (const device of Object.values(hass.devices)) {
+    for (const [domain, key] of device.identifiers) {
+      if (domain === identifier[0] && key === identifier[1]) {
+        return device;
+      }
+    }
+  }
+  return null;
+}
+
+function entitiesForDevice(hass: HomeAssistant, deviceId: string): EntityRegistryEntry[] {
+  return Object.values(hass.entities).filter(
+    (entry) => entry.device_id === deviceId && entry.platform === DOMAIN,
+  );
+}
+
+/**
+ * Resolve every entity for the given zone. Missing entities stay `null`.
+ *
+ * Returns `null` for `deviceId`/`deviceName` if the zone device is not
+ * registered yet (e.g. the integration hasn't been added for that zone).
+ */
+export function findZoneEntities(hass: HomeAssistant, zoneSlug: string): ZoneEntities {
+  const result = emptyZoneEntities();
+  const device = findDeviceByIdentifier(hass, [DOMAIN, `zone:${zoneSlug}`]);
+  if (device === null) return result;
+
+  result.deviceId = device.id;
+  result.deviceName = device.name_by_user ?? device.name;
+
+  const prefix = `${zoneSlug}_`;
+  for (const entry of entitiesForDevice(hass, device.id)) {
+    if (!entry.unique_id.startsWith(prefix)) continue;
+    const suffix = entry.unique_id.slice(prefix.length);
+    const field = KEY_TO_FIELD[suffix];
+    if (field !== undefined) {
+      // Cast: every key in `KEY_TO_FIELD` maps to a string-typed field.
+      (result as unknown as Record<string, string | null>)[field] = entry.entity_id;
+    }
+  }
+  return result;
+}
+
+/** Resolve the singleton `select.{...}_active_profile` entity_id, if registered. */
+export function findActiveProfileEntity(hass: HomeAssistant): string | null {
+  const device = findDeviceByIdentifier(hass, [DOMAIN, 'profile_manager']);
+  if (device === null) return null;
+  for (const entry of entitiesForDevice(hass, device.id)) {
+    if (entry.unique_id === 'profile_manager_active_profile') {
+      return entry.entity_id;
+    }
+  }
+  return null;
+}

--- a/card/src/index.ts
+++ b/card/src/index.ts
@@ -1,0 +1,67 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+interface ComfortBandCardConfig {
+  type: string;
+  zone: string;
+  compact?: boolean;
+}
+
+@customElement('comfort-band-card')
+export class ComfortBandCard extends LitElement {
+  @property({ attribute: false }) public hass?: unknown;
+  @state() private _config?: ComfortBandCardConfig;
+
+  public setConfig(config: ComfortBandCardConfig): void {
+    if (!config?.zone) {
+      throw new Error('comfort-band-card: `zone` is required');
+    }
+    this._config = config;
+  }
+
+  public static override styles = css`
+    :host {
+      display: block;
+      padding: 12px;
+      border-radius: 12px;
+      background: var(--ha-card-background, var(--card-background-color, #fff));
+      box-shadow: var(--ha-card-box-shadow, none);
+    }
+    .stub {
+      color: var(--primary-text-color, #000);
+      font-family: var(--paper-font-body1_-_font-family, sans-serif);
+    }
+  `;
+
+  protected override render() {
+    if (!this._config) return html``;
+    return html`<div class="stub">comfort-band-card · zone: ${this._config.zone}</div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-card': ComfortBandCard;
+  }
+  interface Window {
+    customCards?: Array<{
+      type: string;
+      name: string;
+      description: string;
+      preview?: boolean;
+    }>;
+  }
+}
+
+(window.customCards ??= []).push({
+  type: 'comfort-band-card',
+  name: 'Comfort Band',
+  description: 'Schedule editor and live status for a Comfort Band zone.',
+  preview: false,
+});
+
+console.info(
+  '%c COMFORT-BAND-CARD %c v0.1.0-dev ',
+  'color:white;background:#2196F3;padding:2px 4px;border-radius:3px',
+  'color:#000;background:#fff;padding:2px 4px;border-radius:3px',
+);

--- a/card/src/index.ts
+++ b/card/src/index.ts
@@ -27,7 +27,7 @@ declare global {
 });
 
 console.info(
-  '%c COMFORT-BAND-CARD %c v0.1.0-dev ',
+  '%c COMFORT-BAND-CARD %c v0.1.0 ',
   'color:white;background:#2196F3;padding:2px 4px;border-radius:3px',
   'color:#000;background:#fff;padding:2px 4px;border-radius:3px',
 );

--- a/card/src/index.ts
+++ b/card/src/index.ts
@@ -1,43 +1,14 @@
-import { LitElement, html, css } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
-import type { ComfortBandCardConfig, HomeAssistant } from './types.js';
+/**
+ * Bundle entry point.
+ *
+ * Importing this file registers `<comfort-band-card>` (and its sub-elements
+ * via transitive imports) and pushes the card into HA's `customCards`
+ * registry so it appears in the dashboard's "Add card" picker.
+ */
 
-@customElement('comfort-band-card')
-export class ComfortBandCard extends LitElement {
-  @property({ attribute: false }) public hass?: HomeAssistant;
-  @state() private _config?: ComfortBandCardConfig;
-
-  public setConfig(config: ComfortBandCardConfig): void {
-    if (!config?.zone) {
-      throw new Error('comfort-band-card: `zone` is required');
-    }
-    this._config = config;
-  }
-
-  public static override styles = css`
-    :host {
-      display: block;
-      padding: 12px;
-      border-radius: 12px;
-      background: var(--ha-card-background, var(--card-background-color, #fff));
-      box-shadow: var(--ha-card-box-shadow, none);
-    }
-    .stub {
-      color: var(--primary-text-color, #000);
-      font-family: var(--paper-font-body1_-_font-family, sans-serif);
-    }
-  `;
-
-  protected override render() {
-    if (!this._config) return html``;
-    return html`<div class="stub">comfort-band-card · zone: ${this._config.zone}</div>`;
-  }
-}
+import './comfort-band-card.js';
 
 declare global {
-  interface HTMLElementTagNameMap {
-    'comfort-band-card': ComfortBandCard;
-  }
   interface Window {
     customCards?: Array<{
       type: string;

--- a/card/src/index.ts
+++ b/card/src/index.ts
@@ -1,15 +1,10 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-
-interface ComfortBandCardConfig {
-  type: string;
-  zone: string;
-  compact?: boolean;
-}
+import type { ComfortBandCardConfig, HomeAssistant } from './types.js';
 
 @customElement('comfort-band-card')
 export class ComfortBandCard extends LitElement {
-  @property({ attribute: false }) public hass?: unknown;
+  @property({ attribute: false }) public hass?: HomeAssistant;
   @state() private _config?: ComfortBandCardConfig;
 
   public setConfig(config: ComfortBandCardConfig): void {

--- a/card/src/modal.ts
+++ b/card/src/modal.ts
@@ -1,0 +1,202 @@
+/**
+ * `<comfort-band-modal>` — full-screen tabbed dialog opened by tile tap.
+ *
+ * Uses the native `<dialog>` element (modal API): `showModal()` opens with
+ * a backdrop, ESC and click-outside close it. No browser_mod dependency.
+ *
+ * Tabs in v0.1.0:
+ *   - Now (commit 4)
+ *   - Schedule (commit 7)
+ *   - Profiles (commit 5)
+ *   - Insights (commit 6)
+ *
+ * Tabs the user hasn't reached yet render a "coming soon" placeholder so
+ * the modal works end-to-end through every commit.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import './tabs/now-tab.js';
+import type { ZoneEntities } from './helpers.js';
+import type { HomeAssistant } from './types.js';
+import { tokens } from './styles.js';
+
+type TabId = 'now' | 'schedule' | 'profiles' | 'insights';
+
+const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+  { id: 'now', label: 'Now' },
+  { id: 'schedule', label: 'Schedule' },
+  { id: 'profiles', label: 'Profiles' },
+  { id: 'insights', label: 'Insights' },
+];
+
+@customElement('comfort-band-modal')
+export class ComfortBandModal extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+  @property({ type: String }) public zone = '';
+  @property({ type: String }) public zoneName = '';
+  @property({ attribute: false }) public entities?: ZoneEntities;
+
+  @state() private _activeTab: TabId = 'now';
+  @state() private _isOpen = false;
+
+  @query('dialog') private _dialog?: HTMLDialogElement;
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        --cb-modal-max-width: 480px;
+      }
+      dialog {
+        width: min(90vw, var(--cb-modal-max-width));
+        max-height: min(90vh, 720px);
+        padding: 0;
+        border: none;
+        border-radius: var(--cb-radius-card);
+        background: var(--ha-card-background, var(--card-background-color, #ffffff));
+        color: var(--cb-text-primary);
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+        overflow: hidden;
+      }
+      dialog::backdrop {
+        background: rgba(0, 0, 0, 0.4);
+      }
+      .frame {
+        display: flex;
+        flex-direction: column;
+        max-height: inherit;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--cb-gap-md);
+        border-bottom: 1px solid var(--divider-color, #e0e0e0);
+      }
+      header h2 {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 500;
+        color: var(--cb-text-primary);
+      }
+      .close {
+        font: inherit;
+        font-size: 22px;
+        line-height: 1;
+        background: transparent;
+        border: none;
+        color: var(--cb-text-secondary);
+        cursor: pointer;
+        padding: 4px 8px;
+      }
+      nav {
+        display: flex;
+        gap: 0;
+        border-bottom: 1px solid var(--divider-color, #e0e0e0);
+        overflow-x: auto;
+      }
+      nav button {
+        font: inherit;
+        font-size: 13px;
+        padding: 10px 14px;
+        background: transparent;
+        border: none;
+        border-bottom: 2px solid transparent;
+        color: var(--cb-text-secondary);
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      nav button[aria-selected='true'] {
+        color: var(--cb-accent, var(--primary-color, #03a9f4));
+        border-bottom-color: var(--cb-accent, var(--primary-color, #03a9f4));
+      }
+      .panel {
+        overflow-y: auto;
+        flex: 1;
+      }
+      .placeholder {
+        padding: var(--cb-gap-lg);
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+        text-align: center;
+      }
+    `,
+  ];
+
+  public open(): void {
+    this._isOpen = true;
+    this.updateComplete.then(() => this._dialog?.showModal());
+  }
+
+  public close(): void {
+    this._dialog?.close();
+  }
+
+  public selectTab(tab: TabId): void {
+    this._activeTab = tab;
+  }
+
+  private _onClose = () => {
+    this._isOpen = false;
+    this.dispatchEvent(
+      new CustomEvent('comfort-band-modal-close', { bubbles: true, composed: true }),
+    );
+  };
+
+  private _onSelectTab = (tab: TabId) => {
+    this._activeTab = tab;
+  };
+
+  protected override render() {
+    if (!this._isOpen) return nothing;
+    const title = this.zoneName || this.zone || 'Comfort Band';
+    return html`
+      <dialog @close=${this._onClose}>
+        <div class="frame">
+          <header>
+            <h2>${title}</h2>
+            <button class="close" @click=${this.close} aria-label="Close">×</button>
+          </header>
+          <nav role="tablist">
+            ${TABS.map(
+              (t) => html`
+                <button
+                  role="tab"
+                  aria-selected=${this._activeTab === t.id}
+                  @click=${() => this._onSelectTab(t.id)}
+                >
+                  ${t.label}
+                </button>
+              `,
+            )}
+          </nav>
+          <div class="panel" role="tabpanel">${this._renderTab()}</div>
+        </div>
+      </dialog>
+    `;
+  }
+
+  private _renderTab() {
+    switch (this._activeTab) {
+      case 'now':
+        return html`<comfort-band-now-tab
+          .hass=${this.hass}
+          .zone=${this.zone}
+          .entities=${this.entities}
+        ></comfort-band-now-tab>`;
+      case 'schedule':
+        return html`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
+      case 'profiles':
+        return html`<div class="placeholder">Profiles — landing in commit 5.</div>`;
+      case 'insights':
+        return html`<div class="placeholder">Insights — landing in commit 6.</div>`;
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-modal': ComfortBandModal;
+  }
+}

--- a/card/src/modal.ts
+++ b/card/src/modal.ts
@@ -18,6 +18,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import './tabs/now-tab.js';
 import './tabs/profiles-tab.js';
+import './tabs/insights-tab.js';
 import type { ZoneEntities } from './helpers.js';
 import type { HomeAssistant } from './types.js';
 import { tokens } from './styles.js';
@@ -191,7 +192,10 @@ export class ComfortBandModal extends LitElement {
       case 'profiles':
         return html`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
       case 'insights':
-        return html`<div class="placeholder">Insights — landing in commit 6.</div>`;
+        return html`<comfort-band-insights-tab
+          .hass=${this.hass}
+          .entities=${this.entities}
+        ></comfort-band-insights-tab>`;
     }
   }
 }

--- a/card/src/modal.ts
+++ b/card/src/modal.ts
@@ -19,6 +19,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import './tabs/now-tab.js';
 import './tabs/profiles-tab.js';
 import './tabs/insights-tab.js';
+import './tabs/schedule-tab.js';
 import type { ZoneEntities } from './helpers.js';
 import type { HomeAssistant } from './types.js';
 import { tokens } from './styles.js';
@@ -188,7 +189,10 @@ export class ComfortBandModal extends LitElement {
           .entities=${this.entities}
         ></comfort-band-now-tab>`;
       case 'schedule':
-        return html`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
+        return html`<comfort-band-schedule-tab
+          .hass=${this.hass}
+          .zone=${this.zone}
+        ></comfort-band-schedule-tab>`;
       case 'profiles':
         return html`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
       case 'insights':

--- a/card/src/modal.ts
+++ b/card/src/modal.ts
@@ -17,6 +17,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import './tabs/now-tab.js';
+import './tabs/profiles-tab.js';
 import type { ZoneEntities } from './helpers.js';
 import type { HomeAssistant } from './types.js';
 import { tokens } from './styles.js';
@@ -188,7 +189,7 @@ export class ComfortBandModal extends LitElement {
       case 'schedule':
         return html`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
       case 'profiles':
-        return html`<div class="placeholder">Profiles — landing in commit 5.</div>`;
+        return html`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
       case 'insights':
         return html`<div class="placeholder">Insights — landing in commit 6.</div>`;
     }

--- a/card/src/services.ts
+++ b/card/src/services.ts
@@ -5,9 +5,19 @@
  * the promise from `hass.callService` so callers can `await` for the round-trip.
  */
 
-import type { HomeAssistant, Transition } from './types.js';
+import type { HomeAssistant, ProfileSchedule, Transition } from './types.js';
 
 const DOMAIN = 'comfort_band';
+
+export function getSchedule(
+  hass: HomeAssistant,
+  args: { zone: string; profile: string },
+): Promise<ProfileSchedule | null> {
+  return hass.callWS<ProfileSchedule | null>({
+    type: 'comfort_band/get_schedule',
+    ...args,
+  });
+}
 
 export function setSchedule(
   hass: HomeAssistant,

--- a/card/src/services.ts
+++ b/card/src/services.ts
@@ -1,0 +1,57 @@
+/**
+ * Typed wrappers around the eight `comfort_band.*` services.
+ *
+ * Mirrors `custom_components/comfort_band/services.yaml`. Each call returns
+ * the promise from `hass.callService` so callers can `await` for the round-trip.
+ */
+
+import type { HomeAssistant, Transition } from './types.js';
+
+const DOMAIN = 'comfort_band';
+
+export function setSchedule(
+  hass: HomeAssistant,
+  args: { zone: string; profile: string; transitions: Transition[] },
+): Promise<unknown> {
+  return hass.callService(DOMAIN, 'set_schedule', { ...args });
+}
+
+export function addTransition(
+  hass: HomeAssistant,
+  args: { zone: string; profile: string; at: string; low: number; high: number },
+): Promise<unknown> {
+  return hass.callService(DOMAIN, 'add_transition', { ...args });
+}
+
+export function updateTransition(
+  hass: HomeAssistant,
+  args: { zone: string; profile: string; at: string; low: number; high: number },
+): Promise<unknown> {
+  return hass.callService(DOMAIN, 'update_transition', { ...args });
+}
+
+export function removeTransition(
+  hass: HomeAssistant,
+  args: { zone: string; profile: string; at: string },
+): Promise<unknown> {
+  return hass.callService(DOMAIN, 'remove_transition', { ...args });
+}
+
+export function startOverride(
+  hass: HomeAssistant,
+  args: { zone: string; low?: number; high?: number; hours?: number },
+): Promise<unknown> {
+  const data: Record<string, unknown> = { zone: args.zone };
+  if (args.low !== undefined) data.low = args.low;
+  if (args.high !== undefined) data.high = args.high;
+  if (args.hours !== undefined) data.hours = args.hours;
+  return hass.callService(DOMAIN, 'start_override', data);
+}
+
+export function cancelOverride(hass: HomeAssistant, args: { zone: string }): Promise<unknown> {
+  return hass.callService(DOMAIN, 'cancel_override', { ...args });
+}
+
+export function setProfile(hass: HomeAssistant, args: { profile: string }): Promise<unknown> {
+  return hass.callService(DOMAIN, 'set_profile', { ...args });
+}

--- a/card/src/styles.ts
+++ b/card/src/styles.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared CSS tokens for the Comfort Band card.
+ *
+ * Action colours follow the convention used elsewhere in HA: red for
+ * heating, blue for cooling, neutral grey for idle, light grey for unknown.
+ * Falls back to HA theme variables so themes can override.
+ */
+
+import { css } from 'lit';
+import type { ComfortBandAction } from './types.js';
+
+export const tokens = css`
+  :host {
+    --cb-action-heating: var(--cb-color-heat, var(--state-climate-heat-color, #d9603f));
+    --cb-action-cooling: var(--cb-color-cool, var(--state-climate-cool-color, #2f7fcc));
+    --cb-action-idle: var(--cb-color-idle, var(--state-inactive-color, #888888));
+    --cb-action-unknown: var(--cb-color-unknown, var(--disabled-color, #bdbdbd));
+
+    --cb-track-bg: var(--divider-color, #e0e0e0);
+    --cb-text-primary: var(--primary-text-color, #212121);
+    --cb-text-secondary: var(--secondary-text-color, #727272);
+
+    --cb-radius-card: 12px;
+    --cb-radius-pill: 999px;
+    --cb-gap-xs: 4px;
+    --cb-gap-sm: 8px;
+    --cb-gap-md: 12px;
+    --cb-gap-lg: 16px;
+  }
+`;
+
+/** Maps an action string to its CSS custom-property reference. */
+export function actionColorVar(action: ComfortBandAction | string | null | undefined): string {
+  switch (action) {
+    case 'heating':
+      return 'var(--cb-action-heating)';
+    case 'cooling':
+      return 'var(--cb-action-cooling)';
+    case 'idle':
+      return 'var(--cb-action-idle)';
+    default:
+      return 'var(--cb-action-unknown)';
+  }
+}
+
+/** Coerce any string to a known action, falling back to 'unknown'. */
+export function asAction(value: unknown): ComfortBandAction {
+  if (value === 'heating' || value === 'cooling' || value === 'idle') return value;
+  return 'unknown';
+}
+
+/** Display label for an action (used in chips and a11y). */
+export function actionLabel(action: ComfortBandAction): string {
+  return action.charAt(0).toUpperCase() + action.slice(1);
+}

--- a/card/src/tabs/insights-tab.ts
+++ b/card/src/tabs/insights-tab.ts
@@ -1,0 +1,137 @@
+/**
+ * `<comfort-band-insights-tab>` — Insights tab content.
+ *
+ * Wraps HA's built-in `history-graph` card via the well-known
+ * `window.loadCardHelpers()` async loader (the canonical way for custom
+ * cards to instantiate built-in card types). Falls back to a deep link
+ * to HA's `/history` page if the helper isn't available (e.g. when the
+ * frontend bundle is mid-update or the HA version predates loadCardHelpers).
+ *
+ * v0.2 will replace this with a custom uPlot chart that shades bands by
+ * `current_action`. v0.1 just gives users a trend.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import type { PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { ZoneEntities } from '../helpers.js';
+import type { HomeAssistant } from '../types.js';
+import { tokens } from '../styles.js';
+
+interface CardHelpers {
+  createCardElement: (config: unknown) => HTMLElement & { hass?: unknown };
+}
+
+declare global {
+  interface Window {
+    loadCardHelpers?: () => Promise<CardHelpers>;
+  }
+}
+
+@customElement('comfort-band-insights-tab')
+export class ComfortBandInsightsTab extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+  @property({ attribute: false }) public entities?: ZoneEntities;
+
+  @state() private _graphAvailable: boolean | null = null;
+  private _graphCard: (HTMLElement & { hass?: unknown }) | null = null;
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      .graph-container {
+        min-height: 220px;
+      }
+      .graph-container :first-child {
+        --ha-card-box-shadow: none;
+      }
+      .fallback,
+      .empty {
+        padding: var(--cb-gap-lg);
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+        text-align: center;
+      }
+      .fallback a {
+        color: var(--cb-accent, var(--primary-color, #03a9f4));
+        text-decoration: none;
+        margin-left: 8px;
+      }
+    `,
+  ];
+
+  protected override async firstUpdated(): Promise<void> {
+    await this._maybeMountGraph();
+  }
+
+  protected override updated(changed: PropertyValues<this>): void {
+    if (changed.has('entities') || changed.has('hass')) {
+      void this._maybeMountGraph();
+    }
+  }
+
+  private async _maybeMountGraph(): Promise<void> {
+    const entityId = this.entities?.roomTemperature;
+    if (!entityId || !this.hass) return;
+
+    if (this._graphCard) {
+      this._graphCard.hass = this.hass;
+      return;
+    }
+
+    if (typeof window.loadCardHelpers !== 'function') {
+      this._graphAvailable = false;
+      return;
+    }
+
+    try {
+      const helpers = await window.loadCardHelpers();
+      const card = helpers.createCardElement({
+        type: 'history-graph',
+        entities: [entityId],
+        hours_to_show: 24,
+      });
+      card.hass = this.hass;
+      const container = this.renderRoot.querySelector('.graph-container');
+      if (container) {
+        container.innerHTML = '';
+        container.appendChild(card);
+        this._graphCard = card;
+        this._graphAvailable = true;
+      }
+    } catch {
+      this._graphAvailable = false;
+    }
+  }
+
+  protected override render() {
+    const entityId = this.entities?.roomTemperature;
+    if (!entityId) {
+      return html`<div class="empty">No room temperature sensor for this zone.</div>`;
+    }
+
+    return html`
+      <div class="graph-container"></div>
+      ${
+        this._graphAvailable === false
+          ? html`<div class="fallback">
+              Inline graph unavailable.
+              <a href="/history?entity_id=${entityId}" target="_blank" rel="noopener"
+                >Open in HA history →</a
+              >
+            </div>`
+          : nothing
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-insights-tab': ComfortBandInsightsTab;
+  }
+}

--- a/card/src/tabs/insights-tab.ts
+++ b/card/src/tabs/insights-tab.ts
@@ -116,16 +116,14 @@ export class ComfortBandInsightsTab extends LitElement {
 
     return html`
       <div class="graph-container"></div>
-      ${
-        this._graphAvailable === false
-          ? html`<div class="fallback">
-              Inline graph unavailable.
-              <a href="/history?entity_id=${entityId}" target="_blank" rel="noopener"
-                >Open in HA history →</a
-              >
-            </div>`
-          : nothing
-      }
+      ${this._graphAvailable === false
+        ? html`<div class="fallback">
+            Inline graph unavailable.
+            <a href="/history?entity_id=${entityId}" target="_blank" rel="noopener"
+              >Open in HA history →</a
+            >
+          </div>`
+        : nothing}
     `;
   }
 }

--- a/card/src/tabs/now-tab.ts
+++ b/card/src/tabs/now-tab.ts
@@ -1,0 +1,272 @@
+/**
+ * `<comfort-band-now-tab>` — the "Now" tab content of the modal.
+ *
+ * Reads live state for the zone (room, low, high, action, override) and
+ * shows:
+ *   - Big band gauge at the top.
+ *   - Current action chip (heating / cooling / idle).
+ *   - Dual-handle slider for manual_low/manual_high — any change starts
+ *     an override via `comfort_band.start_override` (the slider's
+ *     `change` event, fired on release, drives the service call).
+ *   - Override-active state line + Cancel-override button.
+ *   - Override-duration buttons (1h / 3h / 6h) that update the
+ *     `number.{zone}_override_hours` entity for future overrides.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import '../band-gauge.js';
+import '../dual-handle-slider.js';
+import type { DualHandleSlider } from '../dual-handle-slider.js';
+import type { ZoneEntities } from '../helpers.js';
+import type { HomeAssistant } from '../types.js';
+import { cancelOverride, startOverride } from '../services.js';
+import { tokens, actionColorVar, asAction, actionLabel } from '../styles.js';
+
+const HOUR_PRESETS = [1, 3, 6] as const;
+
+@customElement('comfort-band-now-tab')
+export class ComfortBandNowTab extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+  @property({ type: String }) public zone = '';
+  @property({ attribute: false }) public entities?: ZoneEntities;
+
+  @state() private _pendingLow: number | null = null;
+  @state() private _pendingHigh: number | null = null;
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      .gauge-row {
+        margin-bottom: var(--cb-gap-md);
+      }
+      .header-row {
+        display: flex;
+        align-items: baseline;
+        gap: var(--cb-gap-sm);
+        margin-bottom: var(--cb-gap-sm);
+      }
+      .room-temp {
+        font-size: 36px;
+        font-weight: 300;
+        color: var(--cb-text-primary);
+        font-variant-numeric: tabular-nums;
+        line-height: 1;
+      }
+      .action-chip {
+        font-size: 11px;
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 2px 8px;
+        border-radius: var(--cb-radius-pill);
+        color: var(--cb-text-on-action, #ffffff);
+      }
+      section {
+        margin-top: var(--cb-gap-lg);
+      }
+      h3 {
+        margin: 0 0 var(--cb-gap-sm);
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--cb-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .override-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--cb-gap-sm);
+        padding: var(--cb-gap-sm) var(--cb-gap-md);
+        border-radius: var(--cb-radius-card);
+        background: var(--cb-track-bg);
+        font-size: 13px;
+        color: var(--cb-text-primary);
+      }
+      .button {
+        font: inherit;
+        padding: 6px 12px;
+        border-radius: var(--cb-radius-pill);
+        border: 1px solid transparent;
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        color: #ffffff;
+        cursor: pointer;
+      }
+      .button.secondary {
+        background: transparent;
+        border-color: var(--divider-color, #cccccc);
+        color: var(--cb-text-primary);
+      }
+      .preset-row {
+        display: flex;
+        gap: var(--cb-gap-sm);
+      }
+      .preset {
+        font: inherit;
+        padding: 4px 10px;
+        border-radius: var(--cb-radius-pill);
+        border: 1px solid var(--divider-color, #cccccc);
+        background: transparent;
+        color: var(--cb-text-primary);
+        cursor: pointer;
+      }
+      .preset.active {
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        color: #ffffff;
+        border-color: transparent;
+      }
+    `,
+  ];
+
+  private get _stateOf() {
+    const states = this.hass?.states ?? {};
+    return (entityId: string | null) => (entityId !== null ? states[entityId] : undefined);
+  }
+
+  private _numericState(entityId: string | null): number {
+    const s = this._stateOf(entityId);
+    if (!s) return NaN;
+    const n = parseFloat(s.state);
+    return Number.isFinite(n) ? n : NaN;
+  }
+
+  private _onSliderInput = (event: CustomEvent<{ low: number; high: number }>) => {
+    this._pendingLow = event.detail.low;
+    this._pendingHigh = event.detail.high;
+  };
+
+  private _onSliderChange = (event: CustomEvent<{ low: number; high: number }>) => {
+    if (!this.hass || !this.zone) return;
+    this._pendingLow = null;
+    this._pendingHigh = null;
+    void startOverride(this.hass, {
+      zone: this.zone,
+      low: event.detail.low,
+      high: event.detail.high,
+    });
+  };
+
+  private _onCancel = () => {
+    if (!this.hass || !this.zone) return;
+    void cancelOverride(this.hass, { zone: this.zone });
+  };
+
+  private _onPickHours = (hours: number) => {
+    if (!this.hass || !this.entities?.overrideHours) return;
+    void this.hass.callService('number', 'set_value', {
+      entity_id: this.entities.overrideHours,
+      value: hours,
+    });
+  };
+
+  protected override render() {
+    if (!this.hass || !this.entities) return nothing;
+
+    const lowState = this._numericState(this.entities.manualLow);
+    const highState = this._numericState(this.entities.manualHigh);
+    const effLow = this._numericState(this.entities.effectiveLow);
+    const effHigh = this._numericState(this.entities.effectiveHigh);
+    const room = this._numericState(this.entities.roomTemperature);
+    const overrideHours = this._numericState(this.entities.overrideHours);
+    const action = this._stateOf(this.entities.currentAction)?.state ?? 'unknown';
+    const overrideActive = this._stateOf(this.entities.overrideActive)?.state === 'on';
+
+    const sliderLow = this._pendingLow ?? (Number.isFinite(lowState) ? lowState : 19);
+    const sliderHigh = this._pendingHigh ?? (Number.isFinite(highState) ? highState : 22);
+
+    const actionTyped = asAction(action);
+    const showChip = actionTyped !== 'idle' && actionTyped !== 'unknown';
+
+    return html`
+      <div class="header-row">
+        <div class="room-temp">${Number.isFinite(room) ? `${room.toFixed(1)}°` : '—'}</div>
+        ${showChip
+          ? html`<span class="action-chip" style="background:${actionColorVar(actionTyped)}"
+              >${actionLabel(actionTyped)}</span
+            >`
+          : nothing}
+      </div>
+      <div class="gauge-row">
+        <band-gauge .low=${effLow} .high=${effHigh} .room=${room} .action=${action}></band-gauge>
+      </div>
+
+      <section>
+        <h3>Manual band</h3>
+        <dual-handle-slider
+          .min=${16}
+          .max=${26}
+          .step=${0.5}
+          .low=${sliderLow}
+          .high=${sliderHigh}
+          @input=${this._onSliderInput}
+          @change=${this._onSliderChange}
+        ></dual-handle-slider>
+      </section>
+
+      ${this._renderOverrideSection(overrideActive)} ${this._renderHoursSection(overrideHours)}
+    `;
+  }
+
+  private _renderOverrideSection(overrideActive: boolean) {
+    if (!overrideActive) return nothing;
+    const ends = this._stateOf(this.entities!.overrideEnds)?.state;
+    const remaining = formatRemaining(ends ?? null);
+    return html`
+      <section>
+        <h3>Override</h3>
+        <div class="override-row">
+          <span>Active${remaining ? ` · ${remaining}` : ''}</span>
+          <button class="button secondary" @click=${this._onCancel}>Cancel</button>
+        </div>
+      </section>
+    `;
+  }
+
+  private _renderHoursSection(overrideHours: number) {
+    if (!this.entities?.overrideHours) return nothing;
+    return html`
+      <section>
+        <h3>Override duration</h3>
+        <div class="preset-row">
+          ${HOUR_PRESETS.map(
+            (h) => html`
+              <button
+                class="preset ${overrideHours === h ? 'active' : ''}"
+                @click=${() => this._onPickHours(h)}
+              >
+                ${h} h
+              </button>
+            `,
+          )}
+        </div>
+      </section>
+    `;
+  }
+}
+
+function formatRemaining(iso: string | null): string {
+  if (!iso) return '';
+  const target = Date.parse(iso);
+  if (Number.isNaN(target)) return '';
+  const ms = target - Date.now();
+  if (ms <= 0) return '';
+  const totalMins = Math.round(ms / 60_000);
+  if (totalMins < 60) return `${totalMins}m left`;
+  const hours = Math.floor(totalMins / 60);
+  const mins = totalMins % 60;
+  return mins ? `${hours}h ${mins}m left` : `${hours}h left`;
+}
+
+// Avoid unused-import lint complaints.
+export type { DualHandleSlider };
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-now-tab': ComfortBandNowTab;
+  }
+}

--- a/card/src/tabs/profiles-tab.ts
+++ b/card/src/tabs/profiles-tab.ts
@@ -1,0 +1,138 @@
+/**
+ * `<comfort-band-profiles-tab>` — Profiles tab content.
+ *
+ * Reads available profiles from the singleton
+ * `select.comfort_band_profiles_active_profile` entity (via
+ * `findActiveProfileEntity`). Selecting a profile fires
+ * `comfort_band.set_profile`, which the integration's profile registry
+ * dispatches to every zone coordinator.
+ *
+ * Profile create / clone / rename / delete are deferred to v0.2 (need
+ * new comfort_band services that don't exist yet).
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { findActiveProfileEntity } from '../helpers.js';
+import { setProfile } from '../services.js';
+import type { HomeAssistant } from '../types.js';
+import { tokens } from '../styles.js';
+
+@customElement('comfort-band-profiles-tab')
+export class ComfortBandProfilesTab extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      .empty {
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+        text-align: center;
+        padding: var(--cb-gap-lg);
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--cb-gap-sm);
+      }
+      li {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--cb-gap-sm) var(--cb-gap-md);
+        border-radius: var(--cb-radius-card);
+        background: var(--cb-track-bg);
+        cursor: pointer;
+        font-size: 14px;
+        color: var(--cb-text-primary);
+      }
+      li.active {
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        color: #ffffff;
+      }
+      li:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 2px;
+      }
+      .name {
+        font-weight: 500;
+        text-transform: capitalize;
+      }
+      .badge {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        opacity: 0.85;
+      }
+      .footer {
+        margin-top: var(--cb-gap-md);
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+        text-align: center;
+      }
+    `,
+  ];
+
+  private _onSelect(profile: string) {
+    if (!this.hass) return;
+    void setProfile(this.hass, { profile });
+  }
+
+  protected override render() {
+    if (!this.hass) return nothing;
+    const entityId = findActiveProfileEntity(this.hass);
+    if (entityId === null) {
+      return html`<div class="empty">Profile manager not registered yet.</div>`;
+    }
+    const state = this.hass.states[entityId];
+    const optionsAttr = state?.attributes.options;
+    const options = Array.isArray(optionsAttr)
+      ? (optionsAttr as unknown[]).filter((v): v is string => typeof v === 'string')
+      : [];
+    const active = state?.state ?? '';
+
+    if (options.length === 0) {
+      return html`<div class="empty">No profiles configured.</div>`;
+    }
+
+    return html`
+      <ul role="listbox" aria-label="Profiles">
+        ${options.map(
+          (profile) => html`
+            <li
+              role="option"
+              tabindex="0"
+              class=${profile === active ? 'active' : ''}
+              aria-selected=${profile === active}
+              @click=${() => this._onSelect(profile)}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  this._onSelect(profile);
+                }
+              }}
+            >
+              <span class="name">${profile}</span>
+              ${profile === active ? html`<span class="badge">Active</span>` : nothing}
+            </li>
+          `,
+        )}
+      </ul>
+      <div class="footer">Create / rename / delete profiles in a future release.</div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-profiles-tab': ComfortBandProfilesTab;
+  }
+}

--- a/card/src/tabs/schedule-tab.ts
+++ b/card/src/tabs/schedule-tab.ts
@@ -1,0 +1,289 @@
+/**
+ * `<comfort-band-schedule-tab>` — Schedule tab content.
+ *
+ * Workflow:
+ *   1. On first render, fetch the current profile's schedule via the
+ *      `comfort_band/get_schedule` websocket command.
+ *   2. Render the timeline editor + the transitions.
+ *   3. User taps empty timeline → add dialog (inline). User taps a
+ *      transition → edit dialog. Long-press → delete event.
+ *   4. All edits persist via `comfort_band.set_schedule` (full schedule
+ *      replacement — atomic and simpler than per-transition mutations).
+ *   5. After write, re-fetch via getSchedule so the displayed list
+ *      stays in sync with the store (which may have normalised values).
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import type { PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import '../timeline-editor.js';
+import '../transition-edit-dialog.js';
+import { findActiveProfileEntity } from '../helpers.js';
+import { getSchedule, setSchedule } from '../services.js';
+import type { HomeAssistant, Transition } from '../types.js';
+import { tokens } from '../styles.js';
+
+type Mode = 'list' | 'add' | 'edit';
+
+@customElement('comfort-band-schedule-tab')
+export class ComfortBandScheduleTab extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+  @property({ type: String }) public zone = '';
+
+  @state() private _profile = '';
+  @state() private _transitions: Transition[] = [];
+  @state() private _loading = true;
+  @state() private _error: string | null = null;
+  @state() private _mode: Mode = 'list';
+  @state() private _editing: Transition | null = null;
+  @state() private _newAt = '06:00';
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      .header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: var(--cb-gap-sm);
+      }
+      .profile-label {
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .profile-value {
+        font-size: 14px;
+        font-weight: 500;
+        text-transform: capitalize;
+        color: var(--cb-text-primary);
+      }
+      .loading,
+      .error {
+        text-align: center;
+        padding: var(--cb-gap-lg);
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+      }
+      .error {
+        color: var(--error-color, #b71c1c);
+      }
+      .list {
+        list-style: none;
+        padding: 0;
+        margin: var(--cb-gap-md) 0 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .list li {
+        display: flex;
+        justify-content: space-between;
+        font-size: 13px;
+        padding: 6px 8px;
+        border-radius: 6px;
+      }
+      .list li:hover {
+        background: var(--cb-track-bg);
+        cursor: pointer;
+      }
+      .list .at {
+        font-variant-numeric: tabular-nums;
+        font-weight: 500;
+      }
+    `,
+  ];
+
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    if (changed.has('hass') && this.hass && this._profile === '') {
+      this._profile = readActiveProfile(this.hass) ?? 'home';
+      void this._refresh();
+    }
+  }
+
+  protected override updated(changed: PropertyValues<this>): void {
+    if (changed.has('hass') && this.hass) {
+      const next = readActiveProfile(this.hass);
+      if (next && next !== this._profile) {
+        this._profile = next;
+        void this._refresh();
+      }
+    }
+  }
+
+  private async _refresh(): Promise<void> {
+    if (!this.hass || !this.zone || !this._profile) return;
+    this._loading = true;
+    this._error = null;
+    try {
+      const schedule = await getSchedule(this.hass, {
+        zone: this.zone,
+        profile: this._profile,
+      });
+      this._transitions = schedule?.baseline ? [...schedule.baseline] : [];
+    } catch (err) {
+      this._error = err instanceof Error ? err.message : 'Failed to load schedule.';
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  private _onAdd = (event: CustomEvent<{ at: string }>) => {
+    this._newAt = event.detail.at;
+    this._editing = null;
+    this._mode = 'add';
+  };
+
+  private _onEdit = (event: CustomEvent<{ transition: Transition }>) => {
+    this._editing = event.detail.transition;
+    this._mode = 'edit';
+  };
+
+  private _onDelete = async (event: CustomEvent<{ at: string }>) => {
+    if (!this.hass) return;
+    const next = this._transitions.filter((t) => t.at !== event.detail.at);
+    await this._writeSchedule(next);
+  };
+
+  private _onDialogSave = async (event: CustomEvent<{ transition: Transition }>): Promise<void> => {
+    const incoming = event.detail.transition;
+    const next: Transition[] = [];
+    if (this._mode === 'edit' && this._editing) {
+      // Replace by old `at` (so a time edit moves the transition cleanly).
+      const oldAt = this._editing.at;
+      for (const t of this._transitions) {
+        if (t.at === oldAt) continue;
+        if (t.at === incoming.at) continue; // collision: drop the existing one at the new time
+        next.push(t);
+      }
+      next.push(incoming);
+    } else {
+      // Add new — drop any existing transition at the same time.
+      for (const t of this._transitions) {
+        if (t.at !== incoming.at) next.push(t);
+      }
+      next.push(incoming);
+    }
+    next.sort((a, b) => a.at.localeCompare(b.at));
+    await this._writeSchedule(next);
+    this._mode = 'list';
+    this._editing = null;
+  };
+
+  private _onDialogDelete = async (event: CustomEvent<{ at: string }>): Promise<void> => {
+    const next = this._transitions.filter((t) => t.at !== event.detail.at);
+    await this._writeSchedule(next);
+    this._mode = 'list';
+    this._editing = null;
+  };
+
+  private _onDialogCancel = () => {
+    this._mode = 'list';
+    this._editing = null;
+  };
+
+  private async _writeSchedule(transitions: Transition[]): Promise<void> {
+    if (!this.hass) return;
+    try {
+      await setSchedule(this.hass, {
+        zone: this.zone,
+        profile: this._profile,
+        transitions,
+      });
+      this._transitions = transitions;
+      void this._refresh();
+    } catch (err) {
+      this._error = err instanceof Error ? err.message : 'Failed to save schedule.';
+    }
+  }
+
+  protected override render() {
+    if (!this.hass) return nothing;
+
+    if (this._mode === 'add' || this._mode === 'edit') {
+      const seed: Transition | null =
+        this._mode === 'edit'
+          ? this._editing
+          : {
+              at: this._newAt,
+              low: defaultLow(this._transitions),
+              high: defaultHigh(this._transitions),
+            };
+      return html`
+        <transition-edit-dialog
+          .transition=${seed}
+          .isNew=${this._mode === 'add'}
+          @dialog-save=${this._onDialogSave}
+          @dialog-cancel=${this._onDialogCancel}
+          @dialog-delete=${this._onDialogDelete}
+        ></transition-edit-dialog>
+      `;
+    }
+
+    return html`
+      <div class="header">
+        <span class="profile-label">Active profile</span>
+        <span class="profile-value">${this._profile || '—'}</span>
+      </div>
+      ${this._loading
+        ? html`<div class="loading">Loading schedule…</div>`
+        : this._error
+          ? html`<div class="error">${this._error}</div>`
+          : html`
+              <timeline-editor
+                .transitions=${this._transitions}
+                @transition-add=${this._onAdd}
+                @transition-edit=${this._onEdit}
+                @transition-delete=${this._onDelete}
+              ></timeline-editor>
+              ${this._renderList()}
+            `}
+    `;
+  }
+
+  private _renderList() {
+    if (this._transitions.length === 0) return nothing;
+    return html`
+      <ul class="list">
+        ${this._transitions.map(
+          (t) => html`
+            <li
+              @click=${() =>
+                this._onEdit(new CustomEvent('transition-edit', { detail: { transition: t } }))}
+            >
+              <span class="at">${t.at}</span>
+              <span>${t.low.toFixed(1)}° – ${t.high.toFixed(1)}°</span>
+            </li>
+          `,
+        )}
+      </ul>
+    `;
+  }
+}
+
+function readActiveProfile(hass: HomeAssistant): string | null {
+  const entity = findActiveProfileEntity(hass);
+  if (!entity) return null;
+  return hass.states[entity]?.state ?? null;
+}
+
+function defaultLow(transitions: Transition[]): number {
+  if (transitions.length === 0) return 19;
+  return transitions[transitions.length - 1].low;
+}
+
+function defaultHigh(transitions: Transition[]): number {
+  if (transitions.length === 0) return 22;
+  return transitions[transitions.length - 1].high;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-schedule-tab': ComfortBandScheduleTab;
+  }
+}

--- a/card/src/tile.ts
+++ b/card/src/tile.ts
@@ -1,0 +1,178 @@
+/**
+ * `<comfort-band-tile>` — compact tile (~120 px tall).
+ *
+ * Composed of zone display name + prominent room temperature + horizontal
+ * `<band-gauge>` + an override pill (when active). Tap fires
+ * `comfort-band-tile-tap`; the parent card opens the modal in response.
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './band-gauge.js';
+import { tokens, actionColorVar, asAction, actionLabel } from './styles.js';
+
+@customElement('comfort-band-tile')
+export class ComfortBandTile extends LitElement {
+  @property({ type: String }) public zoneName = '';
+  @property({ type: Number }) public roomTemp = NaN;
+  @property({ type: Number }) public low = NaN;
+  @property({ type: Number }) public high = NaN;
+  @property({ type: String }) public action: string | null = 'unknown';
+  @property({ type: Boolean }) public overrideActive = false;
+  /** ISO 8601 timestamp at which the override expires (or null). */
+  @property({ type: String }) public overrideEnds: string | null = null;
+  /** Disable the tap-to-expand affordance. Used for compact embeds. */
+  @property({ type: Boolean }) public noExpand = false;
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+      }
+      .tile {
+        display: flex;
+        flex-direction: column;
+        gap: var(--cb-gap-sm);
+        padding: var(--cb-gap-md);
+        border-radius: var(--cb-radius-card);
+        background: var(--ha-card-background, var(--card-background-color, #ffffff));
+        box-shadow: var(--ha-card-box-shadow, none);
+        cursor: pointer;
+        transition: transform 0.12s ease;
+      }
+      .tile.no-expand {
+        cursor: default;
+      }
+      .tile:not(.no-expand):hover {
+        transform: translateY(-1px);
+      }
+      .tile:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 2px;
+      }
+      .header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--cb-gap-sm);
+      }
+      .zone-name {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--cb-text-primary);
+        font-family: var(--paper-font-body1_-_font-family, sans-serif);
+      }
+      .action-chip {
+        font-size: 11px;
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 2px 8px;
+        border-radius: var(--cb-radius-pill);
+        color: var(--cb-text-on-action, #ffffff);
+      }
+      .body {
+        display: flex;
+        align-items: center;
+        gap: var(--cb-gap-md);
+      }
+      .room-temp {
+        font-size: 32px;
+        font-weight: 300;
+        color: var(--cb-text-primary);
+        font-variant-numeric: tabular-nums;
+        line-height: 1;
+        min-width: 70px;
+      }
+      .gauge-wrap {
+        flex: 1;
+        min-width: 0;
+      }
+      .override-pill {
+        align-self: flex-start;
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: var(--cb-radius-pill);
+        background: var(--cb-text-secondary);
+        color: var(--cb-text-on-action, #ffffff);
+        opacity: 0.85;
+      }
+    `,
+  ];
+
+  private _onTap(event: MouseEvent | KeyboardEvent) {
+    if (this.noExpand) return;
+    if (event instanceof KeyboardEvent && event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    this.dispatchEvent(new CustomEvent('comfort-band-tile-tap', { bubbles: true, composed: true }));
+  }
+
+  private _renderRoomTemp(): string {
+    return Number.isFinite(this.roomTemp) ? `${this.roomTemp.toFixed(1)}°` : '—';
+  }
+
+  private _renderOverridePill() {
+    if (!this.overrideActive) return null;
+    const remaining = formatRemaining(this.overrideEnds);
+    return html`<div class="override-pill">Override${remaining ? ` · ${remaining}` : ''}</div>`;
+  }
+
+  private _renderActionChip() {
+    const action = asAction(this.action);
+    if (action === 'idle' || action === 'unknown') return null;
+    const color = actionColorVar(action);
+    return html`<span class="action-chip" style="background:${color}">
+      ${actionLabel(action)}
+    </span>`;
+  }
+
+  protected override render() {
+    return html`
+      <div
+        class="tile ${this.noExpand ? 'no-expand' : ''}"
+        role="${this.noExpand ? 'group' : 'button'}"
+        tabindex="${this.noExpand ? -1 : 0}"
+        @click=${this._onTap}
+        @keydown=${this._onTap}
+      >
+        <div class="header">
+          <div class="zone-name">${this.zoneName || '—'}</div>
+          ${this._renderActionChip()}
+        </div>
+        <div class="body">
+          <div class="room-temp">${this._renderRoomTemp()}</div>
+          <div class="gauge-wrap">
+            <band-gauge
+              .low=${this.low}
+              .high=${this.high}
+              .room=${this.roomTemp}
+              .action=${this.action}
+            ></band-gauge>
+          </div>
+        </div>
+        ${this._renderOverridePill()}
+      </div>
+    `;
+  }
+}
+
+/** Returns "1h 23m left" / "12m left" / "" for non-future timestamps. */
+function formatRemaining(iso: string | null): string {
+  if (!iso) return '';
+  const target = Date.parse(iso);
+  if (Number.isNaN(target)) return '';
+  const ms = target - Date.now();
+  if (ms <= 0) return '';
+  const totalMins = Math.round(ms / 60_000);
+  if (totalMins < 60) return `${totalMins}m left`;
+  const hours = Math.floor(totalMins / 60);
+  const mins = totalMins % 60;
+  return mins ? `${hours}h ${mins}m left` : `${hours}h left`;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'comfort-band-tile': ComfortBandTile;
+  }
+}

--- a/card/src/timeline-editor.ts
+++ b/card/src/timeline-editor.ts
@@ -1,0 +1,253 @@
+/**
+ * `<timeline-editor>` — 24-hour horizontal ribbon of schedule transitions.
+ *
+ * Events emitted (all bubble, composed=true):
+ *   - `transition-add`    { at: 'HH:MM' }   — user tapped empty space.
+ *   - `transition-edit`   { transition }     — user tapped an existing point.
+ *   - `transition-delete` { at: 'HH:MM' }    — user long-pressed a point.
+ *
+ * Drag-to-move-time is deferred to v0.2 — for now, time changes go through
+ * the precise-edit dialog. This keeps interactions unambiguous and tests
+ * tractable. Tap targets get a 12 px hit-radius (per parent plan).
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { Transition } from './types.js';
+import { tokens } from './styles.js';
+
+const LONG_PRESS_MS = 500;
+const TAP_HIT_RADIUS_PCT = 1.5; // ~12 px on a 800 px wide track
+const SNAP_MINUTES = 15;
+const HOUR_LABELS = [0, 6, 12, 18, 24];
+
+function timeStringToMinutes(at: string): number {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(at);
+  if (!match) return 0;
+  return parseInt(match[1], 10) * 60 + parseInt(match[2], 10);
+}
+
+function minutesToTimeString(mins: number): string {
+  const clamped = Math.max(0, Math.min(24 * 60 - 1, mins));
+  const h = Math.floor(clamped / 60);
+  const m = clamped % 60;
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
+
+function minutesToPct(mins: number): number {
+  return (mins / (24 * 60)) * 100;
+}
+
+function snapMinutes(mins: number, step: number): number {
+  return Math.round(mins / step) * step;
+}
+
+@customElement('timeline-editor')
+export class TimelineEditor extends LitElement {
+  @property({ type: Array }) public transitions: Transition[] = [];
+
+  private _longPressTimer: number | null = null;
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+      }
+      .ruler {
+        position: relative;
+        height: 80px;
+        margin: var(--cb-gap-md) 0;
+      }
+      .track {
+        position: absolute;
+        top: 36px;
+        left: 0;
+        right: 0;
+        height: 6px;
+        background: var(--cb-track-bg);
+        border-radius: 3px;
+        cursor: pointer;
+      }
+      .hour-tick {
+        position: absolute;
+        top: 18px;
+        font-size: 10px;
+        color: var(--cb-text-secondary);
+        transform: translateX(-50%);
+        font-variant-numeric: tabular-nums;
+      }
+      .hour-tick.terminal {
+        transform: translateX(-100%);
+      }
+      .hour-tick.start {
+        transform: translateX(0);
+      }
+      .point {
+        position: absolute;
+        top: 30px;
+        width: 18px;
+        height: 18px;
+        margin-left: -9px;
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        border: 2px solid var(--ha-card-background, #ffffff);
+        border-radius: 50%;
+        cursor: pointer;
+        touch-action: none;
+        z-index: 1;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+      }
+      .point:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 3px;
+      }
+      .point-label {
+        position: absolute;
+        top: 56px;
+        font-size: 10px;
+        color: var(--cb-text-secondary);
+        transform: translateX(-50%);
+        white-space: nowrap;
+        font-variant-numeric: tabular-nums;
+      }
+      .empty-hint {
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+        text-align: center;
+        margin-top: var(--cb-gap-sm);
+      }
+    `,
+  ];
+
+  private _xToMinutes(clientX: number, rect: DOMRect): number {
+    if (rect.width === 0) return 0;
+    const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    return snapMinutes(ratio * 24 * 60, SNAP_MINUTES);
+  }
+
+  private _onTrackTap = (event: PointerEvent) => {
+    if ((event.target as HTMLElement).classList.contains('point')) return;
+    const track = this.shadowRoot?.querySelector('.track');
+    if (!track) return;
+    const rect = track.getBoundingClientRect();
+    const minutes = this._xToMinutes(event.clientX, rect);
+    // Avoid creating a transition right on top of an existing one.
+    for (const t of this.transitions) {
+      const existing = timeStringToMinutes(t.at);
+      const distancePct = Math.abs(minutesToPct(existing) - minutesToPct(minutes));
+      if (distancePct < TAP_HIT_RADIUS_PCT) return;
+    }
+    this.dispatchEvent(
+      new CustomEvent('transition-add', {
+        detail: { at: minutesToTimeString(minutes) },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+
+  private _onPointTap = (transition: Transition) => {
+    this.dispatchEvent(
+      new CustomEvent('transition-edit', {
+        detail: { transition },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+
+  private _onPointPointerDown = (event: PointerEvent, transition: Transition) => {
+    event.stopPropagation();
+    if (this._longPressTimer !== null) {
+      window.clearTimeout(this._longPressTimer);
+    }
+    const target = event.currentTarget as HTMLElement;
+    let longPressFired = false;
+    this._longPressTimer = window.setTimeout(() => {
+      longPressFired = true;
+      this._longPressTimer = null;
+      this.dispatchEvent(
+        new CustomEvent('transition-delete', {
+          detail: { at: transition.at },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }, LONG_PRESS_MS);
+    const onUp = () => {
+      target.removeEventListener('pointerup', onUp);
+      target.removeEventListener('pointercancel', onUp);
+      target.removeEventListener('pointerleave', onUp);
+      if (this._longPressTimer !== null) {
+        window.clearTimeout(this._longPressTimer);
+        this._longPressTimer = null;
+        if (!longPressFired) this._onPointTap(transition);
+      }
+    };
+    target.addEventListener('pointerup', onUp);
+    target.addEventListener('pointercancel', onUp);
+    target.addEventListener('pointerleave', onUp);
+  };
+
+  private _onPointKeyDown = (event: KeyboardEvent, transition: Transition) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this._onPointTap(transition);
+    } else if (event.key === 'Delete' || event.key === 'Backspace') {
+      event.preventDefault();
+      this.dispatchEvent(
+        new CustomEvent('transition-delete', {
+          detail: { at: transition.at },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  };
+
+  protected override render() {
+    return html`
+      <div class="ruler">
+        <div class="track" @click=${this._onTrackTap}></div>
+        ${HOUR_LABELS.map((h, i) => {
+          const cls =
+            i === 0
+              ? 'hour-tick start'
+              : i === HOUR_LABELS.length - 1
+                ? 'hour-tick terminal'
+                : 'hour-tick';
+          return html`<div class=${cls} style="left:${(h / 24) * 100}%">${h}h</div>`;
+        })}
+        ${this.transitions.map((t) => {
+          const mins = timeStringToMinutes(t.at);
+          const pct = minutesToPct(mins);
+          const aria = `Transition at ${t.at}, low ${t.low.toFixed(1)} degrees, high ${t.high.toFixed(1)} degrees. Tap to edit, long-press or Delete to remove.`;
+          return html`
+            <button
+              class="point"
+              role="button"
+              style="left:${pct}%"
+              tabindex="0"
+              aria-label=${aria}
+              data-at=${t.at}
+              @pointerdown=${(e: PointerEvent) => this._onPointPointerDown(e, t)}
+              @keydown=${(e: KeyboardEvent) => this._onPointKeyDown(e, t)}
+            ></button>
+            <div class="point-label" style="left:${pct}%">
+              ${t.at} · ${t.low.toFixed(1)}–${t.high.toFixed(1)}°
+            </div>
+          `;
+        })}
+      </div>
+      ${this.transitions.length === 0
+        ? html`<div class="empty-hint">Tap the timeline to add a transition.</div>`
+        : null}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'timeline-editor': TimelineEditor;
+  }
+}

--- a/card/src/transition-edit-dialog.ts
+++ b/card/src/transition-edit-dialog.ts
@@ -1,0 +1,218 @@
+/**
+ * `<transition-edit-dialog>` — inline form for adding or editing a single
+ * schedule transition.
+ *
+ * Renders inside the schedule-tab (not its own modal) — the parent modal
+ * already owns the `<dialog>` element; nesting modals causes z-index pain
+ * and is awkward for keyboard focus. This element is a controlled form:
+ *   - Set `transition` to the row being edited (or null to add new).
+ *   - Listens for `save` / `cancel` / `delete` button clicks; emits
+ *     `dialog-save` { transition } / `dialog-cancel` / `dialog-delete` { at }.
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import type { Transition } from './types.js';
+import { tokens } from './styles.js';
+
+@customElement('transition-edit-dialog')
+export class TransitionEditDialog extends LitElement {
+  @property({ type: Object }) public transition: Transition | null = null;
+  /** True when adding a new transition; false when editing existing. */
+  @property({ type: Boolean }) public isNew = false;
+
+  @state() private _at = '06:00';
+  @state() private _low = 19;
+  @state() private _high = 22;
+  @state() private _error: string | null = null;
+
+  @query('input[name="at"]') private _atInput?: HTMLInputElement;
+
+  public static override styles = [
+    tokens,
+    css`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+        background: var(--ha-card-background, #ffffff);
+        border-radius: var(--cb-radius-card);
+      }
+      h3 {
+        margin: 0 0 var(--cb-gap-md);
+        font-size: 14px;
+        font-weight: 500;
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: var(--cb-gap-md);
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+      }
+      input {
+        font: inherit;
+        font-size: 14px;
+        padding: 8px;
+        border: 1px solid var(--divider-color, #cccccc);
+        border-radius: 6px;
+        color: var(--cb-text-primary);
+        background: transparent;
+      }
+      input:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 1px;
+      }
+      .error {
+        color: var(--error-color, #b71c1c);
+        font-size: 12px;
+        margin-bottom: var(--cb-gap-sm);
+      }
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--cb-gap-sm);
+      }
+      .actions .spacer {
+        flex: 1;
+      }
+      .button {
+        font: inherit;
+        padding: 6px 12px;
+        border-radius: var(--cb-radius-pill);
+        border: 1px solid transparent;
+        cursor: pointer;
+        font-size: 13px;
+      }
+      .button.primary {
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        color: #ffffff;
+      }
+      .button.secondary {
+        background: transparent;
+        border-color: var(--divider-color, #cccccc);
+        color: var(--cb-text-primary);
+      }
+      .button.danger {
+        background: transparent;
+        color: var(--error-color, #b71c1c);
+        border-color: var(--divider-color, #cccccc);
+      }
+    `,
+  ];
+
+  protected override willUpdate(changed: Map<string | number | symbol, unknown>): void {
+    if (changed.has('transition') && this.transition) {
+      this._at = this.transition.at;
+      this._low = this.transition.low;
+      this._high = this.transition.high;
+      this._error = null;
+    }
+  }
+
+  protected override firstUpdated(): void {
+    queueMicrotask(() => this._atInput?.focus());
+  }
+
+  private _onSave = () => {
+    if (!this._validate()) return;
+    this.dispatchEvent(
+      new CustomEvent('dialog-save', {
+        detail: { transition: { at: this._at, low: this._low, high: this._high } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+
+  private _onCancel = () => {
+    this.dispatchEvent(new CustomEvent('dialog-cancel', { bubbles: true, composed: true }));
+  };
+
+  private _onDelete = () => {
+    if (!this.transition) return;
+    this.dispatchEvent(
+      new CustomEvent('dialog-delete', {
+        detail: { at: this.transition.at },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+
+  private _validate(): boolean {
+    if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(this._at)) {
+      this._error = 'Time must be HH:MM (24h, e.g. 06:00).';
+      return false;
+    }
+    if (Number.isNaN(this._low) || Number.isNaN(this._high)) {
+      this._error = 'Low and high must be numbers.';
+      return false;
+    }
+    if (this._low >= this._high) {
+      this._error = 'Low must be less than high.';
+      return false;
+    }
+    if (this._low < 10 || this._high > 35) {
+      this._error = 'Temperatures must be between 10 °C and 35 °C.';
+      return false;
+    }
+    this._error = null;
+    return true;
+  }
+
+  protected override render() {
+    return html`
+      <h3>${this.isNew ? 'Add transition' : 'Edit transition'}</h3>
+      <label>
+        Time (HH:MM)
+        <input
+          name="at"
+          type="text"
+          inputmode="numeric"
+          .value=${this._at}
+          @input=${(e: Event) => (this._at = (e.target as HTMLInputElement).value)}
+        />
+      </label>
+      <label>
+        Low (°C)
+        <input
+          name="low"
+          type="number"
+          step="0.5"
+          min="10"
+          max="35"
+          .value=${String(this._low)}
+          @input=${(e: Event) => (this._low = parseFloat((e.target as HTMLInputElement).value))}
+        />
+      </label>
+      <label>
+        High (°C)
+        <input
+          name="high"
+          type="number"
+          step="0.5"
+          min="10"
+          max="35"
+          .value=${String(this._high)}
+          @input=${(e: Event) => (this._high = parseFloat((e.target as HTMLInputElement).value))}
+        />
+      </label>
+      ${this._error ? html`<div class="error">${this._error}</div>` : null}
+      <div class="actions">
+        ${this.isNew
+          ? null
+          : html`<button class="button danger" @click=${this._onDelete}>Delete</button>`}
+        <div class="spacer"></div>
+        <button class="button secondary" @click=${this._onCancel}>Cancel</button>
+        <button class="button primary" @click=${this._onSave}>Save</button>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'transition-edit-dialog': TransitionEditDialog;
+  }
+}

--- a/card/src/types.ts
+++ b/card/src/types.ts
@@ -1,0 +1,100 @@
+/**
+ * TypeScript types for the Comfort Band card.
+ *
+ * Two groups of types:
+ *   1. Minimal Home Assistant frontend shapes — only what the card uses.
+ *   2. Comfort Band domain types mirroring `storage.py` and `services.yaml`.
+ */
+
+// ---------- Home Assistant ----------
+
+export interface HassEntityAttributes {
+  friendly_name?: string;
+  unit_of_measurement?: string;
+  device_class?: string;
+  options?: string[];
+  [key: string]: unknown;
+}
+
+export interface HassEntity {
+  entity_id: string;
+  state: string;
+  attributes: HassEntityAttributes;
+  last_changed: string;
+  last_updated: string;
+}
+
+export interface EntityRegistryEntry {
+  entity_id: string;
+  unique_id: string;
+  platform: string;
+  device_id: string | null;
+  disabled_by: string | null;
+  hidden_by: string | null;
+  name: string | null;
+  area_id: string | null;
+  translation_key: string | null;
+}
+
+export interface DeviceRegistryEntry {
+  id: string;
+  identifiers: Array<[string, string]>;
+  name: string | null;
+  name_by_user: string | null;
+  area_id: string | null;
+}
+
+export interface HomeAssistant {
+  states: Record<string, HassEntity>;
+  entities: Record<string, EntityRegistryEntry>;
+  devices: Record<string, DeviceRegistryEntry>;
+  callService(
+    domain: string,
+    service: string,
+    serviceData?: Record<string, unknown>,
+  ): Promise<unknown>;
+}
+
+// ---------- Comfort Band domain ----------
+
+/** Mirrors `StoredTransition` in storage.py. */
+export interface Transition {
+  /** "HH:MM" 24-hour clock. */
+  at: string;
+  low: number;
+  high: number;
+}
+
+/** Mirrors `StoredProfileSchedule` in storage.py. */
+export interface ProfileSchedule {
+  baseline: Transition[];
+  current: Transition[];
+}
+
+/** Mirrors `StoredZone` in storage.py. */
+export interface StoredZone {
+  zone_name: string;
+  schedules: Record<string, ProfileSchedule>;
+  manual_low: number;
+  manual_high: number;
+  override_hours: number;
+  override_until: string | null;
+  deadband_below: number;
+  deadband_above: number;
+  min_cycle_minutes: number;
+  enabled: boolean;
+  last_action_at: string | null;
+  last_action: string | null;
+}
+
+/** Values of `sensor.{zone}_current_action`. Mirrors const.py ACTION_*. */
+export type ComfortBandAction = 'heating' | 'cooling' | 'idle' | 'unknown';
+
+// ---------- Card config ----------
+
+export interface ComfortBandCardConfig {
+  type: string;
+  zone: string;
+  /** Compact mode locks the tile (no expand-on-tap). */
+  compact?: boolean;
+}

--- a/card/src/types.ts
+++ b/card/src/types.ts
@@ -53,6 +53,7 @@ export interface HomeAssistant {
     service: string,
     serviceData?: Record<string, unknown>,
   ): Promise<unknown>;
+  callWS<T = unknown>(msg: { type: string } & Record<string, unknown>): Promise<T>;
 }
 
 // ---------- Comfort Band domain ----------

--- a/card/test/_fixture.ts
+++ b/card/test/_fixture.ts
@@ -1,0 +1,25 @@
+/**
+ * Minimal Lit element fixture helpers for component tests.
+ *
+ * happy-dom + Lit don't need anything fancy — `createElement`, append, set
+ * properties, await `updateComplete`. This file just dries up the boilerplate.
+ */
+
+interface LitLike extends HTMLElement {
+  updateComplete: Promise<boolean>;
+}
+
+export async function mount<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  props: Partial<HTMLElementTagNameMap[K]> = {},
+): Promise<HTMLElementTagNameMap[K]> {
+  const el = document.createElement(tag);
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await (el as unknown as LitLike).updateComplete;
+  return el;
+}
+
+export function teardown(): void {
+  document.body.innerHTML = '';
+}

--- a/card/test/band-gauge.test.ts
+++ b/card/test/band-gauge.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import '../src/band-gauge.js';
+import type { BandGauge } from '../src/band-gauge.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+async function gauge(props: Partial<BandGauge>): Promise<BandGauge> {
+  return mount('band-gauge', props);
+}
+
+function svgContent(el: BandGauge): string {
+  return el.shadowRoot!.innerHTML;
+}
+
+describe('band-gauge', () => {
+  it('renders an SVG with track + band + marker when all values are known', async () => {
+    const el = await gauge({ low: 19, high: 23, room: 21, action: 'idle' });
+    const html = svgContent(el);
+    expect(html).toContain('<svg');
+    expect(html).toContain('class="track"');
+    expect(html).toContain('class="band"');
+    expect(html).toContain('<circle');
+  });
+
+  it('omits the band stripe when low/high are missing', async () => {
+    const el = await gauge({ low: NaN, high: NaN, room: 21, action: 'unknown' });
+    const html = svgContent(el);
+    expect(html).toContain('class="track"');
+    expect(html).not.toContain('class="band"');
+  });
+
+  it('omits the marker when room temperature is unknown', async () => {
+    const el = await gauge({ low: 19, high: 23, room: NaN, action: 'idle' });
+    const html = svgContent(el);
+    expect(html).toContain('class="band"');
+    expect(html).not.toContain('<circle');
+  });
+
+  it('writes a descriptive aria-label including the action', async () => {
+    const el = await gauge({ low: 19, high: 23, room: 21.4, action: 'heating' });
+    const aria = el.shadowRoot!.querySelector('svg')!.getAttribute('aria-label');
+    expect(aria).toContain('19.0');
+    expect(aria).toContain('21.4');
+    expect(aria).toContain('23.0');
+    expect(aria).toContain('heating');
+  });
+
+  it('uses the heating colour variable when action is heating', async () => {
+    const el = await gauge({ low: 19, high: 23, room: 17, action: 'heating' });
+    expect(svgContent(el)).toContain('--cb-action-heating');
+  });
+
+  it('uses the cooling colour variable when action is cooling', async () => {
+    const el = await gauge({ low: 19, high: 23, room: 25, action: 'cooling' });
+    expect(svgContent(el)).toContain('--cb-action-cooling');
+  });
+
+  it('falls back to the unknown colour for unrecognised action strings', async () => {
+    const el = await gauge({ low: 19, high: 23, room: 21, action: 'bogus' });
+    expect(svgContent(el)).toContain('--cb-action-unknown');
+  });
+});

--- a/card/test/card-editor.test.ts
+++ b/card/test/card-editor.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/card-editor.js';
+import type { ComfortBandCardEditor } from '../src/card-editor.js';
+import type { HomeAssistant } from '../src/types.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+function makeHass(zones: string[]): HomeAssistant {
+  return {
+    states: {},
+    entities: {},
+    devices: Object.fromEntries(
+      zones.map((slug, i) => [
+        `dev-${i}`,
+        {
+          id: `dev-${i}`,
+          identifiers: [['comfort_band', `zone:${slug}`]] as Array<[string, string]>,
+          name: slug,
+          name_by_user: null,
+          area_id: null,
+        },
+      ]),
+    ),
+    callService: vi.fn(),
+    callWS: vi.fn(),
+  };
+}
+
+async function editor(
+  hass: HomeAssistant,
+  config: Parameters<ComfortBandCardEditor['setConfig']>[0] = {
+    type: 'custom:comfort-band-card',
+    zone: '',
+  },
+): Promise<ComfortBandCardEditor> {
+  const el = await mount('comfort-band-card-editor', { hass });
+  el.setConfig(config);
+  await el.updateComplete;
+  return el;
+}
+
+describe('comfort-band-card-editor', () => {
+  it('lists every Comfort Band zone in the dropdown, sorted', async () => {
+    const el = await editor(makeHass(['mbr', 'gym', 'office']));
+    const options = el.shadowRoot!.querySelectorAll('option:not([disabled])');
+    const values = Array.from(options).map((o) => (o as HTMLOptionElement).value);
+    expect(values).toEqual(['gym', 'mbr', 'office']);
+  });
+
+  it('shows a friendly empty state when no zones are registered', async () => {
+    const el = await editor(makeHass([]));
+    expect(el.shadowRoot!.querySelector('.empty')!.textContent).toContain('No Comfort Band zones');
+  });
+
+  it('fires config-changed with the new zone when the dropdown changes', async () => {
+    const el = await editor(makeHass(['gym', 'office']));
+    const fire = vi.fn();
+    el.addEventListener('config-changed', fire);
+    const select = el.shadowRoot!.querySelector('select') as HTMLSelectElement;
+    select.value = 'office';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(fire.mock.calls[0][0].detail.config).toEqual({
+      type: 'custom:comfort-band-card',
+      zone: 'office',
+    });
+  });
+
+  it('toggles `compact: true` from the checkbox', async () => {
+    const el = await editor(makeHass(['gym']), {
+      type: 'custom:comfort-band-card',
+      zone: 'gym',
+    });
+    const fire = vi.fn();
+    el.addEventListener('config-changed', fire);
+    const checkbox = el.shadowRoot!.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(fire.mock.calls[0][0].detail.config).toEqual({
+      type: 'custom:comfort-band-card',
+      zone: 'gym',
+      compact: true,
+    });
+  });
+
+  it('removes `compact` from the config when unchecked', async () => {
+    const el = await editor(makeHass(['gym']), {
+      type: 'custom:comfort-band-card',
+      zone: 'gym',
+      compact: true,
+    });
+    const fire = vi.fn();
+    el.addEventListener('config-changed', fire);
+    const checkbox = el.shadowRoot!.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(fire.mock.calls[0][0].detail.config).toEqual({
+      type: 'custom:comfort-band-card',
+      zone: 'gym',
+    });
+  });
+});

--- a/card/test/comfort-band-card.test.ts
+++ b/card/test/comfort-band-card.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/comfort-band-card.js';
+import type { ComfortBandCard } from '../src/comfort-band-card.js';
+import type {
+  DeviceRegistryEntry,
+  EntityRegistryEntry,
+  HassEntity,
+  HomeAssistant,
+} from '../src/types.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+function makeHass(zone: string): HomeAssistant {
+  const device: DeviceRegistryEntry = {
+    id: `dev-${zone}`,
+    identifiers: [['comfort_band', `zone:${zone}`]],
+    name: zone.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+    name_by_user: null,
+    area_id: null,
+  };
+
+  const entity = (key: string, entityId: string): EntityRegistryEntry => ({
+    entity_id: entityId,
+    unique_id: `${zone}_${key}`,
+    platform: 'comfort_band',
+    device_id: device.id,
+    disabled_by: null,
+    hidden_by: null,
+    name: null,
+    area_id: null,
+    translation_key: key,
+  });
+
+  const state = (entityId: string, value: string): HassEntity => ({
+    entity_id: entityId,
+    state: value,
+    attributes: {},
+    last_changed: new Date().toISOString(),
+    last_updated: new Date().toISOString(),
+  });
+
+  const entities = [
+    entity('effective_low', `sensor.${zone}_effective_low`),
+    entity('effective_high', `sensor.${zone}_effective_high`),
+    entity('room_temperature', `sensor.${zone}_room_temperature`),
+    entity('current_action', `sensor.${zone}_current_action`),
+    entity('override_active', `binary_sensor.${zone}_override_active`),
+    entity('override_ends', `sensor.${zone}_override_ends`),
+  ];
+
+  return {
+    states: {
+      [`sensor.${zone}_effective_low`]: state(`sensor.${zone}_effective_low`, '19.5'),
+      [`sensor.${zone}_effective_high`]: state(`sensor.${zone}_effective_high`, '22.5'),
+      [`sensor.${zone}_room_temperature`]: state(`sensor.${zone}_room_temperature`, '21.3'),
+      [`sensor.${zone}_current_action`]: state(`sensor.${zone}_current_action`, 'idle'),
+      [`binary_sensor.${zone}_override_active`]: state(
+        `binary_sensor.${zone}_override_active`,
+        'off',
+      ),
+      [`sensor.${zone}_override_ends`]: state(`sensor.${zone}_override_ends`, 'unknown'),
+    },
+    devices: { [device.id]: device },
+    entities: Object.fromEntries(entities.map((e) => [e.entity_id, e])),
+    callService: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+async function card(zone: string, hass: HomeAssistant): Promise<ComfortBandCard> {
+  const el = await mount('comfort-band-card');
+  el.setConfig({ type: 'custom:comfort-band-card', zone });
+  el.hass = hass;
+  await el.updateComplete;
+  return el;
+}
+
+describe('comfort-band-card', () => {
+  it('rejects setConfig without a zone', async () => {
+    const el = await mount('comfort-band-card');
+    expect(() => el.setConfig({ type: 'custom:comfort-band-card' } as never)).toThrow(/zone/);
+  });
+
+  it('reports a card size of 2 (used by HA grid layout)', async () => {
+    const el = await mount('comfort-band-card');
+    expect(el.getCardSize()).toBe(2);
+  });
+
+  it('renders a tile populated from live entity states', async () => {
+    const hass = makeHass('gym');
+    const el = await card('gym', hass);
+    const tile = el.shadowRoot!.querySelector('comfort-band-tile') as HTMLElement & {
+      zoneName: string;
+      roomTemp: number;
+      low: number;
+      high: number;
+      action: string;
+    };
+    expect(tile).not.toBeNull();
+    expect(tile.zoneName).toBe('Gym');
+    expect(tile.roomTemp).toBeCloseTo(21.3, 1);
+    expect(tile.low).toBeCloseTo(19.5, 1);
+    expect(tile.high).toBeCloseTo(22.5, 1);
+    expect(tile.action).toBe('idle');
+  });
+
+  it('shows a placeholder when the zone device is not registered', async () => {
+    const hass: HomeAssistant = {
+      states: {},
+      devices: {},
+      entities: {},
+      callService: vi.fn(),
+    };
+    const el = await card('office', hass);
+    expect(el.shadowRoot!.innerHTML).toContain('not found');
+    expect(el.shadowRoot!.querySelector('comfort-band-tile')).toBeNull();
+  });
+
+  it('forwards override state from binary_sensor + sensor pair', async () => {
+    const hass = makeHass('gym');
+    const future = new Date(Date.now() + 60 * 60_000).toISOString();
+    hass.states['binary_sensor.gym_override_active'].state = 'on';
+    hass.states['sensor.gym_override_ends'].state = future;
+
+    const el = await card('gym', hass);
+    const tile = el.shadowRoot!.querySelector('comfort-band-tile') as HTMLElement & {
+      overrideActive: boolean;
+      overrideEnds: string | null;
+    };
+    expect(tile.overrideActive).toBe(true);
+    expect(tile.overrideEnds).toBe(future);
+  });
+});

--- a/card/test/comfort-band-card.test.ts
+++ b/card/test/comfort-band-card.test.ts
@@ -64,6 +64,7 @@ function makeHass(zone: string): HomeAssistant {
     devices: { [device.id]: device },
     entities: Object.fromEntries(entities.map((e) => [e.entity_id, e])),
     callService: vi.fn().mockResolvedValue(undefined),
+    callWS: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -110,6 +111,7 @@ describe('comfort-band-card', () => {
       devices: {},
       entities: {},
       callService: vi.fn(),
+      callWS: vi.fn(),
     };
     const el = await card('office', hass);
     expect(el.shadowRoot!.innerHTML).toContain('not found');

--- a/card/test/dual-handle-slider.test.ts
+++ b/card/test/dual-handle-slider.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/dual-handle-slider.js';
+import type { DualHandleSlider } from '../src/dual-handle-slider.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+async function slider(props: Partial<DualHandleSlider> = {}): Promise<DualHandleSlider> {
+  return mount('dual-handle-slider', {
+    min: 16,
+    max: 26,
+    step: 0.5,
+    low: 19,
+    high: 22,
+    ...props,
+  });
+}
+
+function getThumbs(el: DualHandleSlider): { low: HTMLElement; high: HTMLElement } {
+  const thumbs = el.shadowRoot!.querySelectorAll<HTMLElement>('.thumb');
+  return { low: thumbs[0], high: thumbs[1] };
+}
+
+describe('dual-handle-slider', () => {
+  it('renders two thumbs with role=slider and the right aria values', async () => {
+    const el = await slider();
+    const { low, high } = getThumbs(el);
+    expect(low.getAttribute('role')).toBe('slider');
+    expect(high.getAttribute('role')).toBe('slider');
+    expect(low.getAttribute('aria-valuenow')).toBe('19');
+    expect(high.getAttribute('aria-valuenow')).toBe('22');
+    expect(low.getAttribute('aria-valuemax')).toBe('21.5');
+    expect(high.getAttribute('aria-valuemin')).toBe('19.5');
+  });
+
+  it('shows formatted values in the label row', async () => {
+    const el = await slider({ low: 19.5, high: 22.5, unit: '°' });
+    const labels = el.shadowRoot!.querySelectorAll('.label-row span');
+    expect(labels[0].textContent).toContain('19.5°');
+    expect(labels[1].textContent).toContain('22.5°');
+  });
+
+  it('arrow keys step the focused thumb and fire a change event', async () => {
+    const el = await slider({ low: 19, high: 22, step: 0.5 });
+    const { low } = getThumbs(el);
+    const events: Array<{ low: number; high: number }> = [];
+    el.addEventListener('change', (e) => events.push((e as CustomEvent).detail));
+
+    low.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    await el.updateComplete;
+    expect(el.low).toBe(19.5);
+    expect(events).toEqual([{ low: 19.5, high: 22 }]);
+
+    low.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    await el.updateComplete;
+    expect(el.low).toBe(19);
+  });
+
+  it('arrow keys cannot push low past high - step', async () => {
+    const el = await slider({ low: 21.5, high: 22, step: 0.5 });
+    const { low } = getThumbs(el);
+    low.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    await el.updateComplete;
+    // Already at high - step (21.5); ArrowRight is rejected.
+    expect(el.low).toBe(21.5);
+  });
+
+  it('arrow keys cannot push high below low + step', async () => {
+    const el = await slider({ low: 19, high: 19.5, step: 0.5 });
+    const { high } = getThumbs(el);
+    high.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    await el.updateComplete;
+    expect(el.high).toBe(19.5);
+  });
+
+  it('Home/End jump to the bounds (within constraints)', async () => {
+    const el = await slider({ low: 19, high: 22, step: 0.5 });
+    const { low, high } = getThumbs(el);
+    const fire = vi.fn();
+    el.addEventListener('change', fire);
+
+    low.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    await el.updateComplete;
+    expect(el.low).toBe(16);
+
+    high.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    await el.updateComplete;
+    expect(el.high).toBe(26);
+  });
+
+  it('snaps to step boundaries on programmatic prop set', async () => {
+    // The snap function rounds to step intervals starting from `min`, so
+    // the user can't end up with values like 19.31 that the integration
+    // would refuse.
+    const el = await slider({ low: 19, high: 22 });
+    const { low } = getThumbs(el);
+    low.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    await el.updateComplete;
+    expect(el.low % 0.5).toBe(0);
+  });
+});

--- a/card/test/helpers.test.ts
+++ b/card/test/helpers.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { findActiveProfileEntity, findZoneEntities } from '../src/helpers.js';
+import type { DeviceRegistryEntry, EntityRegistryEntry, HomeAssistant } from '../src/types.js';
+
+function makeEntity(entity_id: string, unique_id: string, device_id: string): EntityRegistryEntry {
+  return {
+    entity_id,
+    unique_id,
+    platform: 'comfort_band',
+    device_id,
+    disabled_by: null,
+    hidden_by: null,
+    name: null,
+    area_id: null,
+    translation_key: null,
+  };
+}
+
+function makeDevice(
+  id: string,
+  identifiers: Array<[string, string]>,
+  name: string | null,
+  name_by_user: string | null = null,
+): DeviceRegistryEntry {
+  return { id, identifiers, name, name_by_user, area_id: null };
+}
+
+function makeHass(devices: DeviceRegistryEntry[], entities: EntityRegistryEntry[]): HomeAssistant {
+  return {
+    states: {},
+    devices: Object.fromEntries(devices.map((d) => [d.id, d])),
+    entities: Object.fromEntries(entities.map((e) => [e.entity_id, e])),
+    callService: () => Promise.resolve(),
+  };
+}
+
+const ALL_KEYS = [
+  'effective_low',
+  'effective_high',
+  'room_temperature',
+  'override_ends',
+  'current_action',
+  'override_active',
+  'manual_low',
+  'manual_high',
+  'override_hours',
+  'deadband_below',
+  'deadband_above',
+  'min_cycle_minutes',
+  'cancel_override',
+  'enabled',
+];
+
+describe('findZoneEntities', () => {
+  it('resolves every entity for a zone with the canonical entity-id pattern', () => {
+    const device = makeDevice('dev-gym', [['comfort_band', 'zone:gym']], 'Gym');
+    const entities = ALL_KEYS.map((key) =>
+      makeEntity(`sensor.gym_${key}`, `gym_${key}`, 'dev-gym'),
+    );
+    const hass = makeHass([device], entities);
+
+    const out = findZoneEntities(hass, 'gym');
+
+    expect(out.deviceId).toBe('dev-gym');
+    expect(out.deviceName).toBe('Gym');
+    expect(out.effectiveLow).toBe('sensor.gym_effective_low');
+    expect(out.currentAction).toBe('sensor.gym_current_action');
+    expect(out.manualLow).toBe('sensor.gym_manual_low');
+    expect(out.cancelOverride).toBe('sensor.gym_cancel_override');
+    expect(out.enabled).toBe('sensor.gym_enabled');
+  });
+
+  it('resolves entities even when entity_ids have collision suffixes (`_2`)', () => {
+    // Reproduces the post-cutover state: unique_id is canonical (`main_*`)
+    // but entity_id has a `_2` suffix because the legacy entity squatted the slug.
+    const device = makeDevice('dev-main', [['comfort_band', 'zone:main']], 'Main');
+    const entities = [
+      makeEntity('sensor.main_room_temperature_2', 'main_room_temperature', 'dev-main'),
+      makeEntity('sensor.main_current_action_2', 'main_current_action', 'dev-main'),
+      makeEntity('number.main_manual_low_2', 'main_manual_low', 'dev-main'),
+    ];
+    const hass = makeHass([device], entities);
+
+    const out = findZoneEntities(hass, 'main');
+
+    expect(out.roomTemperature).toBe('sensor.main_room_temperature_2');
+    expect(out.currentAction).toBe('sensor.main_current_action_2');
+    expect(out.manualLow).toBe('number.main_manual_low_2');
+  });
+
+  it('resolves entities when the entity_id is wholly renamed (e.g. `gym_hvac_new_*`)', () => {
+    // Reproduces the gym zone's renamed entity_ids — slugs differ from the
+    // canonical pattern but unique_ids stay stable. Lookup by device + unique_id
+    // sidesteps the entity-id naming chaos.
+    const device = makeDevice('dev-gym', [['comfort_band', 'zone:gym']], 'Gym');
+    const entities = [
+      makeEntity('sensor.gym_hvac_new_room_temperature', 'gym_room_temperature', 'dev-gym'),
+      makeEntity('binary_sensor.gym_hvac_new_override_active', 'gym_override_active', 'dev-gym'),
+    ];
+    const hass = makeHass([device], entities);
+
+    const out = findZoneEntities(hass, 'gym');
+
+    expect(out.roomTemperature).toBe('sensor.gym_hvac_new_room_temperature');
+    expect(out.overrideActive).toBe('binary_sensor.gym_hvac_new_override_active');
+  });
+
+  it('prefers `name_by_user` over `name` when present', () => {
+    const device = makeDevice('dev-mbr', [['comfort_band', 'zone:mbr']], 'Mbr', 'Master Bedroom');
+    const hass = makeHass([device], []);
+
+    expect(findZoneEntities(hass, 'mbr').deviceName).toBe('Master Bedroom');
+  });
+
+  it('returns null fields when the zone device is not registered', () => {
+    const hass = makeHass([], []);
+
+    const out = findZoneEntities(hass, 'office');
+
+    expect(out.deviceId).toBe(null);
+    expect(out.effectiveLow).toBe(null);
+    expect(out.currentAction).toBe(null);
+  });
+
+  it('ignores entities from other platforms or other devices', () => {
+    const device = makeDevice('dev-gym', [['comfort_band', 'zone:gym']], 'Gym');
+    const entities: EntityRegistryEntry[] = [
+      makeEntity('sensor.gym_room_temperature', 'gym_room_temperature', 'dev-gym'),
+      // Foreign platform — same unique_id pattern but different platform.
+      {
+        ...makeEntity('sensor.fake_gym_current_action', 'gym_current_action', 'dev-gym'),
+        platform: 'template',
+      },
+      // Another device — sibling device that shouldn't leak through.
+      makeEntity('sensor.other_room_temperature', 'other_room_temperature', 'dev-other'),
+    ];
+    const hass = makeHass([device], entities);
+
+    const out = findZoneEntities(hass, 'gym');
+
+    expect(out.roomTemperature).toBe('sensor.gym_room_temperature');
+    expect(out.currentAction).toBe(null);
+  });
+
+  it('skips entities whose unique_id does not start with the zone prefix', () => {
+    // Defensive: an entity tagged to the zone device but with an unexpected
+    // unique_id (e.g. a future version's diagnostic) should be ignored.
+    const device = makeDevice('dev-gym', [['comfort_band', 'zone:gym']], 'Gym');
+    const entities = [
+      makeEntity('sensor.gym_room_temperature', 'gym_room_temperature', 'dev-gym'),
+      makeEntity('sensor.gym_diag_x', 'diag_x', 'dev-gym'),
+    ];
+    const hass = makeHass([device], entities);
+
+    const out = findZoneEntities(hass, 'gym');
+
+    expect(out.roomTemperature).toBe('sensor.gym_room_temperature');
+    // The unrecognised entity didn't crash — and didn't get assigned anywhere.
+    expect(Object.values(out).every((v) => v !== 'sensor.gym_diag_x')).toBe(true);
+  });
+});
+
+describe('findActiveProfileEntity', () => {
+  it('resolves the singleton profile-manager select', () => {
+    const device = makeDevice(
+      'dev-pm',
+      [['comfort_band', 'profile_manager']],
+      'Comfort Band Profiles',
+    );
+    const entities = [
+      makeEntity(
+        'select.comfort_band_profiles_active_profile',
+        'profile_manager_active_profile',
+        'dev-pm',
+      ),
+    ];
+    const hass = makeHass([device], entities);
+
+    expect(findActiveProfileEntity(hass)).toBe('select.comfort_band_profiles_active_profile');
+  });
+
+  it('returns null when the profile-manager device is missing', () => {
+    expect(findActiveProfileEntity(makeHass([], []))).toBe(null);
+  });
+});

--- a/card/test/helpers.test.ts
+++ b/card/test/helpers.test.ts
@@ -31,6 +31,7 @@ function makeHass(devices: DeviceRegistryEntry[], entities: EntityRegistryEntry[
     devices: Object.fromEntries(devices.map((d) => [d.id, d])),
     entities: Object.fromEntries(entities.map((e) => [e.entity_id, e])),
     callService: () => Promise.resolve(),
+    callWS: () => Promise.resolve() as Promise<never>,
   };
 }
 

--- a/card/test/insights-tab.test.ts
+++ b/card/test/insights-tab.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/tabs/insights-tab.js';
+import type { ComfortBandInsightsTab } from '../src/tabs/insights-tab.js';
+import type { ZoneEntities } from '../src/helpers.js';
+import type { HomeAssistant } from '../src/types.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(() => {
+  teardown();
+  delete (window as { loadCardHelpers?: unknown }).loadCardHelpers;
+});
+
+function makeEntities(roomTemperature: string | null = 'sensor.gym_room_temperature'): ZoneEntities {
+  return {
+    effectiveLow: null,
+    effectiveHigh: null,
+    roomTemperature,
+    overrideEnds: null,
+    currentAction: null,
+    overrideActive: null,
+    manualLow: null,
+    manualHigh: null,
+    overrideHours: null,
+    deadbandBelow: null,
+    deadbandAbove: null,
+    minCycleMinutes: null,
+    cancelOverride: null,
+    enabled: null,
+    deviceId: 'dev-gym',
+    deviceName: 'Gym',
+  };
+}
+
+function makeHass(): HomeAssistant {
+  return {
+    states: {},
+    devices: {},
+    entities: {},
+    callService: vi.fn(),
+  };
+}
+
+async function tab(props: Partial<ComfortBandInsightsTab>): Promise<ComfortBandInsightsTab> {
+  return mount('comfort-band-insights-tab', props);
+}
+
+describe('comfort-band-insights-tab', () => {
+  it('renders an empty message when no room temperature sensor is registered', async () => {
+    const el = await tab({ hass: makeHass(), entities: makeEntities(null) });
+    expect(el.shadowRoot!.querySelector('.empty')!.textContent).toContain('No room temperature');
+  });
+
+  it('shows the fallback link when loadCardHelpers is not on window', async () => {
+    delete (window as { loadCardHelpers?: unknown }).loadCardHelpers;
+    const el = await tab({ hass: makeHass(), entities: makeEntities() });
+    // firstUpdated runs synchronously here; give the microtask a chance.
+    await el.updateComplete;
+    const fallback = el.shadowRoot!.querySelector('.fallback');
+    expect(fallback).not.toBeNull();
+    expect(fallback!.querySelector('a')!.getAttribute('href')).toContain(
+      'sensor.gym_room_temperature',
+    );
+  });
+
+  it('uses loadCardHelpers + createCardElement when available', async () => {
+    const fakeCard = document.createElement('div');
+    Object.assign(fakeCard, { hass: undefined as unknown });
+    const createCardElement = vi.fn().mockReturnValue(fakeCard);
+    (window as { loadCardHelpers?: unknown }).loadCardHelpers = vi
+      .fn()
+      .mockResolvedValue({ createCardElement });
+
+    const hass = makeHass();
+    const el = await tab({ hass, entities: makeEntities() });
+    // Wait for the async firstUpdated → loadCardHelpers chain.
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+    await el.updateComplete;
+
+    expect(createCardElement).toHaveBeenCalledWith({
+      type: 'history-graph',
+      entities: ['sensor.gym_room_temperature'],
+      hours_to_show: 24,
+    });
+    expect(el.shadowRoot!.querySelector('.graph-container')!.contains(fakeCard)).toBe(true);
+    expect((fakeCard as unknown as { hass: unknown }).hass).toBe(hass);
+  });
+
+  it('falls back if loadCardHelpers throws', async () => {
+    (window as { loadCardHelpers?: unknown }).loadCardHelpers = vi
+      .fn()
+      .mockRejectedValue(new Error('boom'));
+
+    const el = await tab({ hass: makeHass(), entities: makeEntities() });
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector('.fallback')).not.toBeNull();
+  });
+});

--- a/card/test/insights-tab.test.ts
+++ b/card/test/insights-tab.test.ts
@@ -10,7 +10,9 @@ afterEach(() => {
   delete (window as { loadCardHelpers?: unknown }).loadCardHelpers;
 });
 
-function makeEntities(roomTemperature: string | null = 'sensor.gym_room_temperature'): ZoneEntities {
+function makeEntities(
+  roomTemperature: string | null = 'sensor.gym_room_temperature',
+): ZoneEntities {
   return {
     effectiveLow: null,
     effectiveHigh: null,
@@ -37,6 +39,7 @@ function makeHass(): HomeAssistant {
     devices: {},
     entities: {},
     callService: vi.fn(),
+    callWS: vi.fn(),
   };
 }
 

--- a/card/test/now-tab.test.ts
+++ b/card/test/now-tab.test.ts
@@ -57,6 +57,7 @@ function makeHass(overrides: Partial<Record<string, string>> = {}): HomeAssistan
     devices: {},
     entities: {},
     callService: vi.fn().mockResolvedValue(undefined),
+    callWS: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/card/test/now-tab.test.ts
+++ b/card/test/now-tab.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/tabs/now-tab.js';
+import type { ComfortBandNowTab } from '../src/tabs/now-tab.js';
+import type { ZoneEntities } from '../src/helpers.js';
+import type { HomeAssistant } from '../src/types.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+function makeEntities(zone = 'gym'): ZoneEntities {
+  return {
+    effectiveLow: `sensor.${zone}_effective_low`,
+    effectiveHigh: `sensor.${zone}_effective_high`,
+    roomTemperature: `sensor.${zone}_room_temperature`,
+    overrideEnds: `sensor.${zone}_override_ends`,
+    currentAction: `sensor.${zone}_current_action`,
+    overrideActive: `binary_sensor.${zone}_override_active`,
+    manualLow: `number.${zone}_manual_low`,
+    manualHigh: `number.${zone}_manual_high`,
+    overrideHours: `number.${zone}_override_hours`,
+    deadbandBelow: `number.${zone}_deadband_below`,
+    deadbandAbove: `number.${zone}_deadband_above`,
+    minCycleMinutes: `number.${zone}_min_cycle_minutes`,
+    cancelOverride: `button.${zone}_cancel_override`,
+    enabled: `switch.${zone}_enabled`,
+    deviceId: `dev-${zone}`,
+    deviceName: zone,
+  };
+}
+
+function makeHass(overrides: Partial<Record<string, string>> = {}): HomeAssistant {
+  const states: Record<string, string> = {
+    'sensor.gym_effective_low': '19.5',
+    'sensor.gym_effective_high': '22.5',
+    'sensor.gym_room_temperature': '21.0',
+    'sensor.gym_current_action': 'idle',
+    'sensor.gym_override_ends': 'unknown',
+    'binary_sensor.gym_override_active': 'off',
+    'number.gym_manual_low': '19',
+    'number.gym_manual_high': '22',
+    'number.gym_override_hours': '3',
+    ...overrides,
+  };
+  return {
+    states: Object.fromEntries(
+      Object.entries(states).map(([k, v]) => [
+        k,
+        {
+          entity_id: k,
+          state: v as string,
+          attributes: {},
+          last_changed: '',
+          last_updated: '',
+        },
+      ]),
+    ),
+    devices: {},
+    entities: {},
+    callService: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+async function nowTab(
+  hass: HomeAssistant,
+  entities = makeEntities(),
+  zone = 'gym',
+): Promise<ComfortBandNowTab> {
+  return mount('comfort-band-now-tab', { hass, entities, zone });
+}
+
+describe('comfort-band-now-tab', () => {
+  it('renders prominent room temperature with one decimal', async () => {
+    const el = await nowTab(makeHass());
+    expect(el.shadowRoot!.querySelector('.room-temp')!.textContent).toContain('21.0°');
+  });
+
+  it('omits the action chip when idle', async () => {
+    const el = await nowTab(makeHass({ 'sensor.gym_current_action': 'idle' }));
+    expect(el.shadowRoot!.querySelector('.action-chip')).toBeNull();
+  });
+
+  it('shows the action chip when heating', async () => {
+    const el = await nowTab(makeHass({ 'sensor.gym_current_action': 'heating' }));
+    expect(el.shadowRoot!.querySelector('.action-chip')!.textContent).toContain('Heating');
+  });
+
+  it('initialises slider from manual_low / manual_high entity states', async () => {
+    const el = await nowTab(
+      makeHass({ 'number.gym_manual_low': '20', 'number.gym_manual_high': '23' }),
+    );
+    const slider = el.shadowRoot!.querySelector('dual-handle-slider') as HTMLElement & {
+      low: number;
+      high: number;
+    };
+    expect(slider.low).toBe(20);
+    expect(slider.high).toBe(23);
+  });
+
+  it('slider change calls comfort_band.start_override with the new band', async () => {
+    const hass = makeHass();
+    const el = await nowTab(hass);
+    const slider = el.shadowRoot!.querySelector('dual-handle-slider')!;
+    slider.dispatchEvent(
+      new CustomEvent('change', { detail: { low: 20.5, high: 23.5 }, bubbles: true }),
+    );
+    await el.updateComplete;
+    expect(hass.callService).toHaveBeenCalledWith('comfort_band', 'start_override', {
+      zone: 'gym',
+      low: 20.5,
+      high: 23.5,
+    });
+  });
+
+  it('hides the override section when override is inactive', async () => {
+    const el = await nowTab(makeHass());
+    expect(el.shadowRoot!.textContent).not.toContain('Cancel');
+  });
+
+  it('shows the override section + Cancel button when override is active', async () => {
+    const el = await nowTab(
+      makeHass({
+        'binary_sensor.gym_override_active': 'on',
+        'sensor.gym_override_ends': new Date(Date.now() + 60 * 60_000).toISOString(),
+      }),
+    );
+    const cancelBtn = el.shadowRoot!.querySelector('.button.secondary');
+    expect(cancelBtn).not.toBeNull();
+    expect(cancelBtn!.textContent).toContain('Cancel');
+  });
+
+  it('Cancel button calls comfort_band.cancel_override', async () => {
+    const hass = makeHass({
+      'binary_sensor.gym_override_active': 'on',
+      'sensor.gym_override_ends': new Date(Date.now() + 60 * 60_000).toISOString(),
+    });
+    const el = await nowTab(hass);
+    const cancel = el.shadowRoot!.querySelector('.button.secondary') as HTMLButtonElement;
+    cancel.click();
+    await el.updateComplete;
+    expect(hass.callService).toHaveBeenCalledWith('comfort_band', 'cancel_override', {
+      zone: 'gym',
+    });
+  });
+
+  it('clicking a duration preset calls number.set_value on the hours entity', async () => {
+    const hass = makeHass({ 'number.gym_override_hours': '3' });
+    const el = await nowTab(hass);
+    const presets = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.preset');
+    presets[2].click(); // 6h
+    await el.updateComplete;
+    expect(hass.callService).toHaveBeenCalledWith('number', 'set_value', {
+      entity_id: 'number.gym_override_hours',
+      value: 6,
+    });
+  });
+
+  it('marks the active duration preset', async () => {
+    const el = await nowTab(makeHass({ 'number.gym_override_hours': '3' }));
+    const presets = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.preset');
+    expect(presets[0].classList.contains('active')).toBe(false);
+    expect(presets[1].classList.contains('active')).toBe(true);
+    expect(presets[2].classList.contains('active')).toBe(false);
+  });
+});

--- a/card/test/profiles-tab.test.ts
+++ b/card/test/profiles-tab.test.ts
@@ -45,6 +45,7 @@ function makeHass(opts: {
     entities: entities as HomeAssistant['entities'],
     devices: devices as HomeAssistant['devices'],
     callService: vi.fn().mockResolvedValue(undefined),
+    callWS: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/card/test/profiles-tab.test.ts
+++ b/card/test/profiles-tab.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/tabs/profiles-tab.js';
+import type { ComfortBandProfilesTab } from '../src/tabs/profiles-tab.js';
+import type { HomeAssistant } from '../src/types.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+function makeHass(opts: {
+  options?: string[];
+  active?: string;
+  selectEntity?: string | null;
+}): HomeAssistant {
+  const entityId = opts.selectEntity ?? 'select.comfort_band_profiles_active_profile';
+  const states: Record<string, ReturnType<typeof entityState>> = {};
+  const entities: Record<string, unknown> = {};
+  const devices: Record<string, unknown> = {};
+
+  if (opts.selectEntity !== null) {
+    devices['dev-pm'] = {
+      id: 'dev-pm',
+      identifiers: [['comfort_band', 'profile_manager']],
+      name: 'Comfort Band Profiles',
+      name_by_user: null,
+      area_id: null,
+    };
+    entities[entityId] = {
+      entity_id: entityId,
+      unique_id: 'profile_manager_active_profile',
+      platform: 'comfort_band',
+      device_id: 'dev-pm',
+      disabled_by: null,
+      hidden_by: null,
+      name: null,
+      area_id: null,
+      translation_key: 'active_profile',
+    };
+    states[entityId] = entityState(entityId, opts.active ?? 'home', {
+      options: opts.options ?? ['home', 'away', 'sleep'],
+    });
+  }
+
+  return {
+    states: states as HomeAssistant['states'],
+    entities: entities as HomeAssistant['entities'],
+    devices: devices as HomeAssistant['devices'],
+    callService: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function entityState(entityId: string, state: string, attributes: Record<string, unknown> = {}) {
+  return {
+    entity_id: entityId,
+    state,
+    attributes,
+    last_changed: '',
+    last_updated: '',
+  };
+}
+
+async function profilesTab(hass: HomeAssistant): Promise<ComfortBandProfilesTab> {
+  return mount('comfort-band-profiles-tab', { hass });
+}
+
+describe('comfort-band-profiles-tab', () => {
+  it('lists every profile from the select options', async () => {
+    const el = await profilesTab(makeHass({ options: ['home', 'away', 'sleep'] }));
+    const items = el.shadowRoot!.querySelectorAll('li');
+    expect(items.length).toBe(3);
+    expect(Array.from(items).map((li) => li.querySelector('.name')!.textContent!.trim())).toEqual([
+      'home',
+      'away',
+      'sleep',
+    ]);
+  });
+
+  it('marks the active profile with the active class and a badge', async () => {
+    const el = await profilesTab(makeHass({ options: ['home', 'away', 'sleep'], active: 'away' }));
+    const items = el.shadowRoot!.querySelectorAll('li');
+    expect(items[0].classList.contains('active')).toBe(false);
+    expect(items[1].classList.contains('active')).toBe(true);
+    expect(items[1].querySelector('.badge')).not.toBeNull();
+    expect(items[2].classList.contains('active')).toBe(false);
+  });
+
+  it('clicking a profile fires comfort_band.set_profile', async () => {
+    const hass = makeHass({ options: ['home', 'away', 'sleep'], active: 'home' });
+    const el = await profilesTab(hass);
+    const items = el.shadowRoot!.querySelectorAll<HTMLLIElement>('li');
+    items[1].click();
+    expect(hass.callService).toHaveBeenCalledWith('comfort_band', 'set_profile', {
+      profile: 'away',
+    });
+  });
+
+  it('Enter / Space on a focused option selects it (keyboard a11y)', async () => {
+    const hass = makeHass({ options: ['home', 'away', 'sleep'], active: 'home' });
+    const el = await profilesTab(hass);
+    const items = el.shadowRoot!.querySelectorAll<HTMLLIElement>('li');
+    items[2].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(hass.callService).toHaveBeenCalledWith('comfort_band', 'set_profile', {
+      profile: 'sleep',
+    });
+  });
+
+  it('renders a friendly empty state when the profile manager is not yet registered', async () => {
+    const el = await profilesTab(makeHass({ selectEntity: null }));
+    expect(el.shadowRoot!.textContent).toContain('not registered');
+  });
+
+  it('renders a no-profiles message when options is empty', async () => {
+    const el = await profilesTab(makeHass({ options: [] }));
+    expect(el.shadowRoot!.textContent).toContain('No profiles');
+  });
+});

--- a/card/test/schedule-tab.test.ts
+++ b/card/test/schedule-tab.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/tabs/schedule-tab.js';
+import type { ComfortBandScheduleTab } from '../src/tabs/schedule-tab.js';
+import type { HomeAssistant, ProfileSchedule, Transition } from '../src/types.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+interface FakeHassOptions {
+  initialSchedule?: ProfileSchedule | null;
+  active?: string;
+}
+
+function makeHass(opts: FakeHassOptions = {}): HomeAssistant {
+  let stored: ProfileSchedule | null = opts.initialSchedule ?? null;
+  const callWS = vi.fn(async (msg: { type: string } & Record<string, unknown>) => {
+    if (msg.type === 'comfort_band/get_schedule') return stored;
+    return null;
+  });
+  const callService = vi.fn(
+    async (_domain: string, service: string, data?: Record<string, unknown>) => {
+      if (service === 'set_schedule' && data) {
+        stored = {
+          baseline: [...((data.transitions as Transition[]) ?? [])],
+          current: [...((data.transitions as Transition[]) ?? [])],
+        };
+      }
+    },
+  );
+  return {
+    states: {
+      'select.comfort_band_profiles_active_profile': {
+        entity_id: 'select.comfort_band_profiles_active_profile',
+        state: opts.active ?? 'home',
+        attributes: { options: ['home', 'away', 'sleep'] },
+        last_changed: '',
+        last_updated: '',
+      },
+    },
+    devices: {
+      'dev-pm': {
+        id: 'dev-pm',
+        identifiers: [['comfort_band', 'profile_manager']],
+        name: 'Comfort Band Profiles',
+        name_by_user: null,
+        area_id: null,
+      },
+    },
+    entities: {
+      'select.comfort_band_profiles_active_profile': {
+        entity_id: 'select.comfort_band_profiles_active_profile',
+        unique_id: 'profile_manager_active_profile',
+        platform: 'comfort_band',
+        device_id: 'dev-pm',
+        disabled_by: null,
+        hidden_by: null,
+        name: null,
+        area_id: null,
+        translation_key: 'active_profile',
+      },
+    },
+    callService,
+    callWS: callWS as HomeAssistant['callWS'],
+  };
+}
+
+async function tab(hass: HomeAssistant, zone = 'gym'): Promise<ComfortBandScheduleTab> {
+  const el = await mount('comfort-band-schedule-tab', { hass, zone });
+  // Allow the async fetch in willUpdate to resolve.
+  await new Promise((r) => setTimeout(r, 0));
+  await el.updateComplete;
+  return el;
+}
+
+describe('comfort-band-schedule-tab', () => {
+  it('fetches the schedule for the active profile via callWS', async () => {
+    const hass = makeHass({
+      initialSchedule: {
+        baseline: [{ at: '06:00', low: 20, high: 23 }],
+        current: [{ at: '06:00', low: 20, high: 23 }],
+      },
+    });
+    await tab(hass);
+    expect(hass.callWS).toHaveBeenCalledWith({
+      type: 'comfort_band/get_schedule',
+      zone: 'gym',
+      profile: 'home',
+    });
+  });
+
+  it('renders transitions from the fetched schedule', async () => {
+    const hass = makeHass({
+      initialSchedule: {
+        baseline: [
+          { at: '06:00', low: 20, high: 23 },
+          { at: '22:00', low: 18, high: 21 },
+        ],
+        current: [],
+      },
+    });
+    const el = await tab(hass);
+    const points = el
+      .shadowRoot!.querySelector('timeline-editor')!
+      .shadowRoot!.querySelectorAll('.point');
+    expect(points.length).toBe(2);
+  });
+
+  it('handles a null schedule (zone has no profile schedule yet) without error', async () => {
+    const hass = makeHass({ initialSchedule: null });
+    const el = await tab(hass);
+    expect(el.shadowRoot!.textContent).not.toContain('Failed');
+    const editor = el.shadowRoot!.querySelector('timeline-editor');
+    expect(editor).not.toBeNull();
+  });
+
+  it('persists deletions via comfort_band.set_schedule', async () => {
+    const hass = makeHass({
+      initialSchedule: {
+        baseline: [
+          { at: '06:00', low: 20, high: 23 },
+          { at: '22:00', low: 18, high: 21 },
+        ],
+        current: [],
+      },
+    });
+    const el = await tab(hass);
+    const editor = el.shadowRoot!.querySelector('timeline-editor')!;
+    editor.dispatchEvent(
+      new CustomEvent('transition-delete', {
+        detail: { at: '22:00' },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    await el.updateComplete;
+    expect(hass.callService).toHaveBeenCalledWith('comfort_band', 'set_schedule', {
+      zone: 'gym',
+      profile: 'home',
+      transitions: [{ at: '06:00', low: 20, high: 23 }],
+    });
+  });
+
+  it('opens the dialog on transition-edit then persists the new values on save', async () => {
+    const hass = makeHass({
+      initialSchedule: {
+        baseline: [{ at: '06:00', low: 20, high: 23 }],
+        current: [],
+      },
+    });
+    const el = await tab(hass);
+
+    const editor = el.shadowRoot!.querySelector('timeline-editor')!;
+    editor.dispatchEvent(
+      new CustomEvent('transition-edit', {
+        detail: { transition: { at: '06:00', low: 20, high: 23 } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await el.updateComplete;
+    const dlg = el.shadowRoot!.querySelector('transition-edit-dialog');
+    expect(dlg).not.toBeNull();
+
+    dlg!.dispatchEvent(
+      new CustomEvent('dialog-save', {
+        detail: { transition: { at: '06:00', low: 20, high: 23.5 } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    await el.updateComplete;
+    expect(hass.callService).toHaveBeenCalledWith('comfort_band', 'set_schedule', {
+      zone: 'gym',
+      profile: 'home',
+      transitions: [{ at: '06:00', low: 20, high: 23.5 }],
+    });
+  });
+
+  it('opens the add dialog on transition-add and persists the new transition on save', async () => {
+    const hass = makeHass({ initialSchedule: null });
+    const el = await tab(hass);
+
+    const editor1 = el.shadowRoot!.querySelector('timeline-editor')!;
+    editor1.dispatchEvent(
+      new CustomEvent('transition-add', {
+        detail: { at: '07:00' },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await el.updateComplete;
+    const dlg1 = el.shadowRoot!.querySelector('transition-edit-dialog');
+    expect(dlg1).not.toBeNull();
+
+    dlg1!.dispatchEvent(
+      new CustomEvent('dialog-save', {
+        detail: { transition: { at: '07:00', low: 19, high: 22 } },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    await el.updateComplete;
+    expect(hass.callService).toHaveBeenCalledWith('comfort_band', 'set_schedule', {
+      zone: 'gym',
+      profile: 'home',
+      transitions: [{ at: '07:00', low: 19, high: 22 }],
+    });
+  });
+
+  it('cancel returns to the list mode without writing', async () => {
+    const hass = makeHass({ initialSchedule: null });
+    const el = await tab(hass);
+    const editor2 = el.shadowRoot!.querySelector('timeline-editor')!;
+    editor2.dispatchEvent(
+      new CustomEvent('transition-add', {
+        detail: { at: '08:00' },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await el.updateComplete;
+    const dlg2 = el.shadowRoot!.querySelector('transition-edit-dialog')!;
+    dlg2.dispatchEvent(new CustomEvent('dialog-cancel', { bubbles: true, composed: true }));
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('transition-edit-dialog')).toBeNull();
+    expect(hass.callService).not.toHaveBeenCalled();
+  });
+});

--- a/card/test/services.test.ts
+++ b/card/test/services.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  addTransition,
+  cancelOverride,
+  removeTransition,
+  setProfile,
+  setSchedule,
+  startOverride,
+  updateTransition,
+} from '../src/services.js';
+import type { HomeAssistant } from '../src/types.js';
+
+function makeMockHass() {
+  const callService = vi.fn().mockResolvedValue(undefined);
+  const hass: HomeAssistant = {
+    states: {},
+    entities: {},
+    devices: {},
+    callService,
+  };
+  return { hass, callService };
+}
+
+describe('service wrappers', () => {
+  it('setSchedule passes zone, profile, and transitions verbatim', async () => {
+    const { hass, callService } = makeMockHass();
+    const transitions = [
+      { at: '06:00', low: 20, high: 23 },
+      { at: '22:00', low: 18, high: 21 },
+    ];
+
+    await setSchedule(hass, { zone: 'gym', profile: 'home', transitions });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'set_schedule', {
+      zone: 'gym',
+      profile: 'home',
+      transitions,
+    });
+  });
+
+  it('addTransition sends the four required fields', async () => {
+    const { hass, callService } = makeMockHass();
+
+    await addTransition(hass, {
+      zone: 'gym',
+      profile: 'home',
+      at: '07:30',
+      low: 19.5,
+      high: 22.5,
+    });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'add_transition', {
+      zone: 'gym',
+      profile: 'home',
+      at: '07:30',
+      low: 19.5,
+      high: 22.5,
+    });
+  });
+
+  it('updateTransition matches by `at` time', async () => {
+    const { hass, callService } = makeMockHass();
+
+    await updateTransition(hass, {
+      zone: 'office',
+      profile: 'away',
+      at: '06:00',
+      low: 17,
+      high: 24,
+    });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'update_transition', {
+      zone: 'office',
+      profile: 'away',
+      at: '06:00',
+      low: 17,
+      high: 24,
+    });
+  });
+
+  it('removeTransition sends only zone, profile, at', async () => {
+    const { hass, callService } = makeMockHass();
+
+    await removeTransition(hass, { zone: 'gym', profile: 'home', at: '22:00' });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'remove_transition', {
+      zone: 'gym',
+      profile: 'home',
+      at: '22:00',
+    });
+  });
+
+  it('startOverride omits undefined optional fields', async () => {
+    const { hass, callService } = makeMockHass();
+
+    await startOverride(hass, { zone: 'gym' });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'start_override', {
+      zone: 'gym',
+    });
+  });
+
+  it('startOverride forwards low/high/hours when provided', async () => {
+    const { hass, callService } = makeMockHass();
+
+    await startOverride(hass, { zone: 'gym', low: 19, high: 22, hours: 4 });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'start_override', {
+      zone: 'gym',
+      low: 19,
+      high: 22,
+      hours: 4,
+    });
+  });
+
+  it('startOverride forwards a partial subset of optionals', async () => {
+    const { hass, callService } = makeMockHass();
+
+    await startOverride(hass, { zone: 'gym', high: 22.5 });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'start_override', {
+      zone: 'gym',
+      high: 22.5,
+    });
+  });
+
+  it('cancelOverride sends only zone', async () => {
+    const { hass, callService } = makeMockHass();
+
+    await cancelOverride(hass, { zone: 'gym' });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'cancel_override', {
+      zone: 'gym',
+    });
+  });
+
+  it('setProfile sends only profile (no zone)', async () => {
+    const { hass, callService } = makeMockHass();
+
+    await setProfile(hass, { profile: 'away' });
+
+    expect(callService).toHaveBeenCalledWith('comfort_band', 'set_profile', {
+      profile: 'away',
+    });
+  });
+});

--- a/card/test/services.test.ts
+++ b/card/test/services.test.ts
@@ -17,6 +17,7 @@ function makeMockHass() {
     entities: {},
     devices: {},
     callService,
+    callWS: vi.fn().mockResolvedValue(undefined),
   };
   return { hass, callService };
 }

--- a/card/test/smoke.test.ts
+++ b/card/test/smoke.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+
+describe('comfort-band-card module', () => {
+  it('registers comfort-band-card as a custom element on import', async () => {
+    await import('../src/index.js');
+    expect(customElements.get('comfort-band-card')).toBeDefined();
+  });
+});

--- a/card/test/tile.test.ts
+++ b/card/test/tile.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/tile.js';
+import type { ComfortBandTile } from '../src/tile.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+async function tile(props: Partial<ComfortBandTile>): Promise<ComfortBandTile> {
+  return mount('comfort-band-tile', props);
+}
+
+describe('comfort-band-tile', () => {
+  it('renders zone name and room temperature in degrees with one decimal', async () => {
+    const el = await tile({ zoneName: 'Gym', roomTemp: 21.4, low: 19, high: 23, action: 'idle' });
+    const sr = el.shadowRoot!;
+    expect(sr.querySelector('.zone-name')!.textContent).toContain('Gym');
+    expect(sr.querySelector('.room-temp')!.textContent).toContain('21.4°');
+  });
+
+  it('shows an em-dash for unknown room temperature', async () => {
+    const el = await tile({ zoneName: 'Gym', roomTemp: NaN, action: 'unknown' });
+    expect(el.shadowRoot!.querySelector('.room-temp')!.textContent).toContain('—');
+  });
+
+  it('renders an action chip when heating or cooling', async () => {
+    const heat = await tile({ zoneName: 'Gym', action: 'heating' });
+    expect(heat.shadowRoot!.querySelector('.action-chip')?.textContent).toContain('Heating');
+    teardown();
+    const cool = await tile({ zoneName: 'Gym', action: 'cooling' });
+    expect(cool.shadowRoot!.querySelector('.action-chip')?.textContent).toContain('Cooling');
+  });
+
+  it('omits the action chip when idle or unknown', async () => {
+    const idle = await tile({ zoneName: 'Gym', action: 'idle' });
+    expect(idle.shadowRoot!.querySelector('.action-chip')).toBeNull();
+    teardown();
+    const unk = await tile({ zoneName: 'Gym', action: 'unknown' });
+    expect(unk.shadowRoot!.querySelector('.action-chip')).toBeNull();
+  });
+
+  it('renders an override pill when override is active', async () => {
+    const future = new Date(Date.now() + 90 * 60_000).toISOString(); // +1h 30m
+    const el = await tile({
+      zoneName: 'Gym',
+      action: 'heating',
+      overrideActive: true,
+      overrideEnds: future,
+    });
+    const pill = el.shadowRoot!.querySelector('.override-pill');
+    expect(pill).not.toBeNull();
+    expect(pill!.textContent).toContain('Override');
+    expect(pill!.textContent).toContain('1h 30m left');
+  });
+
+  it('omits the override pill when override is inactive', async () => {
+    const el = await tile({ zoneName: 'Gym', action: 'idle', overrideActive: false });
+    expect(el.shadowRoot!.querySelector('.override-pill')).toBeNull();
+  });
+
+  it('fires a comfort-band-tile-tap event when tapped', async () => {
+    const el = await tile({ zoneName: 'Gym', action: 'idle' });
+    const listener = vi.fn();
+    el.addEventListener('comfort-band-tile-tap', listener);
+    (el.shadowRoot!.querySelector('.tile') as HTMLElement).click();
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire a tap event in noExpand mode', async () => {
+    const el = await tile({ zoneName: 'Gym', action: 'idle', noExpand: true });
+    const listener = vi.fn();
+    el.addEventListener('comfort-band-tile-tap', listener);
+    (el.shadowRoot!.querySelector('.tile') as HTMLElement).click();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('renders a band-gauge child with the same low/high/room/action', async () => {
+    const el = await tile({
+      zoneName: 'Gym',
+      roomTemp: 21,
+      low: 19,
+      high: 23,
+      action: 'cooling',
+    });
+    const gauge = el.shadowRoot!.querySelector('band-gauge') as HTMLElement & {
+      low: number;
+      high: number;
+      room: number;
+      action: string;
+    };
+    expect(gauge).not.toBeNull();
+    expect(gauge.low).toBe(19);
+    expect(gauge.high).toBe(23);
+    expect(gauge.room).toBe(21);
+    expect(gauge.action).toBe('cooling');
+  });
+});

--- a/card/test/timeline-editor.test.ts
+++ b/card/test/timeline-editor.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/timeline-editor.js';
+import type { TimelineEditor } from '../src/timeline-editor.js';
+import type { Transition } from '../src/types.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+const SCHEDULE: Transition[] = [
+  { at: '06:00', low: 20, high: 23 },
+  { at: '22:00', low: 18, high: 21 },
+];
+
+async function timeline(transitions: Transition[] = SCHEDULE): Promise<TimelineEditor> {
+  return mount('timeline-editor', { transitions });
+}
+
+describe('timeline-editor', () => {
+  it('renders one button per transition with the right time/temp label', async () => {
+    const el = await timeline();
+    const points = el.shadowRoot!.querySelectorAll('.point');
+    expect(points.length).toBe(2);
+    const labels = el.shadowRoot!.querySelectorAll('.point-label');
+    expect(labels[0].textContent).toContain('06:00');
+    expect(labels[0].textContent).toContain('20.0');
+    expect(labels[1].textContent).toContain('22:00');
+  });
+
+  it('shows hour ticks at 0/6/12/18/24', async () => {
+    const el = await timeline();
+    const ticks = el.shadowRoot!.querySelectorAll('.hour-tick');
+    expect(ticks.length).toBe(5);
+    expect(Array.from(ticks).map((t) => t.textContent!.trim())).toEqual([
+      '0h',
+      '6h',
+      '12h',
+      '18h',
+      '24h',
+    ]);
+  });
+
+  it('emits transition-edit when a point is tapped (Enter key)', async () => {
+    const el = await timeline();
+    const events: Transition[] = [];
+    el.addEventListener('transition-edit', (e) =>
+      events.push((e as CustomEvent).detail.transition),
+    );
+    const point = el.shadowRoot!.querySelector('.point') as HTMLElement;
+    point.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(events).toEqual([SCHEDULE[0]]);
+  });
+
+  it('emits transition-delete on Delete keypress', async () => {
+    const el = await timeline();
+    const fire = vi.fn();
+    el.addEventListener('transition-delete', fire);
+    const points = el.shadowRoot!.querySelectorAll('.point');
+    (points[1] as HTMLElement).dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
+    );
+    expect(fire).toHaveBeenCalledOnce();
+    expect(fire.mock.calls[0][0].detail).toEqual({ at: '22:00' });
+  });
+
+  it('shows the empty hint when there are no transitions', async () => {
+    const el = await timeline([]);
+    expect(el.shadowRoot!.querySelector('.empty-hint')).not.toBeNull();
+  });
+
+  it('does not emit add when the empty timeline tap is too close to an existing point', async () => {
+    const el = await timeline();
+    const fire = vi.fn();
+    el.addEventListener('transition-add', fire);
+
+    // Build a synthetic click on the track at exactly 06:00 — which a real
+    // user would map to existing 06:00 transition (the .point handles it).
+    // The track ignores taps if a point exists within ~1.5%.
+    const track = el.shadowRoot!.querySelector('.track') as HTMLElement;
+    Object.defineProperty(track, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        width: 480,
+        right: 480,
+        top: 0,
+        bottom: 24,
+        height: 24,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      }),
+      configurable: true,
+    });
+    // 06:00 is at 6/24 = 25% of width = 120px.
+    track.dispatchEvent(new MouseEvent('click', { clientX: 120, bubbles: true }));
+    expect(fire).not.toHaveBeenCalled();
+  });
+
+  it('emits transition-add with snapped HH:MM when the timeline is tapped at empty space', async () => {
+    const el = await timeline();
+    const fire = vi.fn();
+    el.addEventListener('transition-add', fire);
+
+    const track = el.shadowRoot!.querySelector('.track') as HTMLElement;
+    Object.defineProperty(track, 'getBoundingClientRect', {
+      value: () => ({
+        left: 0,
+        width: 480,
+        right: 480,
+        top: 0,
+        bottom: 24,
+        height: 24,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      }),
+      configurable: true,
+    });
+    // 12:00 = 50% = 240px.
+    track.dispatchEvent(new MouseEvent('click', { clientX: 240, bubbles: true }));
+    expect(fire).toHaveBeenCalledOnce();
+    expect(fire.mock.calls[0][0].detail).toEqual({ at: '12:00' });
+  });
+});

--- a/card/test/transition-edit-dialog.test.ts
+++ b/card/test/transition-edit-dialog.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import '../src/transition-edit-dialog.js';
+import type { TransitionEditDialog } from '../src/transition-edit-dialog.js';
+import { mount, teardown } from './_fixture.js';
+
+afterEach(teardown);
+
+async function dialog(props: Partial<TransitionEditDialog> = {}): Promise<TransitionEditDialog> {
+  return mount('transition-edit-dialog', props);
+}
+
+describe('transition-edit-dialog', () => {
+  it('seeds inputs from the `transition` prop', async () => {
+    const el = await dialog({ transition: { at: '08:30', low: 20.5, high: 23.5 } });
+    const inputs = el.shadowRoot!.querySelectorAll<HTMLInputElement>('input');
+    expect(inputs[0].value).toBe('08:30');
+    expect(inputs[1].value).toBe('20.5');
+    expect(inputs[2].value).toBe('23.5');
+  });
+
+  it('shows "Add transition" header when isNew is true', async () => {
+    const el = await dialog({ isNew: true });
+    expect(el.shadowRoot!.querySelector('h3')!.textContent).toContain('Add');
+  });
+
+  it('shows "Edit transition" + Delete button when isNew is false', async () => {
+    const el = await dialog({
+      transition: { at: '06:00', low: 19, high: 22 },
+      isNew: false,
+    });
+    expect(el.shadowRoot!.querySelector('h3')!.textContent).toContain('Edit');
+    expect(el.shadowRoot!.querySelector('.button.danger')).not.toBeNull();
+  });
+
+  it('Save click fires dialog-save with current values when valid', async () => {
+    const el = await dialog({ transition: { at: '06:00', low: 19, high: 22 }, isNew: false });
+    const fire = vi.fn();
+    el.addEventListener('dialog-save', fire);
+    (el.shadowRoot!.querySelector('.button.primary') as HTMLButtonElement).click();
+    expect(fire).toHaveBeenCalledOnce();
+    expect(fire.mock.calls[0][0].detail.transition).toEqual({ at: '06:00', low: 19, high: 22 });
+  });
+
+  it('blocks save and surfaces an error when low >= high', async () => {
+    const el = await dialog({
+      transition: { at: '06:00', low: 22, high: 22 },
+      isNew: false,
+    });
+    const fire = vi.fn();
+    el.addEventListener('dialog-save', fire);
+    (el.shadowRoot!.querySelector('.button.primary') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(fire).not.toHaveBeenCalled();
+    expect(el.shadowRoot!.querySelector('.error')!.textContent).toContain('less than high');
+  });
+
+  it('blocks save and surfaces an error for invalid time format', async () => {
+    const el = await dialog({ transition: { at: '6:0', low: 19, high: 22 }, isNew: false });
+    const fire = vi.fn();
+    el.addEventListener('dialog-save', fire);
+    (el.shadowRoot!.querySelector('.button.primary') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(fire).not.toHaveBeenCalled();
+    expect(el.shadowRoot!.querySelector('.error')!.textContent).toContain('HH:MM');
+  });
+
+  it('Cancel click fires dialog-cancel', async () => {
+    const el = await dialog({ transition: { at: '06:00', low: 19, high: 22 }, isNew: false });
+    const fire = vi.fn();
+    el.addEventListener('dialog-cancel', fire);
+    (el.shadowRoot!.querySelector('.button.secondary') as HTMLButtonElement).click();
+    expect(fire).toHaveBeenCalledOnce();
+  });
+
+  it('Delete click fires dialog-delete with the original `at`', async () => {
+    const el = await dialog({ transition: { at: '06:00', low: 19, high: 22 }, isNew: false });
+    const fire = vi.fn();
+    el.addEventListener('dialog-delete', fire);
+    (el.shadowRoot!.querySelector('.button.danger') as HTMLButtonElement).click();
+    expect(fire.mock.calls[0][0].detail).toEqual({ at: '06:00' });
+  });
+});

--- a/custom_components/comfort_band/__init__.py
+++ b/custom_components/comfort_band/__init__.py
@@ -35,6 +35,7 @@ from .coordinator import ZoneCoordinator
 from .profiles import ProfileRegistry
 from .services import async_register_services
 from .storage import ComfortBandStore
+from .ws import async_register_ws_commands
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -57,6 +58,7 @@ async def async_setup(hass: HomeAssistant, _config: ConfigType) -> bool:
             hass.async_create_task(hass.config_entries.async_remove(entry.entry_id))
     await _ensure_shared_data(hass)
     await async_register_services(hass)
+    async_register_ws_commands(hass)
     return True
 
 

--- a/custom_components/comfort_band/manifest.json
+++ b/custom_components/comfort_band/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/dpretty/ha-comfort-band/issues",
   "requirements": [],
-  "version": "0.0.2"
+  "version": "0.1.0"
 }

--- a/custom_components/comfort_band/ws.py
+++ b/custom_components/comfort_band/ws.py
@@ -47,8 +47,6 @@ def ws_get_schedule(
     try:
         schedule = data.store.get_zone_schedule(zone, profile)
     except KeyError:
-        connection.send_error(
-            msg["id"], "zone_not_found", f"Zone {zone!r} does not exist"
-        )
+        connection.send_error(msg["id"], "zone_not_found", f"Zone {zone!r} does not exist")
         return
     connection.send_result(msg["id"], schedule)

--- a/custom_components/comfort_band/ws.py
+++ b/custom_components/comfort_band/ws.py
@@ -1,0 +1,54 @@
+"""Websocket commands for the Comfort Band frontend card.
+
+The integration's services in `services.py` are write-only; the card needs
+a read API to render the schedule editor. This module owns the read API.
+Add live-update subscriptions here when the card grows in v0.2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.components.websocket_api import async_register_command
+from homeassistant.components.websocket_api.connection import ActiveConnection
+from homeassistant.components.websocket_api.decorators import websocket_command
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from . import ComfortBandData
+
+
+@callback
+def async_register_ws_commands(hass: HomeAssistant) -> None:
+    """Register every websocket command in this module."""
+    async_register_command(hass, ws_get_schedule)
+
+
+@websocket_command(
+    {
+        vol.Required("type"): "comfort_band/get_schedule",
+        vol.Required("zone"): str,
+        vol.Required("profile"): str,
+    }
+)
+@callback
+def ws_get_schedule(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return `{baseline, current}` for the (zone, profile), or `null` if unset."""
+    data: ComfortBandData = hass.data[DOMAIN]
+    zone = msg["zone"]
+    profile = msg["profile"]
+    try:
+        schedule = data.store.get_zone_schedule(zone, profile)
+    except KeyError:
+        connection.send_error(
+            msg["id"], "zone_not_found", f"Zone {zone!r} does not exist"
+        )
+        return
+    connection.send_result(msg["id"], schedule)

--- a/dist/comfort-band-card.js
+++ b/dist/comfort-band-card.js
@@ -1,15 +1,15 @@
-const Z = globalThis, st = Z.ShadowRoot && (Z.ShadyCSS === void 0 || Z.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, ot = Symbol(), mt = /* @__PURE__ */ new WeakMap();
-let St = class {
+const Z = globalThis, nt = Z.ShadowRoot && (Z.ShadyCSS === void 0 || Z.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, at = Symbol(), bt = /* @__PURE__ */ new WeakMap();
+let Pt = class {
   constructor(t, e, r) {
-    if (this._$cssResult$ = !0, r !== ot) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    if (this._$cssResult$ = !0, r !== at) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = t, this.t = e;
   }
   get styleSheet() {
     let t = this.o;
     const e = this.t;
-    if (st && t === void 0) {
+    if (nt && t === void 0) {
       const r = e !== void 0 && e.length === 1;
-      r && (t = mt.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && mt.set(e, t));
+      r && (t = bt.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && bt.set(e, t));
     }
     return t;
   }
@@ -17,28 +17,28 @@ let St = class {
     return this.cssText;
   }
 };
-const Ut = (i) => new St(typeof i == "string" ? i : i + "", void 0, ot), E = (i, ...t) => {
+const jt = (i) => new Pt(typeof i == "string" ? i : i + "", void 0, at), $ = (i, ...t) => {
   const e = i.length === 1 ? i[0] : t.reduce((r, s, o) => r + ((n) => {
     if (n._$cssResult$ === !0) return n.cssText;
     if (typeof n == "number") return n;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
   })(s) + i[o + 1], i[0]);
-  return new St(e, i, ot);
-}, Rt = (i, t) => {
-  if (st) i.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  return new Pt(e, i, at);
+}, Lt = (i, t) => {
+  if (nt) i.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
   else for (const e of t) {
     const r = document.createElement("style"), s = Z.litNonce;
     s !== void 0 && r.setAttribute("nonce", s), r.textContent = e.cssText, i.appendChild(r);
   }
-}, vt = st ? (i) => i : (i) => i instanceof CSSStyleSheet ? ((t) => {
+}, gt = nt ? (i) => i : (i) => i instanceof CSSStyleSheet ? ((t) => {
   let e = "";
   for (const r of t.cssRules) e += r.cssText;
-  return Ut(e);
+  return jt(e);
 })(i) : i;
-const { is: Lt, defineProperty: jt, getOwnPropertyDescriptor: Bt, getOwnPropertyNames: It, getOwnPropertySymbols: Ft, getPrototypeOf: Vt } = Object, Y = globalThis, bt = Y.trustedTypes, qt = bt ? bt.emptyScript : "", Kt = Y.reactiveElementPolyfillSupport, j = (i, t) => i, G = { toAttribute(i, t) {
+const { is: Bt, defineProperty: It, getOwnPropertyDescriptor: Ft, getOwnPropertyNames: qt, getOwnPropertySymbols: Vt, getPrototypeOf: Kt } = Object, Q = globalThis, _t = Q.trustedTypes, Wt = _t ? _t.emptyScript : "", Gt = Q.reactiveElementPolyfillSupport, B = (i, t) => i, X = { toAttribute(i, t) {
   switch (t) {
     case Boolean:
-      i = i ? qt : null;
+      i = i ? Wt : null;
       break;
     case Object:
     case Array:
@@ -63,8 +63,8 @@ const { is: Lt, defineProperty: jt, getOwnPropertyDescriptor: Bt, getOwnProperty
       }
   }
   return e;
-} }, nt = (i, t) => !Lt(i, t), gt = { attribute: !0, type: String, converter: G, reflect: !1, useDefault: !1, hasChanged: nt };
-Symbol.metadata ??= Symbol("metadata"), Y.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
+} }, ct = (i, t) => !Bt(i, t), $t = { attribute: !0, type: String, converter: X, reflect: !1, useDefault: !1, hasChanged: ct };
+Symbol.metadata ??= Symbol("metadata"), Q.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
 let k = class extends HTMLElement {
   static addInitializer(t) {
     this._$Ei(), (this.l ??= []).push(t);
@@ -72,14 +72,14 @@ let k = class extends HTMLElement {
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, e = gt) {
+  static createProperty(t, e = $t) {
     if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
       const r = Symbol(), s = this.getPropertyDescriptor(t, r, e);
-      s !== void 0 && jt(this.prototype, t, s);
+      s !== void 0 && It(this.prototype, t, s);
     }
   }
   static getPropertyDescriptor(t, e, r) {
-    const { get: s, set: o } = Bt(this.prototype, t) ?? { get() {
+    const { get: s, set: o } = Ft(this.prototype, t) ?? { get() {
       return this[e];
     }, set(n) {
       this[e] = n;
@@ -90,17 +90,17 @@ let k = class extends HTMLElement {
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? gt;
+    return this.elementProperties.get(t) ?? $t;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(j("elementProperties"))) return;
-    const t = Vt(this);
+    if (this.hasOwnProperty(B("elementProperties"))) return;
+    const t = Kt(this);
     t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(j("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(j("properties"))) {
-      const e = this.properties, r = [...It(e), ...Ft(e)];
+    if (this.hasOwnProperty(B("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(B("properties"))) {
+      const e = this.properties, r = [...qt(e), ...Vt(e)];
       for (const s of r) this.createProperty(s, e[s]);
     }
     const t = this[Symbol.metadata];
@@ -119,8 +119,8 @@ let k = class extends HTMLElement {
     const e = [];
     if (Array.isArray(t)) {
       const r = new Set(t.flat(1 / 0).reverse());
-      for (const s of r) e.unshift(vt(s));
-    } else t !== void 0 && e.push(vt(t));
+      for (const s of r) e.unshift(gt(s));
+    } else t !== void 0 && e.push(gt(t));
     return e;
   }
   static _$Eu(t, e) {
@@ -146,7 +146,7 @@ let k = class extends HTMLElement {
   }
   createRenderRoot() {
     const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return Rt(t, this.constructor.elementStyles), t;
+    return Lt(t, this.constructor.elementStyles), t;
   }
   connectedCallback() {
     this.renderRoot ??= this.createRenderRoot(), this.enableUpdating(!0), this._$EO?.forEach((t) => t.hostConnected?.());
@@ -162,14 +162,14 @@ let k = class extends HTMLElement {
   _$ET(t, e) {
     const r = this.constructor.elementProperties.get(t), s = this.constructor._$Eu(t, r);
     if (s !== void 0 && r.reflect === !0) {
-      const o = (r.converter?.toAttribute !== void 0 ? r.converter : G).toAttribute(e, r.type);
+      const o = (r.converter?.toAttribute !== void 0 ? r.converter : X).toAttribute(e, r.type);
       this._$Em = t, o == null ? this.removeAttribute(s) : this.setAttribute(s, o), this._$Em = null;
     }
   }
   _$AK(t, e) {
     const r = this.constructor, s = r._$Eh.get(t);
     if (s !== void 0 && this._$Em !== s) {
-      const o = r.getPropertyOptions(s), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : G;
+      const o = r.getPropertyOptions(s), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : X;
       this._$Em = s;
       const c = n.fromAttribute(e, o.type);
       this[s] = c ?? this._$Ej?.get(s) ?? c, this._$Em = null;
@@ -178,7 +178,7 @@ let k = class extends HTMLElement {
   requestUpdate(t, e, r, s = !1, o) {
     if (t !== void 0) {
       const n = this.constructor;
-      if (s === !1 && (o = this[t]), r ??= n.getPropertyOptions(t), !((r.hasChanged ?? nt)(o, e) || r.useDefault && r.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, r)))) return;
+      if (s === !1 && (o = this[t]), r ??= n.getPropertyOptions(t), !((r.hasChanged ?? ct)(o, e) || r.useDefault && r.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, r)))) return;
       this.C(t, e, r);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
@@ -246,70 +246,70 @@ let k = class extends HTMLElement {
   firstUpdated(t) {
   }
 };
-k.elementStyles = [], k.shadowRootOptions = { mode: "open" }, k[j("elementProperties")] = /* @__PURE__ */ new Map(), k[j("finalized")] = /* @__PURE__ */ new Map(), Kt?.({ ReactiveElement: k }), (Y.reactiveElementVersions ??= []).push("2.1.2");
-const at = globalThis, _t = (i) => i, X = at.trustedTypes, $t = X ? X.createPolicy("lit-html", { createHTML: (i) => i }) : void 0, Nt = "$lit$", x = `lit$${Math.random().toFixed(9).slice(2)}$`, Pt = "?" + x, Wt = `<${Pt}>`, C = document, B = () => C.createComment(""), I = (i) => i === null || typeof i != "object" && typeof i != "function", ct = Array.isArray, Zt = (i) => ct(i) || typeof i?.[Symbol.iterator] == "function", et = `[ 	
-\f\r]`, L = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, yt = /-->/g, wt = />/g, N = RegExp(`>|${et}(?:([^\\s"'>=/]+)(${et}*=${et}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), xt = /'/g, At = /"/g, Ct = /^(?:script|style|textarea|title)$/i, Ot = (i) => (t, ...e) => ({ _$litType$: i, strings: t, values: e }), p = Ot(1), W = Ot(2), H = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), Et = /* @__PURE__ */ new WeakMap(), P = C.createTreeWalker(C, 129);
-function Tt(i, t) {
-  if (!ct(i) || !i.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return $t !== void 0 ? $t.createHTML(t) : t;
+k.elementStyles = [], k.shadowRootOptions = { mode: "open" }, k[B("elementProperties")] = /* @__PURE__ */ new Map(), k[B("finalized")] = /* @__PURE__ */ new Map(), Gt?.({ ReactiveElement: k }), (Q.reactiveElementVersions ??= []).push("2.1.2");
+const lt = globalThis, yt = (i) => i, J = lt.trustedTypes, wt = J ? J.createPolicy("lit-html", { createHTML: (i) => i }) : void 0, Nt = "$lit$", A = `lit$${Math.random().toFixed(9).slice(2)}$`, Ot = "?" + A, Zt = `<${Ot}>`, T = document, I = () => T.createComment(""), F = (i) => i === null || typeof i != "object" && typeof i != "function", ht = Array.isArray, Xt = (i) => ht(i) || typeof i?.[Symbol.iterator] == "function", rt = `[ 	
+\f\r]`, L = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, xt = /-->/g, At = />/g, N = RegExp(`>|${rt}(?:([^\\s"'>=/]+)(${rt}*=${rt}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), Et = /'/g, St = /"/g, Tt = /^(?:script|style|textarea|title)$/i, zt = (i) => (t, ...e) => ({ _$litType$: i, strings: t, values: e }), d = zt(1), G = zt(2), M = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), Ct = /* @__PURE__ */ new WeakMap(), O = T.createTreeWalker(T, 129);
+function Ht(i, t) {
+  if (!ht(i) || !i.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return wt !== void 0 ? wt.createHTML(t) : t;
 }
-const Gt = (i, t) => {
+const Jt = (i, t) => {
   const e = i.length - 1, r = [];
   let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = L;
   for (let c = 0; c < e; c++) {
     const a = i[c];
-    let f, d, l = -1, m = 0;
-    for (; m < a.length && (n.lastIndex = m, d = n.exec(a), d !== null); ) m = n.lastIndex, n === L ? d[1] === "!--" ? n = yt : d[1] !== void 0 ? n = wt : d[2] !== void 0 ? (Ct.test(d[2]) && (s = RegExp("</" + d[2], "g")), n = N) : d[3] !== void 0 && (n = N) : n === N ? d[0] === ">" ? (n = s ?? L, l = -1) : d[1] === void 0 ? l = -2 : (l = n.lastIndex - d[2].length, f = d[1], n = d[3] === void 0 ? N : d[3] === '"' ? At : xt) : n === At || n === xt ? n = N : n === yt || n === wt ? n = L : (n = N, s = void 0);
-    const w = n === N && i[c + 1].startsWith("/>") ? " " : "";
-    o += n === L ? a + Wt : l >= 0 ? (r.push(f), a.slice(0, l) + Nt + a.slice(l) + x + w) : a + x + (l === -2 ? c : w);
+    let f, u, h = -1, m = 0;
+    for (; m < a.length && (n.lastIndex = m, u = n.exec(a), u !== null); ) m = n.lastIndex, n === L ? u[1] === "!--" ? n = xt : u[1] !== void 0 ? n = At : u[2] !== void 0 ? (Tt.test(u[2]) && (s = RegExp("</" + u[2], "g")), n = N) : u[3] !== void 0 && (n = N) : n === N ? u[0] === ">" ? (n = s ?? L, h = -1) : u[1] === void 0 ? h = -2 : (h = n.lastIndex - u[2].length, f = u[1], n = u[3] === void 0 ? N : u[3] === '"' ? St : Et) : n === St || n === Et ? n = N : n === xt || n === At ? n = L : (n = N, s = void 0);
+    const x = n === N && i[c + 1].startsWith("/>") ? " " : "";
+    o += n === L ? a + Zt : h >= 0 ? (r.push(f), a.slice(0, h) + Nt + a.slice(h) + A + x) : a + A + (h === -2 ? c : x);
   }
-  return [Tt(i, o + (i[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
+  return [Ht(i, o + (i[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
 };
-class F {
+class q {
   constructor({ strings: t, _$litType$: e }, r) {
     let s;
     this.parts = [];
     let o = 0, n = 0;
-    const c = t.length - 1, a = this.parts, [f, d] = Gt(t, e);
-    if (this.el = F.createElement(f, r), P.currentNode = this.el.content, e === 2 || e === 3) {
-      const l = this.el.content.firstChild;
-      l.replaceWith(...l.childNodes);
+    const c = t.length - 1, a = this.parts, [f, u] = Jt(t, e);
+    if (this.el = q.createElement(f, r), O.currentNode = this.el.content, e === 2 || e === 3) {
+      const h = this.el.content.firstChild;
+      h.replaceWith(...h.childNodes);
     }
-    for (; (s = P.nextNode()) !== null && a.length < c; ) {
+    for (; (s = O.nextNode()) !== null && a.length < c; ) {
       if (s.nodeType === 1) {
-        if (s.hasAttributes()) for (const l of s.getAttributeNames()) if (l.endsWith(Nt)) {
-          const m = d[n++], w = s.getAttribute(l).split(x), K = /([.?@])?(.*)/.exec(m);
-          a.push({ type: 1, index: o, name: K[2], strings: w, ctor: K[1] === "." ? Jt : K[1] === "?" ? Yt : K[1] === "@" ? Qt : Q }), s.removeAttribute(l);
-        } else l.startsWith(x) && (a.push({ type: 6, index: o }), s.removeAttribute(l));
-        if (Ct.test(s.tagName)) {
-          const l = s.textContent.split(x), m = l.length - 1;
+        if (s.hasAttributes()) for (const h of s.getAttributeNames()) if (h.endsWith(Nt)) {
+          const m = u[n++], x = s.getAttribute(h).split(A), W = /([.?@])?(.*)/.exec(m);
+          a.push({ type: 1, index: o, name: W[2], strings: x, ctor: W[1] === "." ? Qt : W[1] === "?" ? te : W[1] === "@" ? ee : tt }), s.removeAttribute(h);
+        } else h.startsWith(A) && (a.push({ type: 6, index: o }), s.removeAttribute(h));
+        if (Tt.test(s.tagName)) {
+          const h = s.textContent.split(A), m = h.length - 1;
           if (m > 0) {
-            s.textContent = X ? X.emptyScript : "";
-            for (let w = 0; w < m; w++) s.append(l[w], B()), P.nextNode(), a.push({ type: 2, index: ++o });
-            s.append(l[m], B());
+            s.textContent = J ? J.emptyScript : "";
+            for (let x = 0; x < m; x++) s.append(h[x], I()), O.nextNode(), a.push({ type: 2, index: ++o });
+            s.append(h[m], I());
           }
         }
-      } else if (s.nodeType === 8) if (s.data === Pt) a.push({ type: 2, index: o });
+      } else if (s.nodeType === 8) if (s.data === Ot) a.push({ type: 2, index: o });
       else {
-        let l = -1;
-        for (; (l = s.data.indexOf(x, l + 1)) !== -1; ) a.push({ type: 7, index: o }), l += x.length - 1;
+        let h = -1;
+        for (; (h = s.data.indexOf(A, h + 1)) !== -1; ) a.push({ type: 7, index: o }), h += A.length - 1;
       }
       o++;
     }
   }
   static createElement(t, e) {
-    const r = C.createElement("template");
+    const r = T.createElement("template");
     return r.innerHTML = t, r;
   }
 }
-function M(i, t, e = i, r) {
-  if (t === H) return t;
+function D(i, t, e = i, r) {
+  if (t === M) return t;
   let s = r !== void 0 ? e._$Co?.[r] : e._$Cl;
-  const o = I(t) ? void 0 : t._$litDirective$;
-  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(i), s._$AT(i, e, r)), r !== void 0 ? (e._$Co ??= [])[r] = s : e._$Cl = s), s !== void 0 && (t = M(i, s._$AS(i, t.values), s, r)), t;
+  const o = F(t) ? void 0 : t._$litDirective$;
+  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(i), s._$AT(i, e, r)), r !== void 0 ? (e._$Co ??= [])[r] = s : e._$Cl = s), s !== void 0 && (t = D(i, s._$AS(i, t.values), s, r)), t;
 }
-class Xt {
+class Yt {
   constructor(t, e) {
     this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
   }
@@ -320,17 +320,17 @@ class Xt {
     return this._$AM._$AU;
   }
   u(t) {
-    const { el: { content: e }, parts: r } = this._$AD, s = (t?.creationScope ?? C).importNode(e, !0);
-    P.currentNode = s;
-    let o = P.nextNode(), n = 0, c = 0, a = r[0];
+    const { el: { content: e }, parts: r } = this._$AD, s = (t?.creationScope ?? T).importNode(e, !0);
+    O.currentNode = s;
+    let o = O.nextNode(), n = 0, c = 0, a = r[0];
     for (; a !== void 0; ) {
       if (n === a.index) {
         let f;
-        a.type === 2 ? f = new V(o, o.nextSibling, this, t) : a.type === 1 ? f = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (f = new te(o, this, t)), this._$AV.push(f), a = r[++c];
+        a.type === 2 ? f = new V(o, o.nextSibling, this, t) : a.type === 1 ? f = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (f = new ie(o, this, t)), this._$AV.push(f), a = r[++c];
       }
-      n !== a?.index && (o = P.nextNode(), n++);
+      n !== a?.index && (o = O.nextNode(), n++);
     }
-    return P.currentNode = C, s;
+    return O.currentNode = T, s;
   }
   p(t) {
     let e = 0;
@@ -342,7 +342,7 @@ class V {
     return this._$AM?._$AU ?? this._$Cv;
   }
   constructor(t, e, r, s) {
-    this.type = 2, this._$AH = u, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = r, this.options = s, this._$Cv = s?.isConnected ?? !0;
+    this.type = 2, this._$AH = p, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = r, this.options = s, this._$Cv = s?.isConnected ?? !0;
   }
   get parentNode() {
     let t = this._$AA.parentNode;
@@ -356,7 +356,7 @@ class V {
     return this._$AB;
   }
   _$AI(t, e = this) {
-    t = M(this, t, e), I(t) ? t === u || t == null || t === "" ? (this._$AH !== u && this._$AR(), this._$AH = u) : t !== this._$AH && t !== H && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Zt(t) ? this.k(t) : this._(t);
+    t = D(this, t, e), F(t) ? t === p || t == null || t === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : t !== this._$AH && t !== M && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Xt(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -365,38 +365,38 @@ class V {
     this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
   }
   _(t) {
-    this._$AH !== u && I(this._$AH) ? this._$AA.nextSibling.data = t : this.T(C.createTextNode(t)), this._$AH = t;
+    this._$AH !== p && F(this._$AH) ? this._$AA.nextSibling.data = t : this.T(T.createTextNode(t)), this._$AH = t;
   }
   $(t) {
-    const { values: e, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = F.createElement(Tt(r.h, r.h[0]), this.options)), r);
+    const { values: e, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = q.createElement(Ht(r.h, r.h[0]), this.options)), r);
     if (this._$AH?._$AD === s) this._$AH.p(e);
     else {
-      const o = new Xt(s, this), n = o.u(this.options);
+      const o = new Yt(s, this), n = o.u(this.options);
       o.p(e), this.T(n), this._$AH = o;
     }
   }
   _$AC(t) {
-    let e = Et.get(t.strings);
-    return e === void 0 && Et.set(t.strings, e = new F(t)), e;
+    let e = Ct.get(t.strings);
+    return e === void 0 && Ct.set(t.strings, e = new q(t)), e;
   }
   k(t) {
-    ct(this._$AH) || (this._$AH = [], this._$AR());
+    ht(this._$AH) || (this._$AH = [], this._$AR());
     const e = this._$AH;
     let r, s = 0;
-    for (const o of t) s === e.length ? e.push(r = new V(this.O(B()), this.O(B()), this, this.options)) : r = e[s], r._$AI(o), s++;
+    for (const o of t) s === e.length ? e.push(r = new V(this.O(I()), this.O(I()), this, this.options)) : r = e[s], r._$AI(o), s++;
     s < e.length && (this._$AR(r && r._$AB.nextSibling, s), e.length = s);
   }
   _$AR(t = this._$AA.nextSibling, e) {
     for (this._$AP?.(!1, !0, e); t !== this._$AB; ) {
-      const r = _t(t).nextSibling;
-      _t(t).remove(), t = r;
+      const r = yt(t).nextSibling;
+      yt(t).remove(), t = r;
     }
   }
   setConnected(t) {
     this._$AM === void 0 && (this._$Cv = t, this._$AP?.(t));
   }
 }
-class Q {
+class tt {
   get tagName() {
     return this.element.tagName;
   }
@@ -404,53 +404,53 @@ class Q {
     return this._$AM._$AU;
   }
   constructor(t, e, r, s, o) {
-    this.type = 1, this._$AH = u, this._$AN = void 0, this.element = t, this.name = e, this._$AM = s, this.options = o, r.length > 2 || r[0] !== "" || r[1] !== "" ? (this._$AH = Array(r.length - 1).fill(new String()), this.strings = r) : this._$AH = u;
+    this.type = 1, this._$AH = p, this._$AN = void 0, this.element = t, this.name = e, this._$AM = s, this.options = o, r.length > 2 || r[0] !== "" || r[1] !== "" ? (this._$AH = Array(r.length - 1).fill(new String()), this.strings = r) : this._$AH = p;
   }
   _$AI(t, e = this, r, s) {
     const o = this.strings;
     let n = !1;
-    if (o === void 0) t = M(this, t, e, 0), n = !I(t) || t !== this._$AH && t !== H, n && (this._$AH = t);
+    if (o === void 0) t = D(this, t, e, 0), n = !F(t) || t !== this._$AH && t !== M, n && (this._$AH = t);
     else {
       const c = t;
       let a, f;
-      for (t = o[0], a = 0; a < o.length - 1; a++) f = M(this, c[r + a], e, a), f === H && (f = this._$AH[a]), n ||= !I(f) || f !== this._$AH[a], f === u ? t = u : t !== u && (t += (f ?? "") + o[a + 1]), this._$AH[a] = f;
+      for (t = o[0], a = 0; a < o.length - 1; a++) f = D(this, c[r + a], e, a), f === M && (f = this._$AH[a]), n ||= !F(f) || f !== this._$AH[a], f === p ? t = p : t !== p && (t += (f ?? "") + o[a + 1]), this._$AH[a] = f;
     }
     n && !s && this.j(t);
   }
   j(t) {
-    t === u ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+    t === p ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
 }
-class Jt extends Q {
+class Qt extends tt {
   constructor() {
     super(...arguments), this.type = 3;
   }
   j(t) {
-    this.element[this.name] = t === u ? void 0 : t;
+    this.element[this.name] = t === p ? void 0 : t;
   }
 }
-class Yt extends Q {
+class te extends tt {
   constructor() {
     super(...arguments), this.type = 4;
   }
   j(t) {
-    this.element.toggleAttribute(this.name, !!t && t !== u);
+    this.element.toggleAttribute(this.name, !!t && t !== p);
   }
 }
-class Qt extends Q {
+class ee extends tt {
   constructor(t, e, r, s, o) {
     super(t, e, r, s, o), this.type = 5;
   }
   _$AI(t, e = this) {
-    if ((t = M(this, t, e, 0) ?? u) === H) return;
-    const r = this._$AH, s = t === u && r !== u || t.capture !== r.capture || t.once !== r.once || t.passive !== r.passive, o = t !== u && (r === u || s);
+    if ((t = D(this, t, e, 0) ?? p) === M) return;
+    const r = this._$AH, s = t === p && r !== p || t.capture !== r.capture || t.once !== r.once || t.passive !== r.passive, o = t !== p && (r === p || s);
     s && this.element.removeEventListener(this.name, this, r), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
   handleEvent(t) {
     typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class te {
+class ie {
   constructor(t, e, r) {
     this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = r;
   }
@@ -458,21 +458,21 @@ class te {
     return this._$AM._$AU;
   }
   _$AI(t) {
-    M(this, t);
+    D(this, t);
   }
 }
-const ee = at.litHtmlPolyfillSupport;
-ee?.(F, V), (at.litHtmlVersions ??= []).push("3.3.2");
-const ie = (i, t, e) => {
+const re = lt.litHtmlPolyfillSupport;
+re?.(q, V), (lt.litHtmlVersions ??= []).push("3.3.2");
+const se = (i, t, e) => {
   const r = e?.renderBefore ?? t;
   let s = r._$litPart$;
   if (s === void 0) {
     const o = e?.renderBefore ?? null;
-    r._$litPart$ = s = new V(t.insertBefore(B(), o), o, void 0, e ?? {});
+    r._$litPart$ = s = new V(t.insertBefore(I(), o), o, void 0, e ?? {});
   }
   return s._$AI(i), s;
 };
-const lt = globalThis;
+const dt = globalThis;
 class v extends k {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
@@ -483,7 +483,7 @@ class v extends k {
   }
   update(t) {
     const e = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = ie(e, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = se(e, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     super.connectedCallback(), this._$Do?.setConnected(!0);
@@ -492,19 +492,19 @@ class v extends k {
     super.disconnectedCallback(), this._$Do?.setConnected(!1);
   }
   render() {
-    return H;
+    return M;
   }
 }
-v._$litElement$ = !0, v.finalized = !0, lt.litElementHydrateSupport?.({ LitElement: v });
-const re = lt.litElementPolyfillSupport;
-re?.({ LitElement: v });
-(lt.litElementVersions ??= []).push("4.2.2");
-const T = (i) => (t, e) => {
+v._$litElement$ = !0, v.finalized = !0, dt.litElementHydrateSupport?.({ LitElement: v });
+const oe = dt.litElementPolyfillSupport;
+oe?.({ LitElement: v });
+(dt.litElementVersions ??= []).push("4.2.2");
+const S = (i) => (t, e) => {
   e !== void 0 ? e.addInitializer(() => {
     customElements.define(i, t);
   }) : customElements.define(i, t);
 };
-const se = { attribute: !0, type: String, converter: G, reflect: !1, hasChanged: nt }, oe = (i = se, t, e) => {
+const ne = { attribute: !0, type: String, converter: X, reflect: !1, hasChanged: ct }, ae = (i = ne, t, e) => {
   const { kind: r, metadata: s } = e;
   let o = globalThis.litPropertyMetadata.get(s);
   if (o === void 0 && globalThis.litPropertyMetadata.set(s, o = /* @__PURE__ */ new Map()), r === "setter" && ((i = Object.create(i)).wrapped = !0), o.set(e.name, i), r === "accessor") {
@@ -525,25 +525,25 @@ const se = { attribute: !0, type: String, converter: G, reflect: !1, hasChanged:
   }
   throw Error("Unsupported decorator location: " + r);
 };
-function h(i) {
-  return (t, e) => typeof e == "object" ? oe(i, t, e) : ((r, s, o) => {
+function l(i) {
+  return (t, e) => typeof e == "object" ? ae(i, t, e) : ((r, s, o) => {
     const n = s.hasOwnProperty(o);
     return s.constructor.createProperty(o, r), n ? Object.getOwnPropertyDescriptor(s, o) : void 0;
   })(i, t, e);
 }
-function U(i) {
-  return h({ ...i, state: !0, attribute: !1 });
+function H(i) {
+  return l({ ...i, state: !0, attribute: !1 });
 }
-const ne = (i, t, e) => (e.configurable = !0, e.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(i, t, e), e);
-function ht(i, t) {
+const ce = (i, t, e) => (e.configurable = !0, e.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(i, t, e), e);
+function pt(i, t) {
   return (e, r, s) => {
     const o = (n) => n.renderRoot?.querySelector(i) ?? null;
-    return ne(e, r, { get() {
+    return ce(e, r, { get() {
       return o(this);
     } });
   };
 }
-const z = E`
+const C = $`
   :host {
     --cb-action-heating: var(--cb-color-heat, var(--state-climate-heat-color, #d9603f));
     --cb-action-cooling: var(--cb-color-cool, var(--state-climate-cool-color, #2f7fcc));
@@ -562,7 +562,7 @@ const z = E`
     --cb-gap-lg: 16px;
   }
 `;
-function dt(i) {
+function ut(i) {
   switch (i) {
     case "heating":
       return "var(--cb-action-heating)";
@@ -574,40 +574,40 @@ function dt(i) {
       return "var(--cb-action-unknown)";
   }
 }
-function pt(i) {
+function ft(i) {
   return i === "heating" || i === "cooling" || i === "idle" ? i : "unknown";
 }
-function zt(i) {
+function kt(i) {
   return i.charAt(0).toUpperCase() + i.slice(1);
 }
-var ae = Object.defineProperty, ce = Object.getOwnPropertyDescriptor, q = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? ce(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+var le = Object.defineProperty, he = Object.getOwnPropertyDescriptor, K = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? he(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && ae(t, e, s), s;
+  return r && s && le(t, e, s), s;
 };
-const rt = 15, kt = 28, le = kt - rt;
-function it(i) {
-  return Number.isNaN(i) || !Number.isFinite(i) ? 0 : (Math.max(rt, Math.min(kt, i)) - rt) / le * 100;
+const ot = 15, Mt = 28, de = Mt - ot;
+function st(i) {
+  return Number.isNaN(i) || !Number.isFinite(i) ? 0 : (Math.max(ot, Math.min(Mt, i)) - ot) / de * 100;
 }
-let O = class extends v {
+let z = class extends v {
   constructor() {
     super(...arguments), this.low = NaN, this.high = NaN, this.room = NaN, this.action = "unknown";
   }
   render() {
-    const i = pt(this.action), t = dt(i), e = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = e ? it(this.low) : 0, n = r ? it(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), f = s ? it(this.room) : 50, d = (m) => Number.isFinite(m) ? `${m.toFixed(1)}°` : "—", l = `Comfort band gauge: low ${d(this.low)}, room ${d(this.room)}, high ${d(this.high)}, action ${i}`;
-    return p`
-      <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${l}>
-        ${W`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
-        ${e && r ? W`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
-        ${s ? W`<circle cx=${f} cy="12" r="4.5" fill=${t}></circle>` : null}
-        ${s ? W`<circle class="marker-ring" cx=${f} cy="12" r="3" stroke=${t}></circle>` : null}
+    const i = ft(this.action), t = ut(i), e = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = e ? st(this.low) : 0, n = r ? st(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), f = s ? st(this.room) : 50, u = (m) => Number.isFinite(m) ? `${m.toFixed(1)}°` : "—", h = `Comfort band gauge: low ${u(this.low)}, room ${u(this.room)}, high ${u(this.high)}, action ${i}`;
+    return d`
+      <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${h}>
+        ${G`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
+        ${e && r ? G`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
+        ${s ? G`<circle cx=${f} cy="12" r="4.5" fill=${t}></circle>` : null}
+        ${s ? G`<circle class="marker-ring" cx=${f} cy="12" r="3" stroke=${t}></circle>` : null}
       </svg>
     `;
   }
 };
-O.styles = [
-  z,
-  E`
+z.styles = [
+  C,
+  $`
       :host {
         display: block;
         width: 100%;
@@ -635,25 +635,25 @@ O.styles = [
       }
     `
 ];
-q([
-  h({ type: Number })
-], O.prototype, "low", 2);
-q([
-  h({ type: Number })
-], O.prototype, "high", 2);
-q([
-  h({ type: Number })
-], O.prototype, "room", 2);
-q([
-  h({ type: String })
-], O.prototype, "action", 2);
-O = q([
-  T("band-gauge")
-], O);
-var he = Object.defineProperty, de = Object.getOwnPropertyDescriptor, $ = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? de(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+K([
+  l({ type: Number })
+], z.prototype, "low", 2);
+K([
+  l({ type: Number })
+], z.prototype, "high", 2);
+K([
+  l({ type: Number })
+], z.prototype, "room", 2);
+K([
+  l({ type: String })
+], z.prototype, "action", 2);
+z = K([
+  S("band-gauge")
+], z);
+var pe = Object.defineProperty, ue = Object.getOwnPropertyDescriptor, y = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? ue(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && he(t, e, s), s;
+  return r && s && pe(t, e, s), s;
 };
 let b = class extends v {
   constructor() {
@@ -667,19 +667,19 @@ let b = class extends v {
   }
   _renderOverridePill() {
     if (!this.overrideActive) return null;
-    const i = pe(this.overrideEnds);
-    return p`<div class="override-pill">Override${i ? ` · ${i}` : ""}</div>`;
+    const i = fe(this.overrideEnds);
+    return d`<div class="override-pill">Override${i ? ` · ${i}` : ""}</div>`;
   }
   _renderActionChip() {
-    const i = pt(this.action);
+    const i = ft(this.action);
     if (i === "idle" || i === "unknown") return null;
-    const t = dt(i);
-    return p`<span class="action-chip" style="background:${t}">
-      ${zt(i)}
+    const t = ut(i);
+    return d`<span class="action-chip" style="background:${t}">
+      ${kt(i)}
     </span>`;
   }
   render() {
-    return p`
+    return d`
       <div
         class="tile ${this.noExpand ? "no-expand" : ""}"
         role="${this.noExpand ? "group" : "button"}"
@@ -708,8 +708,8 @@ let b = class extends v {
   }
 };
 b.styles = [
-  z,
-  E`
+  C,
+  $`
       :host {
         display: block;
       }
@@ -783,34 +783,34 @@ b.styles = [
       }
     `
 ];
-$([
-  h({ type: String })
+y([
+  l({ type: String })
 ], b.prototype, "zoneName", 2);
-$([
-  h({ type: Number })
+y([
+  l({ type: Number })
 ], b.prototype, "roomTemp", 2);
-$([
-  h({ type: Number })
+y([
+  l({ type: Number })
 ], b.prototype, "low", 2);
-$([
-  h({ type: Number })
+y([
+  l({ type: Number })
 ], b.prototype, "high", 2);
-$([
-  h({ type: String })
+y([
+  l({ type: String })
 ], b.prototype, "action", 2);
-$([
-  h({ type: Boolean })
+y([
+  l({ type: Boolean })
 ], b.prototype, "overrideActive", 2);
-$([
-  h({ type: String })
+y([
+  l({ type: String })
 ], b.prototype, "overrideEnds", 2);
-$([
-  h({ type: Boolean })
+y([
+  l({ type: Boolean })
 ], b.prototype, "noExpand", 2);
-b = $([
-  T("comfort-band-tile")
+b = y([
+  S("comfort-band-tile")
 ], b);
-function pe(i) {
+function fe(i) {
   if (!i) return "";
   const t = Date.parse(i);
   if (Number.isNaN(t)) return "";
@@ -821,10 +821,10 @@ function pe(i) {
   const s = Math.floor(r / 60), o = r % 60;
   return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-var ue = Object.defineProperty, fe = Object.getOwnPropertyDescriptor, y = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? fe(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+var me = Object.defineProperty, ve = Object.getOwnPropertyDescriptor, w = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? ve(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && ue(t, e, s), s;
+  return r && s && me(t, e, s), s;
 };
 let g = class extends v {
   constructor() {
@@ -908,7 +908,7 @@ let g = class extends v {
   }
   render() {
     const i = this._pct(this.low), t = this._pct(this.high);
-    return p`
+    return d`
       <div class="track" @pointerdown=${this._onTrackPointerDown}>
         <div class="fill" style="left:${i}%; width:${t - i}%"></div>
         <div
@@ -946,8 +946,8 @@ let g = class extends v {
   }
 };
 g.styles = [
-  z,
-  E`
+  C,
+  $`
       :host {
         display: block;
         padding: 16px 12px;
@@ -1008,62 +1008,62 @@ g.styles = [
       }
     `
 ];
-y([
-  h({ type: Number })
+w([
+  l({ type: Number })
 ], g.prototype, "min", 2);
-y([
-  h({ type: Number })
+w([
+  l({ type: Number })
 ], g.prototype, "max", 2);
-y([
-  h({ type: Number })
+w([
+  l({ type: Number })
 ], g.prototype, "step", 2);
-y([
-  h({ type: Number })
+w([
+  l({ type: Number })
 ], g.prototype, "low", 2);
-y([
-  h({ type: Number })
+w([
+  l({ type: Number })
 ], g.prototype, "high", 2);
-y([
-  h({ type: String })
+w([
+  l({ type: String })
 ], g.prototype, "unit", 2);
-y([
-  U()
+w([
+  H()
 ], g.prototype, "_dragging", 2);
-y([
-  ht(".track")
+w([
+  pt(".track")
 ], g.prototype, "_track", 2);
-g = y([
-  T("dual-handle-slider")
+g = w([
+  S("dual-handle-slider")
 ], g);
-const ut = "comfort_band";
-function me(i, t) {
-  const e = { zone: t.zone };
-  return t.low !== void 0 && (e.low = t.low), t.high !== void 0 && (e.high = t.high), t.hours !== void 0 && (e.hours = t.hours), i.callService(ut, "start_override", e);
-}
-function ve(i, t) {
-  return i.callService(ut, "cancel_override", { ...t });
-}
+const mt = "comfort_band";
 function be(i, t) {
-  return i.callService(ut, "set_profile", { ...t });
+  const e = { zone: t.zone };
+  return t.low !== void 0 && (e.low = t.low), t.high !== void 0 && (e.high = t.high), t.hours !== void 0 && (e.hours = t.hours), i.callService(mt, "start_override", e);
 }
-var ge = Object.defineProperty, _e = Object.getOwnPropertyDescriptor, R = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? _e(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+function ge(i, t) {
+  return i.callService(mt, "cancel_override", { ...t });
+}
+function _e(i, t) {
+  return i.callService(mt, "set_profile", { ...t });
+}
+var $e = Object.defineProperty, ye = Object.getOwnPropertyDescriptor, j = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? ye(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && ge(t, e, s), s;
+  return r && s && $e(t, e, s), s;
 };
-const $e = [1, 3, 6];
-let A = class extends v {
+const we = [1, 3, 6];
+let E = class extends v {
   constructor() {
     super(...arguments), this.zone = "", this._pendingLow = null, this._pendingHigh = null, this._onSliderInput = (i) => {
       this._pendingLow = i.detail.low, this._pendingHigh = i.detail.high;
     }, this._onSliderChange = (i) => {
-      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, me(this.hass, {
+      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, be(this.hass, {
         zone: this.zone,
         low: i.detail.low,
         high: i.detail.high
       }));
     }, this._onCancel = () => {
-      !this.hass || !this.zone || ve(this.hass, { zone: this.zone });
+      !this.hass || !this.zone || ge(this.hass, { zone: this.zone });
     }, this._onPickHours = (i) => {
       !this.hass || !this.entities?.overrideHours || this.hass.callService("number", "set_value", {
         entity_id: this.entities.overrideHours,
@@ -1082,14 +1082,14 @@ let A = class extends v {
     return Number.isFinite(e) ? e : NaN;
   }
   render() {
-    if (!this.hass || !this.entities) return u;
-    const i = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), e = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", c = this._stateOf(this.entities.overrideActive)?.state === "on", a = this._pendingLow ?? (Number.isFinite(i) ? i : 19), f = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), d = pt(n), l = d !== "idle" && d !== "unknown";
-    return p`
+    if (!this.hass || !this.entities) return p;
+    const i = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), e = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", c = this._stateOf(this.entities.overrideActive)?.state === "on", a = this._pendingLow ?? (Number.isFinite(i) ? i : 19), f = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), u = ft(n), h = u !== "idle" && u !== "unknown";
+    return d`
       <div class="header-row">
         <div class="room-temp">${Number.isFinite(s) ? `${s.toFixed(1)}°` : "—"}</div>
-        ${l ? p`<span class="action-chip" style="background:${dt(d)}"
-              >${zt(d)}</span
-            >` : u}
+        ${h ? d`<span class="action-chip" style="background:${ut(u)}"
+              >${kt(u)}</span
+            >` : p}
       </div>
       <div class="gauge-row">
         <band-gauge .low=${e} .high=${r} .room=${s} .action=${n}></band-gauge>
@@ -1112,9 +1112,9 @@ let A = class extends v {
     `;
   }
   _renderOverrideSection(i) {
-    if (!i) return u;
-    const t = this._stateOf(this.entities.overrideEnds)?.state, e = ye(t ?? null);
-    return p`
+    if (!i) return p;
+    const t = this._stateOf(this.entities.overrideEnds)?.state, e = xe(t ?? null);
+    return d`
       <section>
         <h3>Override</h3>
         <div class="override-row">
@@ -1125,12 +1125,12 @@ let A = class extends v {
     `;
   }
   _renderHoursSection(i) {
-    return this.entities?.overrideHours ? p`
+    return this.entities?.overrideHours ? d`
       <section>
         <h3>Override duration</h3>
         <div class="preset-row">
-          ${$e.map(
-      (t) => p`
+          ${we.map(
+      (t) => d`
               <button
                 class="preset ${i === t ? "active" : ""}"
                 @click=${() => this._onPickHours(t)}
@@ -1141,12 +1141,12 @@ let A = class extends v {
     )}
         </div>
       </section>
-    ` : u;
+    ` : p;
   }
 };
-A.styles = [
-  z,
-  E`
+E.styles = [
+  C,
+  $`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1232,25 +1232,25 @@ A.styles = [
       }
     `
 ];
-R([
-  h({ attribute: !1 })
-], A.prototype, "hass", 2);
-R([
-  h({ type: String })
-], A.prototype, "zone", 2);
-R([
-  h({ attribute: !1 })
-], A.prototype, "entities", 2);
-R([
-  U()
-], A.prototype, "_pendingLow", 2);
-R([
-  U()
-], A.prototype, "_pendingHigh", 2);
-A = R([
-  T("comfort-band-now-tab")
-], A);
-function ye(i) {
+j([
+  l({ attribute: !1 })
+], E.prototype, "hass", 2);
+j([
+  l({ type: String })
+], E.prototype, "zone", 2);
+j([
+  l({ attribute: !1 })
+], E.prototype, "entities", 2);
+j([
+  H()
+], E.prototype, "_pendingLow", 2);
+j([
+  H()
+], E.prototype, "_pendingHigh", 2);
+E = j([
+  S("comfort-band-now-tab")
+], E);
+function xe(i) {
   if (!i) return "";
   const t = Date.parse(i);
   if (Number.isNaN(t)) return "";
@@ -1261,7 +1261,7 @@ function ye(i) {
   const s = Math.floor(r / 60), o = r % 60;
   return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-const ft = "comfort_band", we = {
+const vt = "comfort_band", Ae = {
   effective_low: "effectiveLow",
   effective_high: "effectiveHigh",
   room_temperature: "roomTemperature",
@@ -1277,7 +1277,7 @@ const ft = "comfort_band", we = {
   cancel_override: "cancelOverride",
   enabled: "enabled"
 };
-function xe() {
+function Ee() {
   return {
     effectiveLow: null,
     effectiveHigh: null,
@@ -1297,57 +1297,57 @@ function xe() {
     deviceName: null
   };
 }
-function Ht(i, t) {
+function Dt(i, t) {
   for (const e of Object.values(i.devices))
     for (const [r, s] of e.identifiers)
       if (r === t[0] && s === t[1])
         return e;
   return null;
 }
-function Mt(i, t) {
+function Ut(i, t) {
   return Object.values(i.entities).filter(
-    (e) => e.device_id === t && e.platform === ft
+    (e) => e.device_id === t && e.platform === vt
   );
 }
-function Ae(i, t) {
-  const e = xe(), r = Ht(i, [ft, `zone:${t}`]);
+function Se(i, t) {
+  const e = Ee(), r = Dt(i, [vt, `zone:${t}`]);
   if (r === null) return e;
   e.deviceId = r.id, e.deviceName = r.name_by_user ?? r.name;
   const s = `${t}_`;
-  for (const o of Mt(i, r.id)) {
+  for (const o of Ut(i, r.id)) {
     if (!o.unique_id.startsWith(s)) continue;
-    const n = o.unique_id.slice(s.length), c = we[n];
+    const n = o.unique_id.slice(s.length), c = Ae[n];
     c !== void 0 && (e[c] = o.entity_id);
   }
   return e;
 }
-function Ee(i) {
-  const t = Ht(i, [ft, "profile_manager"]);
+function Ce(i) {
+  const t = Dt(i, [vt, "profile_manager"]);
   if (t === null) return null;
-  for (const e of Mt(i, t.id))
+  for (const e of Ut(i, t.id))
     if (e.unique_id === "profile_manager_active_profile")
       return e.entity_id;
   return null;
 }
-var Se = Object.defineProperty, Ne = Object.getOwnPropertyDescriptor, Dt = (i, t, e, r) => {
+var Pe = Object.defineProperty, Ne = Object.getOwnPropertyDescriptor, Rt = (i, t, e, r) => {
   for (var s = r > 1 ? void 0 : r ? Ne(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && Se(t, e, s), s;
+  return r && s && Pe(t, e, s), s;
 };
-let J = class extends v {
+let Y = class extends v {
   _onSelect(i) {
-    this.hass && be(this.hass, { profile: i });
+    this.hass && _e(this.hass, { profile: i });
   }
   render() {
-    if (!this.hass) return u;
-    const i = Ee(this.hass);
+    if (!this.hass) return p;
+    const i = Ce(this.hass);
     if (i === null)
-      return p`<div class="empty">Profile manager not registered yet.</div>`;
+      return d`<div class="empty">Profile manager not registered yet.</div>`;
     const t = this.hass.states[i], e = t?.attributes.options, r = Array.isArray(e) ? e.filter((o) => typeof o == "string") : [], s = t?.state ?? "";
-    return r.length === 0 ? p`<div class="empty">No profiles configured.</div>` : p`
+    return r.length === 0 ? d`<div class="empty">No profiles configured.</div>` : d`
       <ul role="listbox" aria-label="Profiles">
         ${r.map(
-      (o) => p`
+      (o) => d`
             <li
               role="option"
               tabindex="0"
@@ -1359,7 +1359,7 @@ let J = class extends v {
       }}
             >
               <span class="name">${o}</span>
-              ${o === s ? p`<span class="badge">Active</span>` : u}
+              ${o === s ? d`<span class="badge">Active</span>` : p}
             </li>
           `
     )}
@@ -1368,9 +1368,9 @@ let J = class extends v {
     `;
   }
 };
-J.styles = [
-  z,
-  E`
+Y.styles = [
+  C,
+  $`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1426,18 +1426,110 @@ J.styles = [
       }
     `
 ];
-Dt([
-  h({ attribute: !1 })
-], J.prototype, "hass", 2);
-J = Dt([
-  T("comfort-band-profiles-tab")
-], J);
-var Pe = Object.defineProperty, Ce = Object.getOwnPropertyDescriptor, S = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? Ce(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+Rt([
+  l({ attribute: !1 })
+], Y.prototype, "hass", 2);
+Y = Rt([
+  S("comfort-band-profiles-tab")
+], Y);
+var Oe = Object.defineProperty, Te = Object.getOwnPropertyDescriptor, et = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? Te(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && Pe(t, e, s), s;
+  return r && s && Oe(t, e, s), s;
 };
-const Oe = [
+let U = class extends v {
+  constructor() {
+    super(...arguments), this._graphAvailable = null, this._graphCard = null;
+  }
+  async firstUpdated() {
+    await this._maybeMountGraph();
+  }
+  updated(i) {
+    (i.has("entities") || i.has("hass")) && this._maybeMountGraph();
+  }
+  async _maybeMountGraph() {
+    const i = this.entities?.roomTemperature;
+    if (!(!i || !this.hass)) {
+      if (this._graphCard) {
+        this._graphCard.hass = this.hass;
+        return;
+      }
+      if (typeof window.loadCardHelpers != "function") {
+        this._graphAvailable = !1;
+        return;
+      }
+      try {
+        const e = (await window.loadCardHelpers()).createCardElement({
+          type: "history-graph",
+          entities: [i],
+          hours_to_show: 24
+        });
+        e.hass = this.hass;
+        const r = this.renderRoot.querySelector(".graph-container");
+        r && (r.innerHTML = "", r.appendChild(e), this._graphCard = e, this._graphAvailable = !0);
+      } catch {
+        this._graphAvailable = !1;
+      }
+    }
+  }
+  render() {
+    const i = this.entities?.roomTemperature;
+    return i ? d`
+      <div class="graph-container"></div>
+      ${this._graphAvailable === !1 ? d`<div class="fallback">
+              Inline graph unavailable.
+              <a href="/history?entity_id=${i}" target="_blank" rel="noopener"
+                >Open in HA history →</a
+              >
+            </div>` : p}
+    ` : d`<div class="empty">No room temperature sensor for this zone.</div>`;
+  }
+};
+U.styles = [
+  C,
+  $`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      .graph-container {
+        min-height: 220px;
+      }
+      .graph-container :first-child {
+        --ha-card-box-shadow: none;
+      }
+      .fallback,
+      .empty {
+        padding: var(--cb-gap-lg);
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+        text-align: center;
+      }
+      .fallback a {
+        color: var(--cb-accent, var(--primary-color, #03a9f4));
+        text-decoration: none;
+        margin-left: 8px;
+      }
+    `
+];
+et([
+  l({ attribute: !1 })
+], U.prototype, "hass", 2);
+et([
+  l({ attribute: !1 })
+], U.prototype, "entities", 2);
+et([
+  H()
+], U.prototype, "_graphAvailable", 2);
+U = et([
+  S("comfort-band-insights-tab")
+], U);
+var ze = Object.defineProperty, He = Object.getOwnPropertyDescriptor, P = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? He(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && ze(t, e, s), s;
+};
+const ke = [
   { id: "now", label: "Now" },
   { id: "schedule", label: "Schedule" },
   { id: "profiles", label: "Profiles" },
@@ -1463,9 +1555,9 @@ let _ = class extends v {
     this._activeTab = i;
   }
   render() {
-    if (!this._isOpen) return u;
+    if (!this._isOpen) return p;
     const i = this.zoneName || this.zone || "Comfort Band";
-    return p`
+    return d`
       <dialog @close=${this._onClose}>
         <div class="frame">
           <header>
@@ -1473,8 +1565,8 @@ let _ = class extends v {
             <button class="close" @click=${this.close} aria-label="Close">×</button>
           </header>
           <nav role="tablist">
-            ${Oe.map(
-      (t) => p`
+            ${ke.map(
+      (t) => d`
                 <button
                   role="tab"
                   aria-selected=${this._activeTab === t.id}
@@ -1493,23 +1585,26 @@ let _ = class extends v {
   _renderTab() {
     switch (this._activeTab) {
       case "now":
-        return p`<comfort-band-now-tab
+        return d`<comfort-band-now-tab
           .hass=${this.hass}
           .zone=${this.zone}
           .entities=${this.entities}
         ></comfort-band-now-tab>`;
       case "schedule":
-        return p`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
+        return d`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
       case "profiles":
-        return p`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
+        return d`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
       case "insights":
-        return p`<div class="placeholder">Insights — landing in commit 6.</div>`;
+        return d`<comfort-band-insights-tab
+          .hass=${this.hass}
+          .entities=${this.entities}
+        ></comfort-band-insights-tab>`;
     }
   }
 };
 _.styles = [
-  z,
-  E`
+  C,
+  $`
       :host {
         --cb-modal-max-width: 480px;
       }
@@ -1588,36 +1683,36 @@ _.styles = [
       }
     `
 ];
-S([
-  h({ attribute: !1 })
+P([
+  l({ attribute: !1 })
 ], _.prototype, "hass", 2);
-S([
-  h({ type: String })
+P([
+  l({ type: String })
 ], _.prototype, "zone", 2);
-S([
-  h({ type: String })
+P([
+  l({ type: String })
 ], _.prototype, "zoneName", 2);
-S([
-  h({ attribute: !1 })
+P([
+  l({ attribute: !1 })
 ], _.prototype, "entities", 2);
-S([
-  U()
+P([
+  H()
 ], _.prototype, "_activeTab", 2);
-S([
-  U()
+P([
+  H()
 ], _.prototype, "_isOpen", 2);
-S([
-  ht("dialog")
+P([
+  pt("dialog")
 ], _.prototype, "_dialog", 2);
-_ = S([
-  T("comfort-band-modal")
+_ = P([
+  S("comfort-band-modal")
 ], _);
-var Te = Object.defineProperty, ze = Object.getOwnPropertyDescriptor, tt = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? ze(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+var Me = Object.defineProperty, De = Object.getOwnPropertyDescriptor, it = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? De(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && Te(t, e, s), s;
+  return r && s && Me(t, e, s), s;
 };
-let D = class extends v {
+let R = class extends v {
   constructor() {
     super(...arguments), this._onTileTap = () => {
       this._modal?.open();
@@ -1633,15 +1728,15 @@ let D = class extends v {
     return 2;
   }
   render() {
-    if (!this._config || !this.hass) return p``;
-    const i = this._config.zone, t = Ae(this.hass, i);
+    if (!this._config || !this.hass) return d``;
+    const i = this._config.zone, t = Se(this.hass, i);
     if (t.deviceId === null)
-      return p`<div class="placeholder">
+      return d`<div class="placeholder">
         Comfort Band zone <code>${i}</code> not found. Add it via Settings → Devices &
         Services.
       </div>`;
     const e = this._config.compact === !0, r = this._buildView(this.hass, t);
-    return p`
+    return d`
       <comfort-band-tile
         zoneName=${r.zoneName}
         .roomTemp=${r.roomTemp}
@@ -1653,7 +1748,7 @@ let D = class extends v {
         .noExpand=${e}
         @comfort-band-tile-tap=${this._onTileTap}
       ></comfort-band-tile>
-      ${e ? null : p`<comfort-band-modal
+      ${e ? null : d`<comfort-band-modal
             .hass=${this.hass}
             zone=${i}
             zoneName=${r.zoneName}
@@ -1679,9 +1774,9 @@ let D = class extends v {
     };
   }
 };
-D.styles = [
-  z,
-  E`
+R.styles = [
+  C,
+  $`
       :host {
         display: block;
       }
@@ -1695,18 +1790,18 @@ D.styles = [
       }
     `
 ];
-tt([
-  h({ attribute: !1 })
-], D.prototype, "hass", 2);
-tt([
-  U()
-], D.prototype, "_config", 2);
-tt([
-  ht("comfort-band-modal")
-], D.prototype, "_modal", 2);
-D = tt([
-  T("comfort-band-card")
-], D);
+it([
+  l({ attribute: !1 })
+], R.prototype, "hass", 2);
+it([
+  H()
+], R.prototype, "_config", 2);
+it([
+  pt("comfort-band-modal")
+], R.prototype, "_modal", 2);
+R = it([
+  S("comfort-band-card")
+], R);
 (window.customCards ??= []).push({
   type: "comfort-band-card",
   name: "Comfort Band",

--- a/dist/comfort-band-card.js
+++ b/dist/comfort-band-card.js
@@ -1,15 +1,15 @@
-const M = globalThis, k = M.ShadowRoot && (M.ShadyCSS === void 0 || M.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, z = Symbol(), V = /* @__PURE__ */ new WeakMap();
-let st = class {
-  constructor(t, e, s) {
-    if (this._$cssResult$ = !0, s !== z) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+const D = globalThis, K = D.ShadowRoot && (D.ShadyCSS === void 0 || D.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, Z = Symbol(), it = /* @__PURE__ */ new WeakMap();
+let ut = class {
+  constructor(t, e, i) {
+    if (this._$cssResult$ = !0, i !== Z) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = t, this.t = e;
   }
   get styleSheet() {
     let t = this.o;
     const e = this.t;
-    if (k && t === void 0) {
-      const s = e !== void 0 && e.length === 1;
-      s && (t = V.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), s && V.set(e, t));
+    if (K && t === void 0) {
+      const i = e !== void 0 && e.length === 1;
+      i && (t = it.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), i && it.set(e, t));
     }
     return t;
   }
@@ -17,115 +17,115 @@ let st = class {
     return this.cssText;
   }
 };
-const at = (r) => new st(typeof r == "string" ? r : r + "", void 0, z), lt = (r, ...t) => {
-  const e = r.length === 1 ? r[0] : t.reduce((s, i, o) => s + ((n) => {
+const wt = (s) => new ut(typeof s == "string" ? s : s + "", void 0, Z), L = (s, ...t) => {
+  const e = s.length === 1 ? s[0] : t.reduce((i, r, o) => i + ((n) => {
     if (n._$cssResult$ === !0) return n.cssText;
     if (typeof n == "number") return n;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-  })(i) + r[o + 1], r[0]);
-  return new st(e, r, z);
-}, ct = (r, t) => {
-  if (k) r.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  })(r) + s[o + 1], s[0]);
+  return new ut(e, s, Z);
+}, xt = (s, t) => {
+  if (K) s.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
   else for (const e of t) {
-    const s = document.createElement("style"), i = M.litNonce;
-    i !== void 0 && s.setAttribute("nonce", i), s.textContent = e.cssText, r.appendChild(s);
+    const i = document.createElement("style"), r = D.litNonce;
+    r !== void 0 && i.setAttribute("nonce", r), i.textContent = e.cssText, s.appendChild(i);
   }
-}, W = k ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((t) => {
+}, rt = K ? (s) => s : (s) => s instanceof CSSStyleSheet ? ((t) => {
   let e = "";
-  for (const s of t.cssRules) e += s.cssText;
-  return at(e);
-})(r) : r;
-const { is: dt, defineProperty: pt, getOwnPropertyDescriptor: ut, getOwnPropertyNames: $t, getOwnPropertySymbols: ft, getPrototypeOf: _t } = Object, N = globalThis, F = N.trustedTypes, mt = F ? F.emptyScript : "", At = N.reactiveElementPolyfillSupport, E = (r, t) => r, H = { toAttribute(r, t) {
+  for (const i of t.cssRules) e += i.cssText;
+  return wt(e);
+})(s) : s;
+const { is: Et, defineProperty: St, getOwnPropertyDescriptor: Nt, getOwnPropertyNames: Ct, getOwnPropertySymbols: Pt, getPrototypeOf: Ot } = Object, I = globalThis, st = I.trustedTypes, Tt = st ? st.emptyScript : "", Mt = I.reactiveElementPolyfillSupport, P = (s, t) => s, j = { toAttribute(s, t) {
   switch (t) {
     case Boolean:
-      r = r ? mt : null;
+      s = s ? Tt : null;
       break;
     case Object:
     case Array:
-      r = r == null ? r : JSON.stringify(r);
+      s = s == null ? s : JSON.stringify(s);
   }
-  return r;
-}, fromAttribute(r, t) {
-  let e = r;
+  return s;
+}, fromAttribute(s, t) {
+  let e = s;
   switch (t) {
     case Boolean:
-      e = r !== null;
+      e = s !== null;
       break;
     case Number:
-      e = r === null ? null : Number(r);
+      e = s === null ? null : Number(s);
       break;
     case Object:
     case Array:
       try {
-        e = JSON.parse(r);
+        e = JSON.parse(s);
       } catch {
         e = null;
       }
   }
   return e;
-} }, j = (r, t) => !dt(r, t), Z = { attribute: !0, type: String, converter: H, reflect: !1, useDefault: !1, hasChanged: j };
-Symbol.metadata ??= Symbol("metadata"), N.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
-let g = class extends HTMLElement {
+} }, G = (s, t) => !Et(s, t), ot = { attribute: !0, type: String, converter: j, reflect: !1, useDefault: !1, hasChanged: G };
+Symbol.metadata ??= Symbol("metadata"), I.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
+let E = class extends HTMLElement {
   static addInitializer(t) {
     this._$Ei(), (this.l ??= []).push(t);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, e = Z) {
+  static createProperty(t, e = ot) {
     if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
-      const s = Symbol(), i = this.getPropertyDescriptor(t, s, e);
-      i !== void 0 && pt(this.prototype, t, i);
+      const i = Symbol(), r = this.getPropertyDescriptor(t, i, e);
+      r !== void 0 && St(this.prototype, t, r);
     }
   }
-  static getPropertyDescriptor(t, e, s) {
-    const { get: i, set: o } = ut(this.prototype, t) ?? { get() {
+  static getPropertyDescriptor(t, e, i) {
+    const { get: r, set: o } = Nt(this.prototype, t) ?? { get() {
       return this[e];
     }, set(n) {
       this[e] = n;
     } };
-    return { get: i, set(n) {
-      const a = i?.call(this);
-      o?.call(this, n), this.requestUpdate(t, a, s);
+    return { get: r, set(n) {
+      const c = r?.call(this);
+      o?.call(this, n), this.requestUpdate(t, c, i);
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? Z;
+    return this.elementProperties.get(t) ?? ot;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(E("elementProperties"))) return;
-    const t = _t(this);
+    if (this.hasOwnProperty(P("elementProperties"))) return;
+    const t = Ot(this);
     t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(E("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(E("properties"))) {
-      const e = this.properties, s = [...$t(e), ...ft(e)];
-      for (const i of s) this.createProperty(i, e[i]);
+    if (this.hasOwnProperty(P("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(P("properties"))) {
+      const e = this.properties, i = [...Ct(e), ...Pt(e)];
+      for (const r of i) this.createProperty(r, e[r]);
     }
     const t = this[Symbol.metadata];
     if (t !== null) {
       const e = litPropertyMetadata.get(t);
-      if (e !== void 0) for (const [s, i] of e) this.elementProperties.set(s, i);
+      if (e !== void 0) for (const [i, r] of e) this.elementProperties.set(i, r);
     }
     this._$Eh = /* @__PURE__ */ new Map();
-    for (const [e, s] of this.elementProperties) {
-      const i = this._$Eu(e, s);
-      i !== void 0 && this._$Eh.set(i, e);
+    for (const [e, i] of this.elementProperties) {
+      const r = this._$Eu(e, i);
+      r !== void 0 && this._$Eh.set(r, e);
     }
     this.elementStyles = this.finalizeStyles(this.styles);
   }
   static finalizeStyles(t) {
     const e = [];
     if (Array.isArray(t)) {
-      const s = new Set(t.flat(1 / 0).reverse());
-      for (const i of s) e.unshift(W(i));
-    } else t !== void 0 && e.push(W(t));
+      const i = new Set(t.flat(1 / 0).reverse());
+      for (const r of i) e.unshift(rt(r));
+    } else t !== void 0 && e.push(rt(t));
     return e;
   }
   static _$Eu(t, e) {
-    const s = e.attribute;
-    return s === !1 ? void 0 : typeof s == "string" ? s : typeof t == "string" ? t.toLowerCase() : void 0;
+    const i = e.attribute;
+    return i === !1 ? void 0 : typeof i == "string" ? i : typeof t == "string" ? t.toLowerCase() : void 0;
   }
   constructor() {
     super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
@@ -141,12 +141,12 @@ let g = class extends HTMLElement {
   }
   _$E_() {
     const t = /* @__PURE__ */ new Map(), e = this.constructor.elementProperties;
-    for (const s of e.keys()) this.hasOwnProperty(s) && (t.set(s, this[s]), delete this[s]);
+    for (const i of e.keys()) this.hasOwnProperty(i) && (t.set(i, this[i]), delete this[i]);
     t.size > 0 && (this._$Ep = t);
   }
   createRenderRoot() {
     const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return ct(t, this.constructor.elementStyles), t;
+    return xt(t, this.constructor.elementStyles), t;
   }
   connectedCallback() {
     this.renderRoot ??= this.createRenderRoot(), this.enableUpdating(!0), this._$EO?.forEach((t) => t.hostConnected?.());
@@ -156,35 +156,35 @@ let g = class extends HTMLElement {
   disconnectedCallback() {
     this._$EO?.forEach((t) => t.hostDisconnected?.());
   }
-  attributeChangedCallback(t, e, s) {
-    this._$AK(t, s);
+  attributeChangedCallback(t, e, i) {
+    this._$AK(t, i);
   }
   _$ET(t, e) {
-    const s = this.constructor.elementProperties.get(t), i = this.constructor._$Eu(t, s);
-    if (i !== void 0 && s.reflect === !0) {
-      const o = (s.converter?.toAttribute !== void 0 ? s.converter : H).toAttribute(e, s.type);
-      this._$Em = t, o == null ? this.removeAttribute(i) : this.setAttribute(i, o), this._$Em = null;
+    const i = this.constructor.elementProperties.get(t), r = this.constructor._$Eu(t, i);
+    if (r !== void 0 && i.reflect === !0) {
+      const o = (i.converter?.toAttribute !== void 0 ? i.converter : j).toAttribute(e, i.type);
+      this._$Em = t, o == null ? this.removeAttribute(r) : this.setAttribute(r, o), this._$Em = null;
     }
   }
   _$AK(t, e) {
-    const s = this.constructor, i = s._$Eh.get(t);
-    if (i !== void 0 && this._$Em !== i) {
-      const o = s.getPropertyOptions(i), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : H;
-      this._$Em = i;
-      const a = n.fromAttribute(e, o.type);
-      this[i] = a ?? this._$Ej?.get(i) ?? a, this._$Em = null;
+    const i = this.constructor, r = i._$Eh.get(t);
+    if (r !== void 0 && this._$Em !== r) {
+      const o = i.getPropertyOptions(r), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : j;
+      this._$Em = r;
+      const c = n.fromAttribute(e, o.type);
+      this[r] = c ?? this._$Ej?.get(r) ?? c, this._$Em = null;
     }
   }
-  requestUpdate(t, e, s, i = !1, o) {
+  requestUpdate(t, e, i, r = !1, o) {
     if (t !== void 0) {
       const n = this.constructor;
-      if (i === !1 && (o = this[t]), s ??= n.getPropertyOptions(t), !((s.hasChanged ?? j)(o, e) || s.useDefault && s.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, s)))) return;
-      this.C(t, e, s);
+      if (r === !1 && (o = this[t]), i ??= n.getPropertyOptions(t), !((i.hasChanged ?? G)(o, e) || i.useDefault && i.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, i)))) return;
+      this.C(t, e, i);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
   }
-  C(t, e, { useDefault: s, reflect: i, wrapped: o }, n) {
-    s && !(this._$Ej ??= /* @__PURE__ */ new Map()).has(t) && (this._$Ej.set(t, n ?? e ?? this[t]), o !== !0 || n !== void 0) || (this._$AL.has(t) || (this.hasUpdated || s || (e = void 0), this._$AL.set(t, e)), i === !0 && this._$Em !== t && (this._$Eq ??= /* @__PURE__ */ new Set()).add(t));
+  C(t, e, { useDefault: i, reflect: r, wrapped: o }, n) {
+    i && !(this._$Ej ??= /* @__PURE__ */ new Map()).has(t) && (this._$Ej.set(t, n ?? e ?? this[t]), o !== !0 || n !== void 0) || (this._$AL.has(t) || (this.hasUpdated || i || (e = void 0), this._$AL.set(t, e)), r === !0 && this._$Em !== t && (this._$Eq ??= /* @__PURE__ */ new Set()).add(t));
   }
   async _$EP() {
     this.isUpdatePending = !0;
@@ -203,21 +203,21 @@ let g = class extends HTMLElement {
     if (!this.isUpdatePending) return;
     if (!this.hasUpdated) {
       if (this.renderRoot ??= this.createRenderRoot(), this._$Ep) {
-        for (const [i, o] of this._$Ep) this[i] = o;
+        for (const [r, o] of this._$Ep) this[r] = o;
         this._$Ep = void 0;
       }
-      const s = this.constructor.elementProperties;
-      if (s.size > 0) for (const [i, o] of s) {
-        const { wrapped: n } = o, a = this[i];
-        n !== !0 || this._$AL.has(i) || a === void 0 || this.C(i, void 0, o, a);
+      const i = this.constructor.elementProperties;
+      if (i.size > 0) for (const [r, o] of i) {
+        const { wrapped: n } = o, c = this[r];
+        n !== !0 || this._$AL.has(r) || c === void 0 || this.C(r, void 0, o, c);
       }
     }
     let t = !1;
     const e = this._$AL;
     try {
-      t = this.shouldUpdate(e), t ? (this.willUpdate(e), this._$EO?.forEach((s) => s.hostUpdate?.()), this.update(e)) : this._$EM();
-    } catch (s) {
-      throw t = !1, this._$EM(), s;
+      t = this.shouldUpdate(e), t ? (this.willUpdate(e), this._$EO?.forEach((i) => i.hostUpdate?.()), this.update(e)) : this._$EM();
+    } catch (i) {
+      throw t = !1, this._$EM(), i;
     }
     t && this._$AE(e);
   }
@@ -246,70 +246,70 @@ let g = class extends HTMLElement {
   firstUpdated(t) {
   }
 };
-g.elementStyles = [], g.shadowRootOptions = { mode: "open" }, g[E("elementProperties")] = /* @__PURE__ */ new Map(), g[E("finalized")] = /* @__PURE__ */ new Map(), At?.({ ReactiveElement: g }), (N.reactiveElementVersions ??= []).push("2.1.2");
-const B = globalThis, J = (r) => r, T = B.trustedTypes, K = T ? T.createPolicy("lit-html", { createHTML: (r) => r }) : void 0, it = "$lit$", f = `lit$${Math.random().toFixed(9).slice(2)}$`, rt = "?" + f, gt = `<${rt}>`, A = document, w = () => A.createComment(""), C = (r) => r === null || typeof r != "object" && typeof r != "function", L = Array.isArray, yt = (r) => L(r) || typeof r?.[Symbol.iterator] == "function", D = `[ 	
-\f\r]`, b = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, G = /-->/g, Q = />/g, _ = RegExp(`>|${D}(?:([^\\s"'>=/]+)(${D}*=${D}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), X = /'/g, Y = /"/g, ot = /^(?:script|style|textarea|title)$/i, vt = (r) => (t, ...e) => ({ _$litType$: r, strings: t, values: e }), tt = vt(1), y = Symbol.for("lit-noChange"), d = Symbol.for("lit-nothing"), et = /* @__PURE__ */ new WeakMap(), m = A.createTreeWalker(A, 129);
-function nt(r, t) {
-  if (!L(r) || !r.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return K !== void 0 ? K.createHTML(t) : t;
+E.elementStyles = [], E.shadowRootOptions = { mode: "open" }, E[P("elementProperties")] = /* @__PURE__ */ new Map(), E[P("finalized")] = /* @__PURE__ */ new Map(), Mt?.({ ReactiveElement: E }), (I.reactiveElementVersions ??= []).push("2.1.2");
+const J = globalThis, nt = (s) => s, B = J.trustedTypes, at = B ? B.createPolicy("lit-html", { createHTML: (s) => s }) : void 0, ft = "$lit$", _ = `lit$${Math.random().toFixed(9).slice(2)}$`, $t = "?" + _, Ut = `<${$t}>`, w = document, O = () => w.createComment(""), T = (s) => s === null || typeof s != "object" && typeof s != "function", X = Array.isArray, kt = (s) => X(s) || typeof s?.[Symbol.iterator] == "function", q = `[ 	
+\f\r]`, C = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, ct = /-->/g, lt = />/g, g = RegExp(`>|${q}(?:([^\\s"'>=/]+)(${q}*=${q}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), ht = /'/g, dt = /"/g, mt = /^(?:script|style|textarea|title)$/i, vt = (s) => (t, ...e) => ({ _$litType$: s, strings: t, values: e }), y = vt(1), z = vt(2), S = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), pt = /* @__PURE__ */ new WeakMap(), b = w.createTreeWalker(w, 129);
+function _t(s, t) {
+  if (!X(s) || !s.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return at !== void 0 ? at.createHTML(t) : t;
 }
-const bt = (r, t) => {
-  const e = r.length - 1, s = [];
-  let i, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = b;
-  for (let a = 0; a < e; a++) {
-    const h = r[a];
-    let c, p, l = -1, u = 0;
-    for (; u < h.length && (n.lastIndex = u, p = n.exec(h), p !== null); ) u = n.lastIndex, n === b ? p[1] === "!--" ? n = G : p[1] !== void 0 ? n = Q : p[2] !== void 0 ? (ot.test(p[2]) && (i = RegExp("</" + p[2], "g")), n = _) : p[3] !== void 0 && (n = _) : n === _ ? p[0] === ">" ? (n = i ?? b, l = -1) : p[1] === void 0 ? l = -2 : (l = n.lastIndex - p[2].length, c = p[1], n = p[3] === void 0 ? _ : p[3] === '"' ? Y : X) : n === Y || n === X ? n = _ : n === G || n === Q ? n = b : (n = _, i = void 0);
-    const $ = n === _ && r[a + 1].startsWith("/>") ? " " : "";
-    o += n === b ? h + gt : l >= 0 ? (s.push(c), h.slice(0, l) + it + h.slice(l) + f + $) : h + f + (l === -2 ? a : $);
+const Ht = (s, t) => {
+  const e = s.length - 1, i = [];
+  let r, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = C;
+  for (let c = 0; c < e; c++) {
+    const a = s[c];
+    let h, d, l = -1, f = 0;
+    for (; f < a.length && (n.lastIndex = f, d = n.exec(a), d !== null); ) f = n.lastIndex, n === C ? d[1] === "!--" ? n = ct : d[1] !== void 0 ? n = lt : d[2] !== void 0 ? (mt.test(d[2]) && (r = RegExp("</" + d[2], "g")), n = g) : d[3] !== void 0 && (n = g) : n === g ? d[0] === ">" ? (n = r ?? C, l = -1) : d[1] === void 0 ? l = -2 : (l = n.lastIndex - d[2].length, h = d[1], n = d[3] === void 0 ? g : d[3] === '"' ? dt : ht) : n === dt || n === ht ? n = g : n === ct || n === lt ? n = C : (n = g, r = void 0);
+    const v = n === g && s[c + 1].startsWith("/>") ? " " : "";
+    o += n === C ? a + Ut : l >= 0 ? (i.push(h), a.slice(0, l) + ft + a.slice(l) + _ + v) : a + _ + (l === -2 ? c : v);
   }
-  return [nt(r, o + (r[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), s];
+  return [_t(s, o + (s[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), i];
 };
-class P {
-  constructor({ strings: t, _$litType$: e }, s) {
-    let i;
+class M {
+  constructor({ strings: t, _$litType$: e }, i) {
+    let r;
     this.parts = [];
     let o = 0, n = 0;
-    const a = t.length - 1, h = this.parts, [c, p] = bt(t, e);
-    if (this.el = P.createElement(c, s), m.currentNode = this.el.content, e === 2 || e === 3) {
+    const c = t.length - 1, a = this.parts, [h, d] = Ht(t, e);
+    if (this.el = M.createElement(h, i), b.currentNode = this.el.content, e === 2 || e === 3) {
       const l = this.el.content.firstChild;
       l.replaceWith(...l.childNodes);
     }
-    for (; (i = m.nextNode()) !== null && h.length < a; ) {
-      if (i.nodeType === 1) {
-        if (i.hasAttributes()) for (const l of i.getAttributeNames()) if (l.endsWith(it)) {
-          const u = p[n++], $ = i.getAttribute(l).split(f), U = /([.?@])?(.*)/.exec(u);
-          h.push({ type: 1, index: o, name: U[2], strings: $, ctor: U[1] === "." ? St : U[1] === "?" ? wt : U[1] === "@" ? Ct : R }), i.removeAttribute(l);
-        } else l.startsWith(f) && (h.push({ type: 6, index: o }), i.removeAttribute(l));
-        if (ot.test(i.tagName)) {
-          const l = i.textContent.split(f), u = l.length - 1;
-          if (u > 0) {
-            i.textContent = T ? T.emptyScript : "";
-            for (let $ = 0; $ < u; $++) i.append(l[$], w()), m.nextNode(), h.push({ type: 2, index: ++o });
-            i.append(l[u], w());
+    for (; (r = b.nextNode()) !== null && a.length < c; ) {
+      if (r.nodeType === 1) {
+        if (r.hasAttributes()) for (const l of r.getAttributeNames()) if (l.endsWith(ft)) {
+          const f = d[n++], v = r.getAttribute(l).split(_), R = /([.?@])?(.*)/.exec(f);
+          a.push({ type: 1, index: o, name: R[2], strings: v, ctor: R[1] === "." ? zt : R[1] === "?" ? Dt : R[1] === "@" ? jt : F }), r.removeAttribute(l);
+        } else l.startsWith(_) && (a.push({ type: 6, index: o }), r.removeAttribute(l));
+        if (mt.test(r.tagName)) {
+          const l = r.textContent.split(_), f = l.length - 1;
+          if (f > 0) {
+            r.textContent = B ? B.emptyScript : "";
+            for (let v = 0; v < f; v++) r.append(l[v], O()), b.nextNode(), a.push({ type: 2, index: ++o });
+            r.append(l[f], O());
           }
         }
-      } else if (i.nodeType === 8) if (i.data === rt) h.push({ type: 2, index: o });
+      } else if (r.nodeType === 8) if (r.data === $t) a.push({ type: 2, index: o });
       else {
         let l = -1;
-        for (; (l = i.data.indexOf(f, l + 1)) !== -1; ) h.push({ type: 7, index: o }), l += f.length - 1;
+        for (; (l = r.data.indexOf(_, l + 1)) !== -1; ) a.push({ type: 7, index: o }), l += _.length - 1;
       }
       o++;
     }
   }
   static createElement(t, e) {
-    const s = A.createElement("template");
-    return s.innerHTML = t, s;
+    const i = w.createElement("template");
+    return i.innerHTML = t, i;
   }
 }
-function v(r, t, e = r, s) {
-  if (t === y) return t;
-  let i = s !== void 0 ? e._$Co?.[s] : e._$Cl;
-  const o = C(t) ? void 0 : t._$litDirective$;
-  return i?.constructor !== o && (i?._$AO?.(!1), o === void 0 ? i = void 0 : (i = new o(r), i._$AT(r, e, s)), s !== void 0 ? (e._$Co ??= [])[s] = i : e._$Cl = i), i !== void 0 && (t = v(r, i._$AS(r, t.values), i, s)), t;
+function N(s, t, e = s, i) {
+  if (t === S) return t;
+  let r = i !== void 0 ? e._$Co?.[i] : e._$Cl;
+  const o = T(t) ? void 0 : t._$litDirective$;
+  return r?.constructor !== o && (r?._$AO?.(!1), o === void 0 ? r = void 0 : (r = new o(s), r._$AT(s, e, i)), i !== void 0 ? (e._$Co ??= [])[i] = r : e._$Cl = r), r !== void 0 && (t = N(s, r._$AS(s, t.values), r, i)), t;
 }
-class Et {
+class Rt {
   constructor(t, e) {
     this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
   }
@@ -320,29 +320,29 @@ class Et {
     return this._$AM._$AU;
   }
   u(t) {
-    const { el: { content: e }, parts: s } = this._$AD, i = (t?.creationScope ?? A).importNode(e, !0);
-    m.currentNode = i;
-    let o = m.nextNode(), n = 0, a = 0, h = s[0];
-    for (; h !== void 0; ) {
-      if (n === h.index) {
-        let c;
-        h.type === 2 ? c = new O(o, o.nextSibling, this, t) : h.type === 1 ? c = new h.ctor(o, h.name, h.strings, this, t) : h.type === 6 && (c = new Pt(o, this, t)), this._$AV.push(c), h = s[++a];
+    const { el: { content: e }, parts: i } = this._$AD, r = (t?.creationScope ?? w).importNode(e, !0);
+    b.currentNode = r;
+    let o = b.nextNode(), n = 0, c = 0, a = i[0];
+    for (; a !== void 0; ) {
+      if (n === a.index) {
+        let h;
+        a.type === 2 ? h = new k(o, o.nextSibling, this, t) : a.type === 1 ? h = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (h = new Bt(o, this, t)), this._$AV.push(h), a = i[++c];
       }
-      n !== h?.index && (o = m.nextNode(), n++);
+      n !== a?.index && (o = b.nextNode(), n++);
     }
-    return m.currentNode = A, i;
+    return b.currentNode = w, r;
   }
   p(t) {
     let e = 0;
-    for (const s of this._$AV) s !== void 0 && (s.strings !== void 0 ? (s._$AI(t, s, e), e += s.strings.length - 2) : s._$AI(t[e])), e++;
+    for (const i of this._$AV) i !== void 0 && (i.strings !== void 0 ? (i._$AI(t, i, e), e += i.strings.length - 2) : i._$AI(t[e])), e++;
   }
 }
-class O {
+class k {
   get _$AU() {
     return this._$AM?._$AU ?? this._$Cv;
   }
-  constructor(t, e, s, i) {
-    this.type = 2, this._$AH = d, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = s, this.options = i, this._$Cv = i?.isConnected ?? !0;
+  constructor(t, e, i, r) {
+    this.type = 2, this._$AH = p, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = i, this.options = r, this._$Cv = r?.isConnected ?? !0;
   }
   get parentNode() {
     let t = this._$AA.parentNode;
@@ -356,7 +356,7 @@ class O {
     return this._$AB;
   }
   _$AI(t, e = this) {
-    t = v(this, t, e), C(t) ? t === d || t == null || t === "" ? (this._$AH !== d && this._$AR(), this._$AH = d) : t !== this._$AH && t !== y && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : yt(t) ? this.k(t) : this._(t);
+    t = N(this, t, e), T(t) ? t === p || t == null || t === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : t !== this._$AH && t !== S && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : kt(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -365,115 +365,115 @@ class O {
     this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
   }
   _(t) {
-    this._$AH !== d && C(this._$AH) ? this._$AA.nextSibling.data = t : this.T(A.createTextNode(t)), this._$AH = t;
+    this._$AH !== p && T(this._$AH) ? this._$AA.nextSibling.data = t : this.T(w.createTextNode(t)), this._$AH = t;
   }
   $(t) {
-    const { values: e, _$litType$: s } = t, i = typeof s == "number" ? this._$AC(t) : (s.el === void 0 && (s.el = P.createElement(nt(s.h, s.h[0]), this.options)), s);
-    if (this._$AH?._$AD === i) this._$AH.p(e);
+    const { values: e, _$litType$: i } = t, r = typeof i == "number" ? this._$AC(t) : (i.el === void 0 && (i.el = M.createElement(_t(i.h, i.h[0]), this.options)), i);
+    if (this._$AH?._$AD === r) this._$AH.p(e);
     else {
-      const o = new Et(i, this), n = o.u(this.options);
+      const o = new Rt(r, this), n = o.u(this.options);
       o.p(e), this.T(n), this._$AH = o;
     }
   }
   _$AC(t) {
-    let e = et.get(t.strings);
-    return e === void 0 && et.set(t.strings, e = new P(t)), e;
+    let e = pt.get(t.strings);
+    return e === void 0 && pt.set(t.strings, e = new M(t)), e;
   }
   k(t) {
-    L(this._$AH) || (this._$AH = [], this._$AR());
+    X(this._$AH) || (this._$AH = [], this._$AR());
     const e = this._$AH;
-    let s, i = 0;
-    for (const o of t) i === e.length ? e.push(s = new O(this.O(w()), this.O(w()), this, this.options)) : s = e[i], s._$AI(o), i++;
-    i < e.length && (this._$AR(s && s._$AB.nextSibling, i), e.length = i);
+    let i, r = 0;
+    for (const o of t) r === e.length ? e.push(i = new k(this.O(O()), this.O(O()), this, this.options)) : i = e[r], i._$AI(o), r++;
+    r < e.length && (this._$AR(i && i._$AB.nextSibling, r), e.length = r);
   }
   _$AR(t = this._$AA.nextSibling, e) {
     for (this._$AP?.(!1, !0, e); t !== this._$AB; ) {
-      const s = J(t).nextSibling;
-      J(t).remove(), t = s;
+      const i = nt(t).nextSibling;
+      nt(t).remove(), t = i;
     }
   }
   setConnected(t) {
     this._$AM === void 0 && (this._$Cv = t, this._$AP?.(t));
   }
 }
-class R {
+class F {
   get tagName() {
     return this.element.tagName;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
-  constructor(t, e, s, i, o) {
-    this.type = 1, this._$AH = d, this._$AN = void 0, this.element = t, this.name = e, this._$AM = i, this.options = o, s.length > 2 || s[0] !== "" || s[1] !== "" ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = d;
+  constructor(t, e, i, r, o) {
+    this.type = 1, this._$AH = p, this._$AN = void 0, this.element = t, this.name = e, this._$AM = r, this.options = o, i.length > 2 || i[0] !== "" || i[1] !== "" ? (this._$AH = Array(i.length - 1).fill(new String()), this.strings = i) : this._$AH = p;
   }
-  _$AI(t, e = this, s, i) {
+  _$AI(t, e = this, i, r) {
     const o = this.strings;
     let n = !1;
-    if (o === void 0) t = v(this, t, e, 0), n = !C(t) || t !== this._$AH && t !== y, n && (this._$AH = t);
+    if (o === void 0) t = N(this, t, e, 0), n = !T(t) || t !== this._$AH && t !== S, n && (this._$AH = t);
     else {
-      const a = t;
-      let h, c;
-      for (t = o[0], h = 0; h < o.length - 1; h++) c = v(this, a[s + h], e, h), c === y && (c = this._$AH[h]), n ||= !C(c) || c !== this._$AH[h], c === d ? t = d : t !== d && (t += (c ?? "") + o[h + 1]), this._$AH[h] = c;
+      const c = t;
+      let a, h;
+      for (t = o[0], a = 0; a < o.length - 1; a++) h = N(this, c[i + a], e, a), h === S && (h = this._$AH[a]), n ||= !T(h) || h !== this._$AH[a], h === p ? t = p : t !== p && (t += (h ?? "") + o[a + 1]), this._$AH[a] = h;
     }
-    n && !i && this.j(t);
+    n && !r && this.j(t);
   }
   j(t) {
-    t === d ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+    t === p ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
 }
-class St extends R {
+class zt extends F {
   constructor() {
     super(...arguments), this.type = 3;
   }
   j(t) {
-    this.element[this.name] = t === d ? void 0 : t;
+    this.element[this.name] = t === p ? void 0 : t;
   }
 }
-class wt extends R {
+class Dt extends F {
   constructor() {
     super(...arguments), this.type = 4;
   }
   j(t) {
-    this.element.toggleAttribute(this.name, !!t && t !== d);
+    this.element.toggleAttribute(this.name, !!t && t !== p);
   }
 }
-class Ct extends R {
-  constructor(t, e, s, i, o) {
-    super(t, e, s, i, o), this.type = 5;
+class jt extends F {
+  constructor(t, e, i, r, o) {
+    super(t, e, i, r, o), this.type = 5;
   }
   _$AI(t, e = this) {
-    if ((t = v(this, t, e, 0) ?? d) === y) return;
-    const s = this._$AH, i = t === d && s !== d || t.capture !== s.capture || t.once !== s.once || t.passive !== s.passive, o = t !== d && (s === d || i);
-    i && this.element.removeEventListener(this.name, this, s), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
+    if ((t = N(this, t, e, 0) ?? p) === S) return;
+    const i = this._$AH, r = t === p && i !== p || t.capture !== i.capture || t.once !== i.once || t.passive !== i.passive, o = t !== p && (i === p || r);
+    r && this.element.removeEventListener(this.name, this, i), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
   handleEvent(t) {
     typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class Pt {
-  constructor(t, e, s) {
-    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = s;
+class Bt {
+  constructor(t, e, i) {
+    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = i;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
   _$AI(t) {
-    v(this, t);
+    N(this, t);
   }
 }
-const xt = B.litHtmlPolyfillSupport;
-xt?.(P, O), (B.litHtmlVersions ??= []).push("3.3.2");
-const Ot = (r, t, e) => {
-  const s = e?.renderBefore ?? t;
-  let i = s._$litPart$;
-  if (i === void 0) {
+const Lt = J.litHtmlPolyfillSupport;
+Lt?.(M, k), (J.litHtmlVersions ??= []).push("3.3.2");
+const It = (s, t, e) => {
+  const i = e?.renderBefore ?? t;
+  let r = i._$litPart$;
+  if (r === void 0) {
     const o = e?.renderBefore ?? null;
-    s._$litPart$ = i = new O(t.insertBefore(w(), o), o, void 0, e ?? {});
+    i._$litPart$ = r = new k(t.insertBefore(O(), o), o, void 0, e ?? {});
   }
-  return i._$AI(r), i;
+  return r._$AI(s), r;
 };
-const I = globalThis;
-class S extends g {
+const Y = globalThis;
+class A extends E {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -483,7 +483,7 @@ class S extends g {
   }
   update(t) {
     const e = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Ot(e, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = It(e, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     super.connectedCallback(), this._$Do?.setConnected(!0);
@@ -492,85 +492,472 @@ class S extends g {
     super.disconnectedCallback(), this._$Do?.setConnected(!1);
   }
   render() {
-    return y;
+    return S;
   }
 }
-S._$litElement$ = !0, S.finalized = !0, I.litElementHydrateSupport?.({ LitElement: S });
-const Ut = I.litElementPolyfillSupport;
-Ut?.({ LitElement: S });
-(I.litElementVersions ??= []).push("4.2.2");
-const Mt = (r) => (t, e) => {
+A._$litElement$ = !0, A.finalized = !0, Y.litElementHydrateSupport?.({ LitElement: A });
+const Ft = Y.litElementPolyfillSupport;
+Ft?.({ LitElement: A });
+(Y.litElementVersions ??= []).push("4.2.2");
+const Q = (s) => (t, e) => {
   e !== void 0 ? e.addInitializer(() => {
-    customElements.define(r, t);
-  }) : customElements.define(r, t);
+    customElements.define(s, t);
+  }) : customElements.define(s, t);
 };
-const Ht = { attribute: !0, type: String, converter: H, reflect: !1, hasChanged: j }, Tt = (r = Ht, t, e) => {
-  const { kind: s, metadata: i } = e;
-  let o = globalThis.litPropertyMetadata.get(i);
-  if (o === void 0 && globalThis.litPropertyMetadata.set(i, o = /* @__PURE__ */ new Map()), s === "setter" && ((r = Object.create(r)).wrapped = !0), o.set(e.name, r), s === "accessor") {
+const qt = { attribute: !0, type: String, converter: j, reflect: !1, hasChanged: G }, Vt = (s = qt, t, e) => {
+  const { kind: i, metadata: r } = e;
+  let o = globalThis.litPropertyMetadata.get(r);
+  if (o === void 0 && globalThis.litPropertyMetadata.set(r, o = /* @__PURE__ */ new Map()), i === "setter" && ((s = Object.create(s)).wrapped = !0), o.set(e.name, s), i === "accessor") {
     const { name: n } = e;
-    return { set(a) {
-      const h = t.get.call(this);
-      t.set.call(this, a), this.requestUpdate(n, h, r, !0, a);
-    }, init(a) {
-      return a !== void 0 && this.C(n, void 0, r, a), a;
+    return { set(c) {
+      const a = t.get.call(this);
+      t.set.call(this, c), this.requestUpdate(n, a, s, !0, c);
+    }, init(c) {
+      return c !== void 0 && this.C(n, void 0, s, c), c;
     } };
   }
-  if (s === "setter") {
+  if (i === "setter") {
     const { name: n } = e;
-    return function(a) {
-      const h = this[n];
-      t.call(this, a), this.requestUpdate(n, h, r, !0, a);
+    return function(c) {
+      const a = this[n];
+      t.call(this, c), this.requestUpdate(n, a, s, !0, c);
     };
   }
-  throw Error("Unsupported decorator location: " + s);
+  throw Error("Unsupported decorator location: " + i);
 };
-function ht(r) {
-  return (t, e) => typeof e == "object" ? Tt(r, t, e) : ((s, i, o) => {
-    const n = i.hasOwnProperty(o);
-    return i.constructor.createProperty(o, s), n ? Object.getOwnPropertyDescriptor(i, o) : void 0;
-  })(r, t, e);
+function u(s) {
+  return (t, e) => typeof e == "object" ? Vt(s, t, e) : ((i, r, o) => {
+    const n = r.hasOwnProperty(o);
+    return r.constructor.createProperty(o, i), n ? Object.getOwnPropertyDescriptor(r, o) : void 0;
+  })(s, t, e);
 }
-function Nt(r) {
-  return ht({ ...r, state: !0, attribute: !1 });
+function Wt(s) {
+  return u({ ...s, state: !0, attribute: !1 });
 }
-var Rt = Object.defineProperty, Dt = Object.getOwnPropertyDescriptor, q = (r, t, e, s) => {
-  for (var i = s > 1 ? void 0 : s ? Dt(t, e) : t, o = r.length - 1, n; o >= 0; o--)
-    (n = r[o]) && (i = (s ? n(t, e, i) : n(i)) || i);
-  return s && i && Rt(t, e, i), i;
+const tt = L`
+  :host {
+    --cb-action-heating: var(--cb-color-heat, var(--state-climate-heat-color, #d9603f));
+    --cb-action-cooling: var(--cb-color-cool, var(--state-climate-cool-color, #2f7fcc));
+    --cb-action-idle: var(--cb-color-idle, var(--state-inactive-color, #888888));
+    --cb-action-unknown: var(--cb-color-unknown, var(--disabled-color, #bdbdbd));
+
+    --cb-track-bg: var(--divider-color, #e0e0e0);
+    --cb-text-primary: var(--primary-text-color, #212121);
+    --cb-text-secondary: var(--secondary-text-color, #727272);
+
+    --cb-radius-card: 12px;
+    --cb-radius-pill: 999px;
+    --cb-gap-xs: 4px;
+    --cb-gap-sm: 8px;
+    --cb-gap-md: 12px;
+    --cb-gap-lg: 16px;
+  }
+`;
+function gt(s) {
+  switch (s) {
+    case "heating":
+      return "var(--cb-action-heating)";
+    case "cooling":
+      return "var(--cb-action-cooling)";
+    case "idle":
+      return "var(--cb-action-idle)";
+    default:
+      return "var(--cb-action-unknown)";
+  }
+}
+function bt(s) {
+  return s === "heating" || s === "cooling" || s === "idle" ? s : "unknown";
+}
+function Kt(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+var Zt = Object.defineProperty, Gt = Object.getOwnPropertyDescriptor, H = (s, t, e, i) => {
+  for (var r = i > 1 ? void 0 : i ? Gt(t, e) : t, o = s.length - 1, n; o >= 0; o--)
+    (n = s[o]) && (r = (i ? n(t, e, r) : n(r)) || r);
+  return i && r && Zt(t, e, r), r;
 };
-let x = class extends S {
-  setConfig(r) {
-    if (!r?.zone)
-      throw new Error("comfort-band-card: `zone` is required");
-    this._config = r;
+const W = 15, yt = 28, Jt = yt - W;
+function V(s) {
+  return Number.isNaN(s) || !Number.isFinite(s) ? 0 : (Math.max(W, Math.min(yt, s)) - W) / Jt * 100;
+}
+let x = class extends A {
+  constructor() {
+    super(...arguments), this.low = NaN, this.high = NaN, this.room = NaN, this.action = "unknown";
   }
   render() {
-    return this._config ? tt`<div class="stub">comfort-band-card · zone: ${this._config.zone}</div>` : tt``;
+    const s = bt(this.action), t = gt(s), e = Number.isFinite(this.low), i = Number.isFinite(this.high), r = Number.isFinite(this.room), o = e ? V(this.low) : 0, n = i ? V(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), h = r ? V(this.room) : 50, d = (f) => Number.isFinite(f) ? `${f.toFixed(1)}°` : "—", l = `Comfort band gauge: low ${d(this.low)}, room ${d(this.room)}, high ${d(this.high)}, action ${s}`;
+    return y`
+      <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${l}>
+        ${z`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
+        ${e && i ? z`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
+        ${r ? z`<circle cx=${h} cy="12" r="4.5" fill=${t}></circle>` : null}
+        ${r ? z`<circle class="marker-ring" cx=${h} cy="12" r="3" stroke=${t}></circle>` : null}
+      </svg>
+    `;
   }
 };
-x.styles = lt`
-    :host {
-      display: block;
-      padding: 12px;
-      border-radius: 12px;
-      background: var(--ha-card-background, var(--card-background-color, #fff));
-      box-shadow: var(--ha-card-box-shadow, none);
-    }
-    .stub {
-      color: var(--primary-text-color, #000);
-      font-family: var(--paper-font-body1_-_font-family, sans-serif);
-    }
-  `;
-q([
-  ht({ attribute: !1 })
-], x.prototype, "hass", 2);
-q([
-  Nt()
-], x.prototype, "_config", 2);
-x = q([
-  Mt("comfort-band-card")
+x.styles = [
+  tt,
+  L`
+      :host {
+        display: block;
+        width: 100%;
+      }
+      svg {
+        display: block;
+        width: 100%;
+        height: 24px;
+        overflow: visible;
+      }
+      .track {
+        fill: var(--cb-track-bg);
+      }
+      .band {
+        opacity: 0.85;
+      }
+      .marker-ring {
+        fill: var(--ha-card-background, var(--card-background-color, #ffffff));
+        stroke-width: 2;
+      }
+      .label {
+        font-size: 11px;
+        fill: var(--cb-text-secondary);
+        font-family: var(--paper-font-body1_-_font-family, sans-serif);
+      }
+    `
+];
+H([
+  u({ type: Number })
+], x.prototype, "low", 2);
+H([
+  u({ type: Number })
+], x.prototype, "high", 2);
+H([
+  u({ type: Number })
+], x.prototype, "room", 2);
+H([
+  u({ type: String })
+], x.prototype, "action", 2);
+x = H([
+  Q("band-gauge")
 ], x);
+var Xt = Object.defineProperty, Yt = Object.getOwnPropertyDescriptor, m = (s, t, e, i) => {
+  for (var r = i > 1 ? void 0 : i ? Yt(t, e) : t, o = s.length - 1, n; o >= 0; o--)
+    (n = s[o]) && (r = (i ? n(t, e, r) : n(r)) || r);
+  return i && r && Xt(t, e, r), r;
+};
+let $ = class extends A {
+  constructor() {
+    super(...arguments), this.zoneName = "", this.roomTemp = NaN, this.low = NaN, this.high = NaN, this.action = "unknown", this.overrideActive = !1, this.overrideEnds = null, this.noExpand = !1;
+  }
+  _onTap(s) {
+    this.noExpand || s instanceof KeyboardEvent && s.key !== "Enter" && s.key !== " " || (s.preventDefault(), this.dispatchEvent(new CustomEvent("comfort-band-tile-tap", { bubbles: !0, composed: !0 })));
+  }
+  _renderRoomTemp() {
+    return Number.isFinite(this.roomTemp) ? `${this.roomTemp.toFixed(1)}°` : "—";
+  }
+  _renderOverridePill() {
+    if (!this.overrideActive) return null;
+    const s = Qt(this.overrideEnds);
+    return y`<div class="override-pill">Override${s ? ` · ${s}` : ""}</div>`;
+  }
+  _renderActionChip() {
+    const s = bt(this.action);
+    if (s === "idle" || s === "unknown") return null;
+    const t = gt(s);
+    return y`<span class="action-chip" style="background:${t}">
+      ${Kt(s)}
+    </span>`;
+  }
+  render() {
+    return y`
+      <div
+        class="tile ${this.noExpand ? "no-expand" : ""}"
+        role="${this.noExpand ? "group" : "button"}"
+        tabindex="${this.noExpand ? -1 : 0}"
+        @click=${this._onTap}
+        @keydown=${this._onTap}
+      >
+        <div class="header">
+          <div class="zone-name">${this.zoneName || "—"}</div>
+          ${this._renderActionChip()}
+        </div>
+        <div class="body">
+          <div class="room-temp">${this._renderRoomTemp()}</div>
+          <div class="gauge-wrap">
+            <band-gauge
+              .low=${this.low}
+              .high=${this.high}
+              .room=${this.roomTemp}
+              .action=${this.action}
+            ></band-gauge>
+          </div>
+        </div>
+        ${this._renderOverridePill()}
+      </div>
+    `;
+  }
+};
+$.styles = [
+  tt,
+  L`
+      :host {
+        display: block;
+      }
+      .tile {
+        display: flex;
+        flex-direction: column;
+        gap: var(--cb-gap-sm);
+        padding: var(--cb-gap-md);
+        border-radius: var(--cb-radius-card);
+        background: var(--ha-card-background, var(--card-background-color, #ffffff));
+        box-shadow: var(--ha-card-box-shadow, none);
+        cursor: pointer;
+        transition: transform 0.12s ease;
+      }
+      .tile.no-expand {
+        cursor: default;
+      }
+      .tile:not(.no-expand):hover {
+        transform: translateY(-1px);
+      }
+      .tile:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 2px;
+      }
+      .header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--cb-gap-sm);
+      }
+      .zone-name {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--cb-text-primary);
+        font-family: var(--paper-font-body1_-_font-family, sans-serif);
+      }
+      .action-chip {
+        font-size: 11px;
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 2px 8px;
+        border-radius: var(--cb-radius-pill);
+        color: var(--cb-text-on-action, #ffffff);
+      }
+      .body {
+        display: flex;
+        align-items: center;
+        gap: var(--cb-gap-md);
+      }
+      .room-temp {
+        font-size: 32px;
+        font-weight: 300;
+        color: var(--cb-text-primary);
+        font-variant-numeric: tabular-nums;
+        line-height: 1;
+        min-width: 70px;
+      }
+      .gauge-wrap {
+        flex: 1;
+        min-width: 0;
+      }
+      .override-pill {
+        align-self: flex-start;
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: var(--cb-radius-pill);
+        background: var(--cb-text-secondary);
+        color: var(--cb-text-on-action, #ffffff);
+        opacity: 0.85;
+      }
+    `
+];
+m([
+  u({ type: String })
+], $.prototype, "zoneName", 2);
+m([
+  u({ type: Number })
+], $.prototype, "roomTemp", 2);
+m([
+  u({ type: Number })
+], $.prototype, "low", 2);
+m([
+  u({ type: Number })
+], $.prototype, "high", 2);
+m([
+  u({ type: String })
+], $.prototype, "action", 2);
+m([
+  u({ type: Boolean })
+], $.prototype, "overrideActive", 2);
+m([
+  u({ type: String })
+], $.prototype, "overrideEnds", 2);
+m([
+  u({ type: Boolean })
+], $.prototype, "noExpand", 2);
+$ = m([
+  Q("comfort-band-tile")
+], $);
+function Qt(s) {
+  if (!s) return "";
+  const t = Date.parse(s);
+  if (Number.isNaN(t)) return "";
+  const e = t - Date.now();
+  if (e <= 0) return "";
+  const i = Math.round(e / 6e4);
+  if (i < 60) return `${i}m left`;
+  const r = Math.floor(i / 60), o = i % 60;
+  return o ? `${r}h ${o}m left` : `${r}h left`;
+}
+const At = "comfort_band", te = {
+  effective_low: "effectiveLow",
+  effective_high: "effectiveHigh",
+  room_temperature: "roomTemperature",
+  override_ends: "overrideEnds",
+  current_action: "currentAction",
+  override_active: "overrideActive",
+  manual_low: "manualLow",
+  manual_high: "manualHigh",
+  override_hours: "overrideHours",
+  deadband_below: "deadbandBelow",
+  deadband_above: "deadbandAbove",
+  min_cycle_minutes: "minCycleMinutes",
+  cancel_override: "cancelOverride",
+  enabled: "enabled"
+};
+function ee() {
+  return {
+    effectiveLow: null,
+    effectiveHigh: null,
+    roomTemperature: null,
+    overrideEnds: null,
+    currentAction: null,
+    overrideActive: null,
+    manualLow: null,
+    manualHigh: null,
+    overrideHours: null,
+    deadbandBelow: null,
+    deadbandAbove: null,
+    minCycleMinutes: null,
+    cancelOverride: null,
+    enabled: null,
+    deviceId: null,
+    deviceName: null
+  };
+}
+function ie(s, t) {
+  for (const e of Object.values(s.devices))
+    for (const [i, r] of e.identifiers)
+      if (i === t[0] && r === t[1])
+        return e;
+  return null;
+}
+function re(s, t) {
+  return Object.values(s.entities).filter(
+    (e) => e.device_id === t && e.platform === At
+  );
+}
+function se(s, t) {
+  const e = ee(), i = ie(s, [At, `zone:${t}`]);
+  if (i === null) return e;
+  e.deviceId = i.id, e.deviceName = i.name_by_user ?? i.name;
+  const r = `${t}_`;
+  for (const o of re(s, i.id)) {
+    if (!o.unique_id.startsWith(r)) continue;
+    const n = o.unique_id.slice(r.length), c = te[n];
+    c !== void 0 && (e[c] = o.entity_id);
+  }
+  return e;
+}
+var oe = Object.defineProperty, ne = Object.getOwnPropertyDescriptor, et = (s, t, e, i) => {
+  for (var r = i > 1 ? void 0 : i ? ne(t, e) : t, o = s.length - 1, n; o >= 0; o--)
+    (n = s[o]) && (r = (i ? n(t, e, r) : n(r)) || r);
+  return i && r && oe(t, e, r), r;
+};
+let U = class extends A {
+  constructor() {
+    super(...arguments), this._onTileTap = () => {
+      console.debug("comfort-band-card: tile tap (modal lands in commit 4)");
+    };
+  }
+  setConfig(s) {
+    if (!s?.zone)
+      throw new Error("comfort-band-card: `zone` is required");
+    this._config = s;
+  }
+  /** HA's panel/grid uses this to size the card. ~1 row per ~50 px of content. */
+  getCardSize() {
+    return 2;
+  }
+  render() {
+    if (!this._config || !this.hass) return y``;
+    const s = this._config.zone, t = se(this.hass, s);
+    if (t.deviceId === null)
+      return y`<div class="placeholder">
+        Comfort Band zone <code>${s}</code> not found. Add it via Settings → Devices &
+        Services.
+      </div>`;
+    const e = this._config.compact === !0, i = this._buildView(this.hass, t);
+    return y`
+      <comfort-band-tile
+        zoneName=${i.zoneName}
+        .roomTemp=${i.roomTemp}
+        .low=${i.low}
+        .high=${i.high}
+        .action=${i.action}
+        .overrideActive=${i.overrideActive}
+        .overrideEnds=${i.overrideEnds}
+        .noExpand=${e}
+        @comfort-band-tile-tap=${this._onTileTap}
+      ></comfort-band-tile>
+    `;
+  }
+  _buildView(s, t) {
+    const e = (r) => r !== null ? s.states[r] : void 0, i = (r) => {
+      const o = e(r);
+      if (!o) return NaN;
+      const n = parseFloat(o.state);
+      return Number.isFinite(n) ? n : NaN;
+    };
+    return {
+      zoneName: t.deviceName ?? this._config.zone,
+      low: i(t.effectiveLow),
+      high: i(t.effectiveHigh),
+      roomTemp: i(t.roomTemperature),
+      action: e(t.currentAction)?.state ?? "unknown",
+      overrideActive: e(t.overrideActive)?.state === "on",
+      overrideEnds: e(t.overrideEnds)?.state ?? null
+    };
+  }
+};
+U.styles = [
+  tt,
+  L`
+      :host {
+        display: block;
+      }
+      .placeholder {
+        padding: var(--cb-gap-md);
+        border-radius: var(--cb-radius-card);
+        background: var(--ha-card-background, var(--card-background-color, #fff));
+        color: var(--cb-text-secondary);
+        font-family: var(--paper-font-body1_-_font-family, sans-serif);
+        font-size: 13px;
+      }
+    `
+];
+et([
+  u({ attribute: !1 })
+], U.prototype, "hass", 2);
+et([
+  Wt()
+], U.prototype, "_config", 2);
+U = et([
+  Q("comfort-band-card")
+], U);
 (window.customCards ??= []).push({
   type: "comfort-band-card",
   name: "Comfort Band",
@@ -582,6 +969,3 @@ console.info(
   "color:white;background:#2196F3;padding:2px 4px;border-radius:3px",
   "color:#000;background:#fff;padding:2px 4px;border-radius:3px"
 );
-export {
-  x as ComfortBandCard
-};

--- a/dist/comfort-band-card.js
+++ b/dist/comfort-band-card.js
@@ -1,15 +1,15 @@
-const Z = globalThis, nt = Z.ShadowRoot && (Z.ShadyCSS === void 0 || Z.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, at = Symbol(), bt = /* @__PURE__ */ new WeakMap();
-let Pt = class {
-  constructor(t, e, r) {
-    if (this._$cssResult$ = !0, r !== at) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
-    this.cssText = t, this.t = e;
+const Q = globalThis, ft = Q.ShadowRoot && (Q.ShadyCSS === void 0 || Q.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, mt = Symbol(), xt = /* @__PURE__ */ new WeakMap();
+let Lt = class {
+  constructor(t, i, r) {
+    if (this._$cssResult$ = !0, r !== mt) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    this.cssText = t, this.t = i;
   }
   get styleSheet() {
     let t = this.o;
-    const e = this.t;
-    if (nt && t === void 0) {
-      const r = e !== void 0 && e.length === 1;
-      r && (t = bt.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && bt.set(e, t));
+    const i = this.t;
+    if (ft && t === void 0) {
+      const r = i !== void 0 && i.length === 1;
+      r && (t = xt.get(i)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && xt.set(i, t));
     }
     return t;
   }
@@ -17,72 +17,72 @@ let Pt = class {
     return this.cssText;
   }
 };
-const jt = (i) => new Pt(typeof i == "string" ? i : i + "", void 0, at), $ = (i, ...t) => {
-  const e = i.length === 1 ? i[0] : t.reduce((r, s, o) => r + ((n) => {
+const Zt = (e) => new Lt(typeof e == "string" ? e : e + "", void 0, mt), _ = (e, ...t) => {
+  const i = e.length === 1 ? e[0] : t.reduce((r, s, o) => r + ((n) => {
     if (n._$cssResult$ === !0) return n.cssText;
     if (typeof n == "number") return n;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-  })(s) + i[o + 1], i[0]);
-  return new Pt(e, i, at);
-}, Lt = (i, t) => {
-  if (nt) i.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
-  else for (const e of t) {
-    const r = document.createElement("style"), s = Z.litNonce;
-    s !== void 0 && r.setAttribute("nonce", s), r.textContent = e.cssText, i.appendChild(r);
+  })(s) + e[o + 1], e[0]);
+  return new Lt(i, e, mt);
+}, Jt = (e, t) => {
+  if (ft) e.adoptedStyleSheets = t.map((i) => i instanceof CSSStyleSheet ? i : i.styleSheet);
+  else for (const i of t) {
+    const r = document.createElement("style"), s = Q.litNonce;
+    s !== void 0 && r.setAttribute("nonce", s), r.textContent = i.cssText, e.appendChild(r);
   }
-}, gt = nt ? (i) => i : (i) => i instanceof CSSStyleSheet ? ((t) => {
-  let e = "";
-  for (const r of t.cssRules) e += r.cssText;
-  return jt(e);
-})(i) : i;
-const { is: Bt, defineProperty: It, getOwnPropertyDescriptor: Ft, getOwnPropertyNames: qt, getOwnPropertySymbols: Vt, getPrototypeOf: Kt } = Object, Q = globalThis, _t = Q.trustedTypes, Wt = _t ? _t.emptyScript : "", Gt = Q.reactiveElementPolyfillSupport, B = (i, t) => i, X = { toAttribute(i, t) {
+}, At = ft ? (e) => e : (e) => e instanceof CSSStyleSheet ? ((t) => {
+  let i = "";
+  for (const r of t.cssRules) i += r.cssText;
+  return Zt(i);
+})(e) : e;
+const { is: Yt, defineProperty: Qt, getOwnPropertyDescriptor: te, getOwnPropertyNames: ee, getOwnPropertySymbols: ie, getPrototypeOf: re } = Object, st = globalThis, Et = st.trustedTypes, se = Et ? Et.emptyScript : "", oe = st.reactiveElementPolyfillSupport, V = (e, t) => e, tt = { toAttribute(e, t) {
   switch (t) {
     case Boolean:
-      i = i ? Wt : null;
+      e = e ? se : null;
       break;
     case Object:
     case Array:
-      i = i == null ? i : JSON.stringify(i);
+      e = e == null ? e : JSON.stringify(e);
   }
-  return i;
-}, fromAttribute(i, t) {
-  let e = i;
+  return e;
+}, fromAttribute(e, t) {
+  let i = e;
   switch (t) {
     case Boolean:
-      e = i !== null;
+      i = e !== null;
       break;
     case Number:
-      e = i === null ? null : Number(i);
+      i = e === null ? null : Number(e);
       break;
     case Object:
     case Array:
       try {
-        e = JSON.parse(i);
+        i = JSON.parse(e);
       } catch {
-        e = null;
+        i = null;
       }
   }
-  return e;
-} }, ct = (i, t) => !Bt(i, t), $t = { attribute: !0, type: String, converter: X, reflect: !1, useDefault: !1, hasChanged: ct };
-Symbol.metadata ??= Symbol("metadata"), Q.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
-let k = class extends HTMLElement {
+  return i;
+} }, vt = (e, t) => !Yt(e, t), St = { attribute: !0, type: String, converter: tt, reflect: !1, useDefault: !1, hasChanged: vt };
+Symbol.metadata ??= Symbol("metadata"), st.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
+let U = class extends HTMLElement {
   static addInitializer(t) {
     this._$Ei(), (this.l ??= []).push(t);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, e = $t) {
-    if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
-      const r = Symbol(), s = this.getPropertyDescriptor(t, r, e);
-      s !== void 0 && It(this.prototype, t, s);
+  static createProperty(t, i = St) {
+    if (i.state && (i.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((i = Object.create(i)).wrapped = !0), this.elementProperties.set(t, i), !i.noAccessor) {
+      const r = Symbol(), s = this.getPropertyDescriptor(t, r, i);
+      s !== void 0 && Qt(this.prototype, t, s);
     }
   }
-  static getPropertyDescriptor(t, e, r) {
-    const { get: s, set: o } = Ft(this.prototype, t) ?? { get() {
-      return this[e];
+  static getPropertyDescriptor(t, i, r) {
+    const { get: s, set: o } = te(this.prototype, t) ?? { get() {
+      return this[i];
     }, set(n) {
-      this[e] = n;
+      this[i] = n;
     } };
     return { get: s, set(n) {
       const c = s?.call(this);
@@ -90,41 +90,41 @@ let k = class extends HTMLElement {
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? $t;
+    return this.elementProperties.get(t) ?? St;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(B("elementProperties"))) return;
-    const t = Kt(this);
+    if (this.hasOwnProperty(V("elementProperties"))) return;
+    const t = re(this);
     t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(B("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(B("properties"))) {
-      const e = this.properties, r = [...qt(e), ...Vt(e)];
-      for (const s of r) this.createProperty(s, e[s]);
+    if (this.hasOwnProperty(V("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(V("properties"))) {
+      const i = this.properties, r = [...ee(i), ...ie(i)];
+      for (const s of r) this.createProperty(s, i[s]);
     }
     const t = this[Symbol.metadata];
     if (t !== null) {
-      const e = litPropertyMetadata.get(t);
-      if (e !== void 0) for (const [r, s] of e) this.elementProperties.set(r, s);
+      const i = litPropertyMetadata.get(t);
+      if (i !== void 0) for (const [r, s] of i) this.elementProperties.set(r, s);
     }
     this._$Eh = /* @__PURE__ */ new Map();
-    for (const [e, r] of this.elementProperties) {
-      const s = this._$Eu(e, r);
-      s !== void 0 && this._$Eh.set(s, e);
+    for (const [i, r] of this.elementProperties) {
+      const s = this._$Eu(i, r);
+      s !== void 0 && this._$Eh.set(s, i);
     }
     this.elementStyles = this.finalizeStyles(this.styles);
   }
   static finalizeStyles(t) {
-    const e = [];
+    const i = [];
     if (Array.isArray(t)) {
       const r = new Set(t.flat(1 / 0).reverse());
-      for (const s of r) e.unshift(gt(s));
-    } else t !== void 0 && e.push(gt(t));
-    return e;
+      for (const s of r) i.unshift(At(s));
+    } else t !== void 0 && i.push(At(t));
+    return i;
   }
-  static _$Eu(t, e) {
-    const r = e.attribute;
+  static _$Eu(t, i) {
+    const r = i.attribute;
     return r === !1 ? void 0 : typeof r == "string" ? r : typeof t == "string" ? t.toLowerCase() : void 0;
   }
   constructor() {
@@ -140,13 +140,13 @@ let k = class extends HTMLElement {
     this._$EO?.delete(t);
   }
   _$E_() {
-    const t = /* @__PURE__ */ new Map(), e = this.constructor.elementProperties;
-    for (const r of e.keys()) this.hasOwnProperty(r) && (t.set(r, this[r]), delete this[r]);
+    const t = /* @__PURE__ */ new Map(), i = this.constructor.elementProperties;
+    for (const r of i.keys()) this.hasOwnProperty(r) && (t.set(r, this[r]), delete this[r]);
     t.size > 0 && (this._$Ep = t);
   }
   createRenderRoot() {
     const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return Lt(t, this.constructor.elementStyles), t;
+    return Jt(t, this.constructor.elementStyles), t;
   }
   connectedCallback() {
     this.renderRoot ??= this.createRenderRoot(), this.enableUpdating(!0), this._$EO?.forEach((t) => t.hostConnected?.());
@@ -156,42 +156,42 @@ let k = class extends HTMLElement {
   disconnectedCallback() {
     this._$EO?.forEach((t) => t.hostDisconnected?.());
   }
-  attributeChangedCallback(t, e, r) {
+  attributeChangedCallback(t, i, r) {
     this._$AK(t, r);
   }
-  _$ET(t, e) {
+  _$ET(t, i) {
     const r = this.constructor.elementProperties.get(t), s = this.constructor._$Eu(t, r);
     if (s !== void 0 && r.reflect === !0) {
-      const o = (r.converter?.toAttribute !== void 0 ? r.converter : X).toAttribute(e, r.type);
+      const o = (r.converter?.toAttribute !== void 0 ? r.converter : tt).toAttribute(i, r.type);
       this._$Em = t, o == null ? this.removeAttribute(s) : this.setAttribute(s, o), this._$Em = null;
     }
   }
-  _$AK(t, e) {
+  _$AK(t, i) {
     const r = this.constructor, s = r._$Eh.get(t);
     if (s !== void 0 && this._$Em !== s) {
-      const o = r.getPropertyOptions(s), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : X;
+      const o = r.getPropertyOptions(s), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : tt;
       this._$Em = s;
-      const c = n.fromAttribute(e, o.type);
+      const c = n.fromAttribute(i, o.type);
       this[s] = c ?? this._$Ej?.get(s) ?? c, this._$Em = null;
     }
   }
-  requestUpdate(t, e, r, s = !1, o) {
+  requestUpdate(t, i, r, s = !1, o) {
     if (t !== void 0) {
       const n = this.constructor;
-      if (s === !1 && (o = this[t]), r ??= n.getPropertyOptions(t), !((r.hasChanged ?? ct)(o, e) || r.useDefault && r.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, r)))) return;
-      this.C(t, e, r);
+      if (s === !1 && (o = this[t]), r ??= n.getPropertyOptions(t), !((r.hasChanged ?? vt)(o, i) || r.useDefault && r.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, r)))) return;
+      this.C(t, i, r);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
   }
-  C(t, e, { useDefault: r, reflect: s, wrapped: o }, n) {
-    r && !(this._$Ej ??= /* @__PURE__ */ new Map()).has(t) && (this._$Ej.set(t, n ?? e ?? this[t]), o !== !0 || n !== void 0) || (this._$AL.has(t) || (this.hasUpdated || r || (e = void 0), this._$AL.set(t, e)), s === !0 && this._$Em !== t && (this._$Eq ??= /* @__PURE__ */ new Set()).add(t));
+  C(t, i, { useDefault: r, reflect: s, wrapped: o }, n) {
+    r && !(this._$Ej ??= /* @__PURE__ */ new Map()).has(t) && (this._$Ej.set(t, n ?? i ?? this[t]), o !== !0 || n !== void 0) || (this._$AL.has(t) || (this.hasUpdated || r || (i = void 0), this._$AL.set(t, i)), s === !0 && this._$Em !== t && (this._$Eq ??= /* @__PURE__ */ new Set()).add(t));
   }
   async _$EP() {
     this.isUpdatePending = !0;
     try {
       await this._$ES;
-    } catch (e) {
-      Promise.reject(e);
+    } catch (i) {
+      Promise.reject(i);
     }
     const t = this.scheduleUpdate();
     return t != null && await t, !this.isUpdatePending;
@@ -213,18 +213,18 @@ let k = class extends HTMLElement {
       }
     }
     let t = !1;
-    const e = this._$AL;
+    const i = this._$AL;
     try {
-      t = this.shouldUpdate(e), t ? (this.willUpdate(e), this._$EO?.forEach((r) => r.hostUpdate?.()), this.update(e)) : this._$EM();
+      t = this.shouldUpdate(i), t ? (this.willUpdate(i), this._$EO?.forEach((r) => r.hostUpdate?.()), this.update(i)) : this._$EM();
     } catch (r) {
       throw t = !1, this._$EM(), r;
     }
-    t && this._$AE(e);
+    t && this._$AE(i);
   }
   willUpdate(t) {
   }
   _$AE(t) {
-    this._$EO?.forEach((e) => e.hostUpdated?.()), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(t)), this.updated(t);
+    this._$EO?.forEach((i) => i.hostUpdated?.()), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(t)), this.updated(t);
   }
   _$EM() {
     this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = !1;
@@ -239,79 +239,79 @@ let k = class extends HTMLElement {
     return !0;
   }
   update(t) {
-    this._$Eq &&= this._$Eq.forEach((e) => this._$ET(e, this[e])), this._$EM();
+    this._$Eq &&= this._$Eq.forEach((i) => this._$ET(i, this[i])), this._$EM();
   }
   updated(t) {
   }
   firstUpdated(t) {
   }
 };
-k.elementStyles = [], k.shadowRootOptions = { mode: "open" }, k[B("elementProperties")] = /* @__PURE__ */ new Map(), k[B("finalized")] = /* @__PURE__ */ new Map(), Gt?.({ ReactiveElement: k }), (Q.reactiveElementVersions ??= []).push("2.1.2");
-const lt = globalThis, yt = (i) => i, J = lt.trustedTypes, wt = J ? J.createPolicy("lit-html", { createHTML: (i) => i }) : void 0, Nt = "$lit$", A = `lit$${Math.random().toFixed(9).slice(2)}$`, Ot = "?" + A, Zt = `<${Ot}>`, T = document, I = () => T.createComment(""), F = (i) => i === null || typeof i != "object" && typeof i != "function", ht = Array.isArray, Xt = (i) => ht(i) || typeof i?.[Symbol.iterator] == "function", rt = `[ 	
-\f\r]`, L = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, xt = /-->/g, At = />/g, N = RegExp(`>|${rt}(?:([^\\s"'>=/]+)(${rt}*=${rt}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), Et = /'/g, St = /"/g, Tt = /^(?:script|style|textarea|title)$/i, zt = (i) => (t, ...e) => ({ _$litType$: i, strings: t, values: e }), d = zt(1), G = zt(2), M = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), Ct = /* @__PURE__ */ new WeakMap(), O = T.createTreeWalker(T, 129);
-function Ht(i, t) {
-  if (!ht(i) || !i.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return wt !== void 0 ? wt.createHTML(t) : t;
+U.elementStyles = [], U.shadowRootOptions = { mode: "open" }, U[V("elementProperties")] = /* @__PURE__ */ new Map(), U[V("finalized")] = /* @__PURE__ */ new Map(), oe?.({ ReactiveElement: U }), (st.reactiveElementVersions ??= []).push("2.1.2");
+const bt = globalThis, Pt = (e) => e, et = bt.trustedTypes, Ct = et ? et.createPolicy("lit-html", { createHTML: (e) => e }) : void 0, Ut = "$lit$", N = `lit$${Math.random().toFixed(9).slice(2)}$`, Rt = "?" + N, ne = `<${Rt}>`, H = document, K = () => H.createComment(""), W = (e) => e === null || typeof e != "object" && typeof e != "function", gt = Array.isArray, ae = (e) => gt(e) || typeof e?.[Symbol.iterator] == "function", ht = `[ 	
+\f\r]`, q = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, Tt = /-->/g, Nt = />/g, D = RegExp(`>|${ht}(?:([^\\s"'>=/]+)(${ht}*=${ht}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), Ot = /'/g, zt = /"/g, jt = /^(?:script|style|textarea|title)$/i, Bt = (e) => (t, ...i) => ({ _$litType$: e, strings: t, values: i }), l = Bt(1), Y = Bt(2), R = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), kt = /* @__PURE__ */ new WeakMap(), M = H.createTreeWalker(H, 129);
+function It(e, t) {
+  if (!gt(e) || !e.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return Ct !== void 0 ? Ct.createHTML(t) : t;
 }
-const Jt = (i, t) => {
-  const e = i.length - 1, r = [];
-  let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = L;
-  for (let c = 0; c < e; c++) {
-    const a = i[c];
-    let f, u, h = -1, m = 0;
-    for (; m < a.length && (n.lastIndex = m, u = n.exec(a), u !== null); ) m = n.lastIndex, n === L ? u[1] === "!--" ? n = xt : u[1] !== void 0 ? n = At : u[2] !== void 0 ? (Tt.test(u[2]) && (s = RegExp("</" + u[2], "g")), n = N) : u[3] !== void 0 && (n = N) : n === N ? u[0] === ">" ? (n = s ?? L, h = -1) : u[1] === void 0 ? h = -2 : (h = n.lastIndex - u[2].length, f = u[1], n = u[3] === void 0 ? N : u[3] === '"' ? St : Et) : n === St || n === Et ? n = N : n === xt || n === At ? n = L : (n = N, s = void 0);
-    const x = n === N && i[c + 1].startsWith("/>") ? " " : "";
-    o += n === L ? a + Zt : h >= 0 ? (r.push(f), a.slice(0, h) + Nt + a.slice(h) + A + x) : a + A + (h === -2 ? c : x);
+const le = (e, t) => {
+  const i = e.length - 1, r = [];
+  let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = q;
+  for (let c = 0; c < i; c++) {
+    const a = e[c];
+    let f, u, d = -1, b = 0;
+    for (; b < a.length && (n.lastIndex = b, u = n.exec(a), u !== null); ) b = n.lastIndex, n === q ? u[1] === "!--" ? n = Tt : u[1] !== void 0 ? n = Nt : u[2] !== void 0 ? (jt.test(u[2]) && (s = RegExp("</" + u[2], "g")), n = D) : u[3] !== void 0 && (n = D) : n === D ? u[0] === ">" ? (n = s ?? q, d = -1) : u[1] === void 0 ? d = -2 : (d = n.lastIndex - u[2].length, f = u[1], n = u[3] === void 0 ? D : u[3] === '"' ? zt : Ot) : n === zt || n === Ot ? n = D : n === Tt || n === Nt ? n = q : (n = D, s = void 0);
+    const T = n === D && e[c + 1].startsWith("/>") ? " " : "";
+    o += n === q ? a + ne : d >= 0 ? (r.push(f), a.slice(0, d) + Ut + a.slice(d) + N + T) : a + N + (d === -2 ? c : T);
   }
-  return [Ht(i, o + (i[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
+  return [It(e, o + (e[i] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
 };
-class q {
-  constructor({ strings: t, _$litType$: e }, r) {
+class X {
+  constructor({ strings: t, _$litType$: i }, r) {
     let s;
     this.parts = [];
     let o = 0, n = 0;
-    const c = t.length - 1, a = this.parts, [f, u] = Jt(t, e);
-    if (this.el = q.createElement(f, r), O.currentNode = this.el.content, e === 2 || e === 3) {
-      const h = this.el.content.firstChild;
-      h.replaceWith(...h.childNodes);
+    const c = t.length - 1, a = this.parts, [f, u] = le(t, i);
+    if (this.el = X.createElement(f, r), M.currentNode = this.el.content, i === 2 || i === 3) {
+      const d = this.el.content.firstChild;
+      d.replaceWith(...d.childNodes);
     }
-    for (; (s = O.nextNode()) !== null && a.length < c; ) {
+    for (; (s = M.nextNode()) !== null && a.length < c; ) {
       if (s.nodeType === 1) {
-        if (s.hasAttributes()) for (const h of s.getAttributeNames()) if (h.endsWith(Nt)) {
-          const m = u[n++], x = s.getAttribute(h).split(A), W = /([.?@])?(.*)/.exec(m);
-          a.push({ type: 1, index: o, name: W[2], strings: x, ctor: W[1] === "." ? Qt : W[1] === "?" ? te : W[1] === "@" ? ee : tt }), s.removeAttribute(h);
-        } else h.startsWith(A) && (a.push({ type: 6, index: o }), s.removeAttribute(h));
-        if (Tt.test(s.tagName)) {
-          const h = s.textContent.split(A), m = h.length - 1;
-          if (m > 0) {
-            s.textContent = J ? J.emptyScript : "";
-            for (let x = 0; x < m; x++) s.append(h[x], I()), O.nextNode(), a.push({ type: 2, index: ++o });
-            s.append(h[m], I());
+        if (s.hasAttributes()) for (const d of s.getAttributeNames()) if (d.endsWith(Ut)) {
+          const b = u[n++], T = s.getAttribute(d).split(N), J = /([.?@])?(.*)/.exec(b);
+          a.push({ type: 1, index: o, name: J[2], strings: T, ctor: J[1] === "." ? he : J[1] === "?" ? de : J[1] === "@" ? pe : ot }), s.removeAttribute(d);
+        } else d.startsWith(N) && (a.push({ type: 6, index: o }), s.removeAttribute(d));
+        if (jt.test(s.tagName)) {
+          const d = s.textContent.split(N), b = d.length - 1;
+          if (b > 0) {
+            s.textContent = et ? et.emptyScript : "";
+            for (let T = 0; T < b; T++) s.append(d[T], K()), M.nextNode(), a.push({ type: 2, index: ++o });
+            s.append(d[b], K());
           }
         }
-      } else if (s.nodeType === 8) if (s.data === Ot) a.push({ type: 2, index: o });
+      } else if (s.nodeType === 8) if (s.data === Rt) a.push({ type: 2, index: o });
       else {
-        let h = -1;
-        for (; (h = s.data.indexOf(A, h + 1)) !== -1; ) a.push({ type: 7, index: o }), h += A.length - 1;
+        let d = -1;
+        for (; (d = s.data.indexOf(N, d + 1)) !== -1; ) a.push({ type: 7, index: o }), d += N.length - 1;
       }
       o++;
     }
   }
-  static createElement(t, e) {
-    const r = T.createElement("template");
+  static createElement(t, i) {
+    const r = H.createElement("template");
     return r.innerHTML = t, r;
   }
 }
-function D(i, t, e = i, r) {
-  if (t === M) return t;
-  let s = r !== void 0 ? e._$Co?.[r] : e._$Cl;
-  const o = F(t) ? void 0 : t._$litDirective$;
-  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(i), s._$AT(i, e, r)), r !== void 0 ? (e._$Co ??= [])[r] = s : e._$Cl = s), s !== void 0 && (t = D(i, s._$AS(i, t.values), s, r)), t;
+function j(e, t, i = e, r) {
+  if (t === R) return t;
+  let s = r !== void 0 ? i._$Co?.[r] : i._$Cl;
+  const o = W(t) ? void 0 : t._$litDirective$;
+  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(e), s._$AT(e, i, r)), r !== void 0 ? (i._$Co ??= [])[r] = s : i._$Cl = s), s !== void 0 && (t = j(e, s._$AS(e, t.values), s, r)), t;
 }
-class Yt {
-  constructor(t, e) {
-    this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
+class ce {
+  constructor(t, i) {
+    this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = i;
   }
   get parentNode() {
     return this._$AM.parentNode;
@@ -320,34 +320,34 @@ class Yt {
     return this._$AM._$AU;
   }
   u(t) {
-    const { el: { content: e }, parts: r } = this._$AD, s = (t?.creationScope ?? T).importNode(e, !0);
-    O.currentNode = s;
-    let o = O.nextNode(), n = 0, c = 0, a = r[0];
+    const { el: { content: i }, parts: r } = this._$AD, s = (t?.creationScope ?? H).importNode(i, !0);
+    M.currentNode = s;
+    let o = M.nextNode(), n = 0, c = 0, a = r[0];
     for (; a !== void 0; ) {
       if (n === a.index) {
         let f;
-        a.type === 2 ? f = new V(o, o.nextSibling, this, t) : a.type === 1 ? f = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (f = new ie(o, this, t)), this._$AV.push(f), a = r[++c];
+        a.type === 2 ? f = new G(o, o.nextSibling, this, t) : a.type === 1 ? f = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (f = new ue(o, this, t)), this._$AV.push(f), a = r[++c];
       }
-      n !== a?.index && (o = O.nextNode(), n++);
+      n !== a?.index && (o = M.nextNode(), n++);
     }
-    return O.currentNode = T, s;
+    return M.currentNode = H, s;
   }
   p(t) {
-    let e = 0;
-    for (const r of this._$AV) r !== void 0 && (r.strings !== void 0 ? (r._$AI(t, r, e), e += r.strings.length - 2) : r._$AI(t[e])), e++;
+    let i = 0;
+    for (const r of this._$AV) r !== void 0 && (r.strings !== void 0 ? (r._$AI(t, r, i), i += r.strings.length - 2) : r._$AI(t[i])), i++;
   }
 }
-class V {
+class G {
   get _$AU() {
     return this._$AM?._$AU ?? this._$Cv;
   }
-  constructor(t, e, r, s) {
-    this.type = 2, this._$AH = p, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = r, this.options = s, this._$Cv = s?.isConnected ?? !0;
+  constructor(t, i, r, s) {
+    this.type = 2, this._$AH = p, this._$AN = void 0, this._$AA = t, this._$AB = i, this._$AM = r, this.options = s, this._$Cv = s?.isConnected ?? !0;
   }
   get parentNode() {
     let t = this._$AA.parentNode;
-    const e = this._$AM;
-    return e !== void 0 && t?.nodeType === 11 && (t = e.parentNode), t;
+    const i = this._$AM;
+    return i !== void 0 && t?.nodeType === 11 && (t = i.parentNode), t;
   }
   get startNode() {
     return this._$AA;
@@ -355,8 +355,8 @@ class V {
   get endNode() {
     return this._$AB;
   }
-  _$AI(t, e = this) {
-    t = D(this, t, e), F(t) ? t === p || t == null || t === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : t !== this._$AH && t !== M && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Xt(t) ? this.k(t) : this._(t);
+  _$AI(t, i = this) {
+    t = j(this, t, i), W(t) ? t === p || t == null || t === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : t !== this._$AH && t !== R && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : ae(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -365,55 +365,55 @@ class V {
     this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
   }
   _(t) {
-    this._$AH !== p && F(this._$AH) ? this._$AA.nextSibling.data = t : this.T(T.createTextNode(t)), this._$AH = t;
+    this._$AH !== p && W(this._$AH) ? this._$AA.nextSibling.data = t : this.T(H.createTextNode(t)), this._$AH = t;
   }
   $(t) {
-    const { values: e, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = q.createElement(Ht(r.h, r.h[0]), this.options)), r);
-    if (this._$AH?._$AD === s) this._$AH.p(e);
+    const { values: i, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = X.createElement(It(r.h, r.h[0]), this.options)), r);
+    if (this._$AH?._$AD === s) this._$AH.p(i);
     else {
-      const o = new Yt(s, this), n = o.u(this.options);
-      o.p(e), this.T(n), this._$AH = o;
+      const o = new ce(s, this), n = o.u(this.options);
+      o.p(i), this.T(n), this._$AH = o;
     }
   }
   _$AC(t) {
-    let e = Ct.get(t.strings);
-    return e === void 0 && Ct.set(t.strings, e = new q(t)), e;
+    let i = kt.get(t.strings);
+    return i === void 0 && kt.set(t.strings, i = new X(t)), i;
   }
   k(t) {
-    ht(this._$AH) || (this._$AH = [], this._$AR());
-    const e = this._$AH;
+    gt(this._$AH) || (this._$AH = [], this._$AR());
+    const i = this._$AH;
     let r, s = 0;
-    for (const o of t) s === e.length ? e.push(r = new V(this.O(I()), this.O(I()), this, this.options)) : r = e[s], r._$AI(o), s++;
-    s < e.length && (this._$AR(r && r._$AB.nextSibling, s), e.length = s);
+    for (const o of t) s === i.length ? i.push(r = new G(this.O(K()), this.O(K()), this, this.options)) : r = i[s], r._$AI(o), s++;
+    s < i.length && (this._$AR(r && r._$AB.nextSibling, s), i.length = s);
   }
-  _$AR(t = this._$AA.nextSibling, e) {
-    for (this._$AP?.(!1, !0, e); t !== this._$AB; ) {
-      const r = yt(t).nextSibling;
-      yt(t).remove(), t = r;
+  _$AR(t = this._$AA.nextSibling, i) {
+    for (this._$AP?.(!1, !0, i); t !== this._$AB; ) {
+      const r = Pt(t).nextSibling;
+      Pt(t).remove(), t = r;
     }
   }
   setConnected(t) {
     this._$AM === void 0 && (this._$Cv = t, this._$AP?.(t));
   }
 }
-class tt {
+class ot {
   get tagName() {
     return this.element.tagName;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
-  constructor(t, e, r, s, o) {
-    this.type = 1, this._$AH = p, this._$AN = void 0, this.element = t, this.name = e, this._$AM = s, this.options = o, r.length > 2 || r[0] !== "" || r[1] !== "" ? (this._$AH = Array(r.length - 1).fill(new String()), this.strings = r) : this._$AH = p;
+  constructor(t, i, r, s, o) {
+    this.type = 1, this._$AH = p, this._$AN = void 0, this.element = t, this.name = i, this._$AM = s, this.options = o, r.length > 2 || r[0] !== "" || r[1] !== "" ? (this._$AH = Array(r.length - 1).fill(new String()), this.strings = r) : this._$AH = p;
   }
-  _$AI(t, e = this, r, s) {
+  _$AI(t, i = this, r, s) {
     const o = this.strings;
     let n = !1;
-    if (o === void 0) t = D(this, t, e, 0), n = !F(t) || t !== this._$AH && t !== M, n && (this._$AH = t);
+    if (o === void 0) t = j(this, t, i, 0), n = !W(t) || t !== this._$AH && t !== R, n && (this._$AH = t);
     else {
       const c = t;
       let a, f;
-      for (t = o[0], a = 0; a < o.length - 1; a++) f = D(this, c[r + a], e, a), f === M && (f = this._$AH[a]), n ||= !F(f) || f !== this._$AH[a], f === p ? t = p : t !== p && (t += (f ?? "") + o[a + 1]), this._$AH[a] = f;
+      for (t = o[0], a = 0; a < o.length - 1; a++) f = j(this, c[r + a], i, a), f === R && (f = this._$AH[a]), n ||= !W(f) || f !== this._$AH[a], f === p ? t = p : t !== p && (t += (f ?? "") + o[a + 1]), this._$AH[a] = f;
     }
     n && !s && this.j(t);
   }
@@ -421,7 +421,7 @@ class tt {
     t === p ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
 }
-class Qt extends tt {
+class he extends ot {
   constructor() {
     super(...arguments), this.type = 3;
   }
@@ -429,7 +429,7 @@ class Qt extends tt {
     this.element[this.name] = t === p ? void 0 : t;
   }
 }
-class te extends tt {
+class de extends ot {
   constructor() {
     super(...arguments), this.type = 4;
   }
@@ -437,12 +437,12 @@ class te extends tt {
     this.element.toggleAttribute(this.name, !!t && t !== p);
   }
 }
-class ee extends tt {
-  constructor(t, e, r, s, o) {
-    super(t, e, r, s, o), this.type = 5;
+class pe extends ot {
+  constructor(t, i, r, s, o) {
+    super(t, i, r, s, o), this.type = 5;
   }
-  _$AI(t, e = this) {
-    if ((t = D(this, t, e, 0) ?? p) === M) return;
+  _$AI(t, i = this) {
+    if ((t = j(this, t, i, 0) ?? p) === R) return;
     const r = this._$AH, s = t === p && r !== p || t.capture !== r.capture || t.once !== r.once || t.passive !== r.passive, o = t !== p && (r === p || s);
     s && this.element.removeEventListener(this.name, this, r), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
@@ -450,30 +450,30 @@ class ee extends tt {
     typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class ie {
-  constructor(t, e, r) {
-    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = r;
+class ue {
+  constructor(t, i, r) {
+    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = i, this.options = r;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
   _$AI(t) {
-    D(this, t);
+    j(this, t);
   }
 }
-const re = lt.litHtmlPolyfillSupport;
-re?.(q, V), (lt.litHtmlVersions ??= []).push("3.3.2");
-const se = (i, t, e) => {
-  const r = e?.renderBefore ?? t;
+const fe = bt.litHtmlPolyfillSupport;
+fe?.(X, G), (bt.litHtmlVersions ??= []).push("3.3.2");
+const me = (e, t, i) => {
+  const r = i?.renderBefore ?? t;
   let s = r._$litPart$;
   if (s === void 0) {
-    const o = e?.renderBefore ?? null;
-    r._$litPart$ = s = new V(t.insertBefore(I(), o), o, void 0, e ?? {});
+    const o = i?.renderBefore ?? null;
+    r._$litPart$ = s = new G(t.insertBefore(K(), o), o, void 0, i ?? {});
   }
-  return s._$AI(i), s;
+  return s._$AI(e), s;
 };
-const dt = globalThis;
-class v extends k {
+const _t = globalThis;
+class v extends U {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -482,8 +482,8 @@ class v extends k {
     return this.renderOptions.renderBefore ??= t.firstChild, t;
   }
   update(t) {
-    const e = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = se(e, this.renderRoot, this.renderOptions);
+    const i = this.render();
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = me(i, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     super.connectedCallback(), this._$Do?.setConnected(!0);
@@ -492,58 +492,58 @@ class v extends k {
     super.disconnectedCallback(), this._$Do?.setConnected(!1);
   }
   render() {
-    return M;
+    return R;
   }
 }
-v._$litElement$ = !0, v.finalized = !0, dt.litElementHydrateSupport?.({ LitElement: v });
-const oe = dt.litElementPolyfillSupport;
-oe?.({ LitElement: v });
-(dt.litElementVersions ??= []).push("4.2.2");
-const S = (i) => (t, e) => {
-  e !== void 0 ? e.addInitializer(() => {
-    customElements.define(i, t);
-  }) : customElements.define(i, t);
+v._$litElement$ = !0, v.finalized = !0, _t.litElementHydrateSupport?.({ LitElement: v });
+const ve = _t.litElementPolyfillSupport;
+ve?.({ LitElement: v });
+(_t.litElementVersions ??= []).push("4.2.2");
+const w = (e) => (t, i) => {
+  i !== void 0 ? i.addInitializer(() => {
+    customElements.define(e, t);
+  }) : customElements.define(e, t);
 };
-const ne = { attribute: !0, type: String, converter: X, reflect: !1, hasChanged: ct }, ae = (i = ne, t, e) => {
-  const { kind: r, metadata: s } = e;
+const be = { attribute: !0, type: String, converter: tt, reflect: !1, hasChanged: vt }, ge = (e = be, t, i) => {
+  const { kind: r, metadata: s } = i;
   let o = globalThis.litPropertyMetadata.get(s);
-  if (o === void 0 && globalThis.litPropertyMetadata.set(s, o = /* @__PURE__ */ new Map()), r === "setter" && ((i = Object.create(i)).wrapped = !0), o.set(e.name, i), r === "accessor") {
-    const { name: n } = e;
+  if (o === void 0 && globalThis.litPropertyMetadata.set(s, o = /* @__PURE__ */ new Map()), r === "setter" && ((e = Object.create(e)).wrapped = !0), o.set(i.name, e), r === "accessor") {
+    const { name: n } = i;
     return { set(c) {
       const a = t.get.call(this);
-      t.set.call(this, c), this.requestUpdate(n, a, i, !0, c);
+      t.set.call(this, c), this.requestUpdate(n, a, e, !0, c);
     }, init(c) {
-      return c !== void 0 && this.C(n, void 0, i, c), c;
+      return c !== void 0 && this.C(n, void 0, e, c), c;
     } };
   }
   if (r === "setter") {
-    const { name: n } = e;
+    const { name: n } = i;
     return function(c) {
       const a = this[n];
-      t.call(this, c), this.requestUpdate(n, a, i, !0, c);
+      t.call(this, c), this.requestUpdate(n, a, e, !0, c);
     };
   }
   throw Error("Unsupported decorator location: " + r);
 };
-function l(i) {
-  return (t, e) => typeof e == "object" ? ae(i, t, e) : ((r, s, o) => {
+function h(e) {
+  return (t, i) => typeof i == "object" ? ge(e, t, i) : ((r, s, o) => {
     const n = s.hasOwnProperty(o);
     return s.constructor.createProperty(o, r), n ? Object.getOwnPropertyDescriptor(s, o) : void 0;
-  })(i, t, e);
+  })(e, t, i);
 }
-function H(i) {
-  return l({ ...i, state: !0, attribute: !1 });
+function m(e) {
+  return h({ ...e, state: !0, attribute: !1 });
 }
-const ce = (i, t, e) => (e.configurable = !0, e.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(i, t, e), e);
-function pt(i, t) {
-  return (e, r, s) => {
-    const o = (n) => n.renderRoot?.querySelector(i) ?? null;
-    return ce(e, r, { get() {
+const _e = (e, t, i) => (i.configurable = !0, i.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(e, t, i), i);
+function nt(e, t) {
+  return (i, r, s) => {
+    const o = (n) => n.renderRoot?.querySelector(e) ?? null;
+    return _e(i, r, { get() {
       return o(this);
     } });
   };
 }
-const C = $`
+const x = _`
   :host {
     --cb-action-heating: var(--cb-color-heat, var(--state-climate-heat-color, #d9603f));
     --cb-action-cooling: var(--cb-color-cool, var(--state-climate-cool-color, #2f7fcc));
@@ -562,8 +562,8 @@ const C = $`
     --cb-gap-lg: 16px;
   }
 `;
-function ut(i) {
-  switch (i) {
+function $t(e) {
+  switch (e) {
     case "heating":
       return "var(--cb-action-heating)";
     case "cooling":
@@ -574,40 +574,40 @@ function ut(i) {
       return "var(--cb-action-unknown)";
   }
 }
-function ft(i) {
-  return i === "heating" || i === "cooling" || i === "idle" ? i : "unknown";
+function yt(e) {
+  return e === "heating" || e === "cooling" || e === "idle" ? e : "unknown";
 }
-function kt(i) {
-  return i.charAt(0).toUpperCase() + i.slice(1);
+function Ft(e) {
+  return e.charAt(0).toUpperCase() + e.slice(1);
 }
-var le = Object.defineProperty, he = Object.getOwnPropertyDescriptor, K = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? he(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && le(t, e, s), s;
+var $e = Object.defineProperty, ye = Object.getOwnPropertyDescriptor, Z = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? ye(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && $e(t, i, s), s;
 };
-const ot = 15, Mt = 28, de = Mt - ot;
-function st(i) {
-  return Number.isNaN(i) || !Number.isFinite(i) ? 0 : (Math.max(ot, Math.min(Mt, i)) - ot) / de * 100;
+const ut = 15, qt = 28, we = qt - ut;
+function dt(e) {
+  return Number.isNaN(e) || !Number.isFinite(e) ? 0 : (Math.max(ut, Math.min(qt, e)) - ut) / we * 100;
 }
-let z = class extends v {
+let L = class extends v {
   constructor() {
     super(...arguments), this.low = NaN, this.high = NaN, this.room = NaN, this.action = "unknown";
   }
   render() {
-    const i = ft(this.action), t = ut(i), e = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = e ? st(this.low) : 0, n = r ? st(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), f = s ? st(this.room) : 50, u = (m) => Number.isFinite(m) ? `${m.toFixed(1)}°` : "—", h = `Comfort band gauge: low ${u(this.low)}, room ${u(this.room)}, high ${u(this.high)}, action ${i}`;
-    return d`
-      <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${h}>
-        ${G`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
-        ${e && r ? G`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
-        ${s ? G`<circle cx=${f} cy="12" r="4.5" fill=${t}></circle>` : null}
-        ${s ? G`<circle class="marker-ring" cx=${f} cy="12" r="3" stroke=${t}></circle>` : null}
+    const e = yt(this.action), t = $t(e), i = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = i ? dt(this.low) : 0, n = r ? dt(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), f = s ? dt(this.room) : 50, u = (b) => Number.isFinite(b) ? `${b.toFixed(1)}°` : "—", d = `Comfort band gauge: low ${u(this.low)}, room ${u(this.room)}, high ${u(this.high)}, action ${e}`;
+    return l`
+      <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${d}>
+        ${Y`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
+        ${i && r ? Y`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
+        ${s ? Y`<circle cx=${f} cy="12" r="4.5" fill=${t}></circle>` : null}
+        ${s ? Y`<circle class="marker-ring" cx=${f} cy="12" r="3" stroke=${t}></circle>` : null}
       </svg>
     `;
   }
 };
-z.styles = [
-  C,
-  $`
+L.styles = [
+  x,
+  _`
       :host {
         display: block;
         width: 100%;
@@ -635,51 +635,51 @@ z.styles = [
       }
     `
 ];
-K([
-  l({ type: Number })
-], z.prototype, "low", 2);
-K([
-  l({ type: Number })
-], z.prototype, "high", 2);
-K([
-  l({ type: Number })
-], z.prototype, "room", 2);
-K([
-  l({ type: String })
-], z.prototype, "action", 2);
-z = K([
-  S("band-gauge")
-], z);
-var pe = Object.defineProperty, ue = Object.getOwnPropertyDescriptor, y = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? ue(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && pe(t, e, s), s;
+Z([
+  h({ type: Number })
+], L.prototype, "low", 2);
+Z([
+  h({ type: Number })
+], L.prototype, "high", 2);
+Z([
+  h({ type: Number })
+], L.prototype, "room", 2);
+Z([
+  h({ type: String })
+], L.prototype, "action", 2);
+L = Z([
+  w("band-gauge")
+], L);
+var xe = Object.defineProperty, Ae = Object.getOwnPropertyDescriptor, P = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Ae(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && xe(t, i, s), s;
 };
-let b = class extends v {
+let $ = class extends v {
   constructor() {
     super(...arguments), this.zoneName = "", this.roomTemp = NaN, this.low = NaN, this.high = NaN, this.action = "unknown", this.overrideActive = !1, this.overrideEnds = null, this.noExpand = !1;
   }
-  _onTap(i) {
-    this.noExpand || i instanceof KeyboardEvent && i.key !== "Enter" && i.key !== " " || (i.preventDefault(), this.dispatchEvent(new CustomEvent("comfort-band-tile-tap", { bubbles: !0, composed: !0 })));
+  _onTap(e) {
+    this.noExpand || e instanceof KeyboardEvent && e.key !== "Enter" && e.key !== " " || (e.preventDefault(), this.dispatchEvent(new CustomEvent("comfort-band-tile-tap", { bubbles: !0, composed: !0 })));
   }
   _renderRoomTemp() {
     return Number.isFinite(this.roomTemp) ? `${this.roomTemp.toFixed(1)}°` : "—";
   }
   _renderOverridePill() {
     if (!this.overrideActive) return null;
-    const i = fe(this.overrideEnds);
-    return d`<div class="override-pill">Override${i ? ` · ${i}` : ""}</div>`;
+    const e = Ee(this.overrideEnds);
+    return l`<div class="override-pill">Override${e ? ` · ${e}` : ""}</div>`;
   }
   _renderActionChip() {
-    const i = ft(this.action);
-    if (i === "idle" || i === "unknown") return null;
-    const t = ut(i);
-    return d`<span class="action-chip" style="background:${t}">
-      ${kt(i)}
+    const e = yt(this.action);
+    if (e === "idle" || e === "unknown") return null;
+    const t = $t(e);
+    return l`<span class="action-chip" style="background:${t}">
+      ${Ft(e)}
     </span>`;
   }
   render() {
-    return d`
+    return l`
       <div
         class="tile ${this.noExpand ? "no-expand" : ""}"
         role="${this.noExpand ? "group" : "button"}"
@@ -707,9 +707,9 @@ let b = class extends v {
     `;
   }
 };
-b.styles = [
-  C,
-  $`
+$.styles = [
+  x,
+  _`
       :host {
         display: block;
       }
@@ -783,137 +783,137 @@ b.styles = [
       }
     `
 ];
-y([
-  l({ type: String })
-], b.prototype, "zoneName", 2);
-y([
-  l({ type: Number })
-], b.prototype, "roomTemp", 2);
-y([
-  l({ type: Number })
-], b.prototype, "low", 2);
-y([
-  l({ type: Number })
-], b.prototype, "high", 2);
-y([
-  l({ type: String })
-], b.prototype, "action", 2);
-y([
-  l({ type: Boolean })
-], b.prototype, "overrideActive", 2);
-y([
-  l({ type: String })
-], b.prototype, "overrideEnds", 2);
-y([
-  l({ type: Boolean })
-], b.prototype, "noExpand", 2);
-b = y([
-  S("comfort-band-tile")
-], b);
-function fe(i) {
-  if (!i) return "";
-  const t = Date.parse(i);
+P([
+  h({ type: String })
+], $.prototype, "zoneName", 2);
+P([
+  h({ type: Number })
+], $.prototype, "roomTemp", 2);
+P([
+  h({ type: Number })
+], $.prototype, "low", 2);
+P([
+  h({ type: Number })
+], $.prototype, "high", 2);
+P([
+  h({ type: String })
+], $.prototype, "action", 2);
+P([
+  h({ type: Boolean })
+], $.prototype, "overrideActive", 2);
+P([
+  h({ type: String })
+], $.prototype, "overrideEnds", 2);
+P([
+  h({ type: Boolean })
+], $.prototype, "noExpand", 2);
+$ = P([
+  w("comfort-band-tile")
+], $);
+function Ee(e) {
+  if (!e) return "";
+  const t = Date.parse(e);
   if (Number.isNaN(t)) return "";
-  const e = t - Date.now();
-  if (e <= 0) return "";
-  const r = Math.round(e / 6e4);
+  const i = t - Date.now();
+  if (i <= 0) return "";
+  const r = Math.round(i / 6e4);
   if (r < 60) return `${r}m left`;
   const s = Math.floor(r / 60), o = r % 60;
   return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-var me = Object.defineProperty, ve = Object.getOwnPropertyDescriptor, w = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? ve(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && me(t, e, s), s;
+var Se = Object.defineProperty, Pe = Object.getOwnPropertyDescriptor, C = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Pe(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && Se(t, i, s), s;
 };
-let g = class extends v {
+let y = class extends v {
   constructor() {
-    super(...arguments), this.min = 16, this.max = 26, this.step = 0.5, this.low = 19, this.high = 22, this.unit = "°", this._dragging = null, this._onThumbPointerDown = (i, t) => {
-      i.preventDefault();
-      const e = i.currentTarget;
-      e.setPointerCapture(i.pointerId), this._dragging = t;
+    super(...arguments), this.min = 16, this.max = 26, this.step = 0.5, this.low = 19, this.high = 22, this.unit = "°", this._dragging = null, this._onThumbPointerDown = (e, t) => {
+      e.preventDefault();
+      const i = e.currentTarget;
+      i.setPointerCapture(e.pointerId), this._dragging = t;
       const r = (o) => {
         this._setHandle(t, this._xToValue(o.clientX)) && this._fire("input");
       }, s = (o) => {
-        e.releasePointerCapture(o.pointerId), e.removeEventListener("pointermove", r), e.removeEventListener("pointerup", s), e.removeEventListener("pointercancel", s), this._dragging = null, this._fire("change");
+        i.releasePointerCapture(o.pointerId), i.removeEventListener("pointermove", r), i.removeEventListener("pointerup", s), i.removeEventListener("pointercancel", s), this._dragging = null, this._fire("change");
       };
-      e.addEventListener("pointermove", r), e.addEventListener("pointerup", s), e.addEventListener("pointercancel", s);
-    }, this._onTrackPointerDown = (i) => {
-      if (i.target.classList.contains("thumb")) return;
-      const t = this._xToValue(i.clientX), e = (this.low + this.high) / 2, r = t < e ? "low" : "high";
+      i.addEventListener("pointermove", r), i.addEventListener("pointerup", s), i.addEventListener("pointercancel", s);
+    }, this._onTrackPointerDown = (e) => {
+      if (e.target.classList.contains("thumb")) return;
+      const t = this._xToValue(e.clientX), i = (this.low + this.high) / 2, r = t < i ? "low" : "high";
       this._setHandle(r, t) && this._fire("change");
-    }, this._onKeyDown = (i, t) => {
-      let e = 0;
-      switch (i.key) {
+    }, this._onKeyDown = (e, t) => {
+      let i = 0;
+      switch (e.key) {
         case "ArrowLeft":
         case "ArrowDown":
-          e = -this.step;
+          i = -this.step;
           break;
         case "ArrowRight":
         case "ArrowUp":
-          e = this.step;
+          i = this.step;
           break;
         case "Home":
-          i.preventDefault(), this._setHandle(t, this.min) && this._fire("change");
+          e.preventDefault(), this._setHandle(t, this.min) && this._fire("change");
           return;
         case "End":
-          i.preventDefault(), this._setHandle(t, this.max) && this._fire("change");
+          e.preventDefault(), this._setHandle(t, this.max) && this._fire("change");
           return;
         default:
           return;
       }
-      i.preventDefault();
+      e.preventDefault();
       const r = t === "low" ? this.low : this.high;
-      this._setHandle(t, r + e) && this._fire("change");
+      this._setHandle(t, r + i) && this._fire("change");
     };
   }
-  _pct(i) {
+  _pct(e) {
     const t = this.max - this.min;
-    return t <= 0 ? 0 : (i - this.min) / t * 100;
+    return t <= 0 ? 0 : (e - this.min) / t * 100;
   }
-  _snap(i) {
-    const t = Math.round((i - this.min) / this.step) * this.step + this.min;
+  _snap(e) {
+    const t = Math.round((e - this.min) / this.step) * this.step + this.min;
     return Math.max(this.min, Math.min(this.max, t));
   }
-  _setHandle(i, t) {
-    const e = this._snap(t);
-    if (i === "low") {
-      const r = Math.min(e, this.high - this.step);
+  _setHandle(e, t) {
+    const i = this._snap(t);
+    if (e === "low") {
+      const r = Math.min(i, this.high - this.step);
       if (r === this.low) return !1;
       this.low = r;
     } else {
-      const r = Math.max(e, this.low + this.step);
+      const r = Math.max(i, this.low + this.step);
       if (r === this.high) return !1;
       this.high = r;
     }
     return !0;
   }
-  _xToValue(i) {
+  _xToValue(e) {
     const t = this._track?.getBoundingClientRect();
     if (!t || t.width === 0) return this.min;
-    const e = Math.max(0, Math.min(1, (i - t.left) / t.width));
-    return this.min + e * (this.max - this.min);
+    const i = Math.max(0, Math.min(1, (e - t.left) / t.width));
+    return this.min + i * (this.max - this.min);
   }
-  _fire(i) {
+  _fire(e) {
     this.dispatchEvent(
-      new CustomEvent(i, {
+      new CustomEvent(e, {
         detail: { low: this.low, high: this.high },
         bubbles: !0,
         composed: !0
       })
     );
   }
-  _fmt(i) {
-    return `${i.toFixed(1)}${this.unit}`;
+  _fmt(e) {
+    return `${e.toFixed(1)}${this.unit}`;
   }
   render() {
-    const i = this._pct(this.low), t = this._pct(this.high);
-    return d`
+    const e = this._pct(this.low), t = this._pct(this.high);
+    return l`
       <div class="track" @pointerdown=${this._onTrackPointerDown}>
-        <div class="fill" style="left:${i}%; width:${t - i}%"></div>
+        <div class="fill" style="left:${e}%; width:${t - e}%"></div>
         <div
           class="thumb ${this._dragging === "low" ? "dragging" : ""}"
-          style="left:${i}%"
+          style="left:${e}%"
           tabindex="0"
           role="slider"
           aria-label="Lower bound"
@@ -921,8 +921,8 @@ let g = class extends v {
           aria-valuemax=${this.high - this.step}
           aria-valuenow=${this.low}
           aria-valuetext=${this._fmt(this.low)}
-          @pointerdown=${(e) => this._onThumbPointerDown(e, "low")}
-          @keydown=${(e) => this._onKeyDown(e, "low")}
+          @pointerdown=${(i) => this._onThumbPointerDown(i, "low")}
+          @keydown=${(i) => this._onKeyDown(i, "low")}
         ></div>
         <div
           class="thumb ${this._dragging === "high" ? "dragging" : ""}"
@@ -934,8 +934,8 @@ let g = class extends v {
           aria-valuemax=${this.max}
           aria-valuenow=${this.high}
           aria-valuetext=${this._fmt(this.high)}
-          @pointerdown=${(e) => this._onThumbPointerDown(e, "high")}
-          @keydown=${(e) => this._onKeyDown(e, "high")}
+          @pointerdown=${(i) => this._onThumbPointerDown(i, "high")}
+          @keydown=${(i) => this._onKeyDown(i, "high")}
         ></div>
       </div>
       <div class="label-row">
@@ -945,9 +945,9 @@ let g = class extends v {
     `;
   }
 };
-g.styles = [
-  C,
-  $`
+y.styles = [
+  x,
+  _`
       :host {
         display: block;
         padding: 16px 12px;
@@ -1008,91 +1008,100 @@ g.styles = [
       }
     `
 ];
-w([
-  l({ type: Number })
-], g.prototype, "min", 2);
-w([
-  l({ type: Number })
-], g.prototype, "max", 2);
-w([
-  l({ type: Number })
-], g.prototype, "step", 2);
-w([
-  l({ type: Number })
-], g.prototype, "low", 2);
-w([
-  l({ type: Number })
-], g.prototype, "high", 2);
-w([
-  l({ type: String })
-], g.prototype, "unit", 2);
-w([
-  H()
-], g.prototype, "_dragging", 2);
-w([
-  pt(".track")
-], g.prototype, "_track", 2);
-g = w([
-  S("dual-handle-slider")
-], g);
-const mt = "comfort_band";
-function be(i, t) {
-  const e = { zone: t.zone };
-  return t.low !== void 0 && (e.low = t.low), t.high !== void 0 && (e.high = t.high), t.hours !== void 0 && (e.hours = t.hours), i.callService(mt, "start_override", e);
+C([
+  h({ type: Number })
+], y.prototype, "min", 2);
+C([
+  h({ type: Number })
+], y.prototype, "max", 2);
+C([
+  h({ type: Number })
+], y.prototype, "step", 2);
+C([
+  h({ type: Number })
+], y.prototype, "low", 2);
+C([
+  h({ type: Number })
+], y.prototype, "high", 2);
+C([
+  h({ type: String })
+], y.prototype, "unit", 2);
+C([
+  m()
+], y.prototype, "_dragging", 2);
+C([
+  nt(".track")
+], y.prototype, "_track", 2);
+y = C([
+  w("dual-handle-slider")
+], y);
+const at = "comfort_band";
+function Ce(e, t) {
+  return e.callWS({
+    type: "comfort_band/get_schedule",
+    ...t
+  });
 }
-function ge(i, t) {
-  return i.callService(mt, "cancel_override", { ...t });
+function Te(e, t) {
+  return e.callService(at, "set_schedule", { ...t });
 }
-function _e(i, t) {
-  return i.callService(mt, "set_profile", { ...t });
+function Ne(e, t) {
+  const i = { zone: t.zone };
+  return t.low !== void 0 && (i.low = t.low), t.high !== void 0 && (i.high = t.high), t.hours !== void 0 && (i.hours = t.hours), e.callService(at, "start_override", i);
 }
-var $e = Object.defineProperty, ye = Object.getOwnPropertyDescriptor, j = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? ye(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && $e(t, e, s), s;
+function Oe(e, t) {
+  return e.callService(at, "cancel_override", { ...t });
+}
+function ze(e, t) {
+  return e.callService(at, "set_profile", { ...t });
+}
+var ke = Object.defineProperty, De = Object.getOwnPropertyDescriptor, F = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? De(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && ke(t, i, s), s;
 };
-const we = [1, 3, 6];
-let E = class extends v {
+const Me = [1, 3, 6];
+let O = class extends v {
   constructor() {
-    super(...arguments), this.zone = "", this._pendingLow = null, this._pendingHigh = null, this._onSliderInput = (i) => {
-      this._pendingLow = i.detail.low, this._pendingHigh = i.detail.high;
-    }, this._onSliderChange = (i) => {
-      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, be(this.hass, {
+    super(...arguments), this.zone = "", this._pendingLow = null, this._pendingHigh = null, this._onSliderInput = (e) => {
+      this._pendingLow = e.detail.low, this._pendingHigh = e.detail.high;
+    }, this._onSliderChange = (e) => {
+      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, Ne(this.hass, {
         zone: this.zone,
-        low: i.detail.low,
-        high: i.detail.high
+        low: e.detail.low,
+        high: e.detail.high
       }));
     }, this._onCancel = () => {
-      !this.hass || !this.zone || ge(this.hass, { zone: this.zone });
-    }, this._onPickHours = (i) => {
+      !this.hass || !this.zone || Oe(this.hass, { zone: this.zone });
+    }, this._onPickHours = (e) => {
       !this.hass || !this.entities?.overrideHours || this.hass.callService("number", "set_value", {
         entity_id: this.entities.overrideHours,
-        value: i
+        value: e
       });
     };
   }
   get _stateOf() {
-    const i = this.hass?.states ?? {};
-    return (t) => t !== null ? i[t] : void 0;
+    const e = this.hass?.states ?? {};
+    return (t) => t !== null ? e[t] : void 0;
   }
-  _numericState(i) {
-    const t = this._stateOf(i);
+  _numericState(e) {
+    const t = this._stateOf(e);
     if (!t) return NaN;
-    const e = parseFloat(t.state);
-    return Number.isFinite(e) ? e : NaN;
+    const i = parseFloat(t.state);
+    return Number.isFinite(i) ? i : NaN;
   }
   render() {
     if (!this.hass || !this.entities) return p;
-    const i = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), e = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", c = this._stateOf(this.entities.overrideActive)?.state === "on", a = this._pendingLow ?? (Number.isFinite(i) ? i : 19), f = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), u = ft(n), h = u !== "idle" && u !== "unknown";
-    return d`
+    const e = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), i = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", c = this._stateOf(this.entities.overrideActive)?.state === "on", a = this._pendingLow ?? (Number.isFinite(e) ? e : 19), f = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), u = yt(n), d = u !== "idle" && u !== "unknown";
+    return l`
       <div class="header-row">
         <div class="room-temp">${Number.isFinite(s) ? `${s.toFixed(1)}°` : "—"}</div>
-        ${h ? d`<span class="action-chip" style="background:${ut(u)}"
-              >${kt(u)}</span
+        ${d ? l`<span class="action-chip" style="background:${$t(u)}"
+              >${Ft(u)}</span
             >` : p}
       </div>
       <div class="gauge-row">
-        <band-gauge .low=${e} .high=${r} .room=${s} .action=${n}></band-gauge>
+        <band-gauge .low=${i} .high=${r} .room=${s} .action=${n}></band-gauge>
       </div>
 
       <section>
@@ -1111,28 +1120,28 @@ let E = class extends v {
       ${this._renderOverrideSection(c)} ${this._renderHoursSection(o)}
     `;
   }
-  _renderOverrideSection(i) {
-    if (!i) return p;
-    const t = this._stateOf(this.entities.overrideEnds)?.state, e = xe(t ?? null);
-    return d`
+  _renderOverrideSection(e) {
+    if (!e) return p;
+    const t = this._stateOf(this.entities.overrideEnds)?.state, i = He(t ?? null);
+    return l`
       <section>
         <h3>Override</h3>
         <div class="override-row">
-          <span>Active${e ? ` · ${e}` : ""}</span>
+          <span>Active${i ? ` · ${i}` : ""}</span>
           <button class="button secondary" @click=${this._onCancel}>Cancel</button>
         </div>
       </section>
     `;
   }
-  _renderHoursSection(i) {
-    return this.entities?.overrideHours ? d`
+  _renderHoursSection(e) {
+    return this.entities?.overrideHours ? l`
       <section>
         <h3>Override duration</h3>
         <div class="preset-row">
-          ${we.map(
-      (t) => d`
+          ${Me.map(
+      (t) => l`
               <button
-                class="preset ${i === t ? "active" : ""}"
+                class="preset ${e === t ? "active" : ""}"
                 @click=${() => this._onPickHours(t)}
               >
                 ${t} h
@@ -1144,9 +1153,9 @@ let E = class extends v {
     ` : p;
   }
 };
-E.styles = [
-  C,
-  $`
+O.styles = [
+  x,
+  _`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1232,36 +1241,36 @@ E.styles = [
       }
     `
 ];
-j([
-  l({ attribute: !1 })
-], E.prototype, "hass", 2);
-j([
-  l({ type: String })
-], E.prototype, "zone", 2);
-j([
-  l({ attribute: !1 })
-], E.prototype, "entities", 2);
-j([
-  H()
-], E.prototype, "_pendingLow", 2);
-j([
-  H()
-], E.prototype, "_pendingHigh", 2);
-E = j([
-  S("comfort-band-now-tab")
-], E);
-function xe(i) {
-  if (!i) return "";
-  const t = Date.parse(i);
+F([
+  h({ attribute: !1 })
+], O.prototype, "hass", 2);
+F([
+  h({ type: String })
+], O.prototype, "zone", 2);
+F([
+  h({ attribute: !1 })
+], O.prototype, "entities", 2);
+F([
+  m()
+], O.prototype, "_pendingLow", 2);
+F([
+  m()
+], O.prototype, "_pendingHigh", 2);
+O = F([
+  w("comfort-band-now-tab")
+], O);
+function He(e) {
+  if (!e) return "";
+  const t = Date.parse(e);
   if (Number.isNaN(t)) return "";
-  const e = t - Date.now();
-  if (e <= 0) return "";
-  const r = Math.round(e / 6e4);
+  const i = t - Date.now();
+  if (i <= 0) return "";
+  const r = Math.round(i / 6e4);
   if (r < 60) return `${r}m left`;
   const s = Math.floor(r / 60), o = r % 60;
   return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-const vt = "comfort_band", Ae = {
+const wt = "comfort_band", Le = {
   effective_low: "effectiveLow",
   effective_high: "effectiveHigh",
   room_temperature: "roomTemperature",
@@ -1277,7 +1286,7 @@ const vt = "comfort_band", Ae = {
   cancel_override: "cancelOverride",
   enabled: "enabled"
 };
-function Ee() {
+function Ue() {
   return {
     effectiveLow: null,
     effectiveHigh: null,
@@ -1297,57 +1306,57 @@ function Ee() {
     deviceName: null
   };
 }
-function Dt(i, t) {
-  for (const e of Object.values(i.devices))
-    for (const [r, s] of e.identifiers)
+function Vt(e, t) {
+  for (const i of Object.values(e.devices))
+    for (const [r, s] of i.identifiers)
       if (r === t[0] && s === t[1])
-        return e;
+        return i;
   return null;
 }
-function Ut(i, t) {
-  return Object.values(i.entities).filter(
-    (e) => e.device_id === t && e.platform === vt
+function Kt(e, t) {
+  return Object.values(e.entities).filter(
+    (i) => i.device_id === t && i.platform === wt
   );
 }
-function Se(i, t) {
-  const e = Ee(), r = Dt(i, [vt, `zone:${t}`]);
-  if (r === null) return e;
-  e.deviceId = r.id, e.deviceName = r.name_by_user ?? r.name;
+function Re(e, t) {
+  const i = Ue(), r = Vt(e, [wt, `zone:${t}`]);
+  if (r === null) return i;
+  i.deviceId = r.id, i.deviceName = r.name_by_user ?? r.name;
   const s = `${t}_`;
-  for (const o of Ut(i, r.id)) {
+  for (const o of Kt(e, r.id)) {
     if (!o.unique_id.startsWith(s)) continue;
-    const n = o.unique_id.slice(s.length), c = Ae[n];
-    c !== void 0 && (e[c] = o.entity_id);
+    const n = o.unique_id.slice(s.length), c = Le[n];
+    c !== void 0 && (i[c] = o.entity_id);
   }
-  return e;
+  return i;
 }
-function Ce(i) {
-  const t = Dt(i, [vt, "profile_manager"]);
+function Wt(e) {
+  const t = Vt(e, [wt, "profile_manager"]);
   if (t === null) return null;
-  for (const e of Ut(i, t.id))
-    if (e.unique_id === "profile_manager_active_profile")
-      return e.entity_id;
+  for (const i of Kt(e, t.id))
+    if (i.unique_id === "profile_manager_active_profile")
+      return i.entity_id;
   return null;
 }
-var Pe = Object.defineProperty, Ne = Object.getOwnPropertyDescriptor, Rt = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? Ne(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && Pe(t, e, s), s;
+var je = Object.defineProperty, Be = Object.getOwnPropertyDescriptor, Xt = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Be(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && je(t, i, s), s;
 };
-let Y = class extends v {
-  _onSelect(i) {
-    this.hass && _e(this.hass, { profile: i });
+let it = class extends v {
+  _onSelect(e) {
+    this.hass && ze(this.hass, { profile: e });
   }
   render() {
     if (!this.hass) return p;
-    const i = Ce(this.hass);
-    if (i === null)
-      return d`<div class="empty">Profile manager not registered yet.</div>`;
-    const t = this.hass.states[i], e = t?.attributes.options, r = Array.isArray(e) ? e.filter((o) => typeof o == "string") : [], s = t?.state ?? "";
-    return r.length === 0 ? d`<div class="empty">No profiles configured.</div>` : d`
+    const e = Wt(this.hass);
+    if (e === null)
+      return l`<div class="empty">Profile manager not registered yet.</div>`;
+    const t = this.hass.states[e], i = t?.attributes.options, r = Array.isArray(i) ? i.filter((o) => typeof o == "string") : [], s = t?.state ?? "";
+    return r.length === 0 ? l`<div class="empty">No profiles configured.</div>` : l`
       <ul role="listbox" aria-label="Profiles">
         ${r.map(
-      (o) => d`
+      (o) => l`
             <li
               role="option"
               tabindex="0"
@@ -1359,7 +1368,7 @@ let Y = class extends v {
       }}
             >
               <span class="name">${o}</span>
-              ${o === s ? d`<span class="badge">Active</span>` : p}
+              ${o === s ? l`<span class="badge">Active</span>` : p}
             </li>
           `
     )}
@@ -1368,9 +1377,9 @@ let Y = class extends v {
     `;
   }
 };
-Y.styles = [
-  C,
-  $`
+it.styles = [
+  x,
+  _`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1426,30 +1435,30 @@ Y.styles = [
       }
     `
 ];
-Rt([
-  l({ attribute: !1 })
-], Y.prototype, "hass", 2);
-Y = Rt([
-  S("comfort-band-profiles-tab")
-], Y);
-var Oe = Object.defineProperty, Te = Object.getOwnPropertyDescriptor, et = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? Te(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && Oe(t, e, s), s;
+Xt([
+  h({ attribute: !1 })
+], it.prototype, "hass", 2);
+it = Xt([
+  w("comfort-band-profiles-tab")
+], it);
+var Ie = Object.defineProperty, Fe = Object.getOwnPropertyDescriptor, lt = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Fe(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && Ie(t, i, s), s;
 };
-let U = class extends v {
+let B = class extends v {
   constructor() {
     super(...arguments), this._graphAvailable = null, this._graphCard = null;
   }
   async firstUpdated() {
     await this._maybeMountGraph();
   }
-  updated(i) {
-    (i.has("entities") || i.has("hass")) && this._maybeMountGraph();
+  updated(e) {
+    (e.has("entities") || e.has("hass")) && this._maybeMountGraph();
   }
   async _maybeMountGraph() {
-    const i = this.entities?.roomTemperature;
-    if (!(!i || !this.hass)) {
+    const e = this.entities?.roomTemperature;
+    if (!(!e || !this.hass)) {
       if (this._graphCard) {
         this._graphCard.hass = this.hass;
         return;
@@ -1459,35 +1468,35 @@ let U = class extends v {
         return;
       }
       try {
-        const e = (await window.loadCardHelpers()).createCardElement({
+        const i = (await window.loadCardHelpers()).createCardElement({
           type: "history-graph",
-          entities: [i],
+          entities: [e],
           hours_to_show: 24
         });
-        e.hass = this.hass;
+        i.hass = this.hass;
         const r = this.renderRoot.querySelector(".graph-container");
-        r && (r.innerHTML = "", r.appendChild(e), this._graphCard = e, this._graphAvailable = !0);
+        r && (r.innerHTML = "", r.appendChild(i), this._graphCard = i, this._graphAvailable = !0);
       } catch {
         this._graphAvailable = !1;
       }
     }
   }
   render() {
-    const i = this.entities?.roomTemperature;
-    return i ? d`
+    const e = this.entities?.roomTemperature;
+    return e ? l`
       <div class="graph-container"></div>
-      ${this._graphAvailable === !1 ? d`<div class="fallback">
-              Inline graph unavailable.
-              <a href="/history?entity_id=${i}" target="_blank" rel="noopener"
-                >Open in HA history →</a
-              >
-            </div>` : p}
-    ` : d`<div class="empty">No room temperature sensor for this zone.</div>`;
+      ${this._graphAvailable === !1 ? l`<div class="fallback">
+            Inline graph unavailable.
+            <a href="/history?entity_id=${e}" target="_blank" rel="noopener"
+              >Open in HA history →</a
+            >
+          </div>` : p}
+    ` : l`<div class="empty">No room temperature sensor for this zone.</div>`;
   }
 };
-U.styles = [
-  C,
-  $`
+B.styles = [
+  x,
+  _`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1512,37 +1521,624 @@ U.styles = [
       }
     `
 ];
-et([
-  l({ attribute: !1 })
-], U.prototype, "hass", 2);
-et([
-  l({ attribute: !1 })
-], U.prototype, "entities", 2);
-et([
-  H()
-], U.prototype, "_graphAvailable", 2);
-U = et([
-  S("comfort-band-insights-tab")
-], U);
-var ze = Object.defineProperty, He = Object.getOwnPropertyDescriptor, P = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? He(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && ze(t, e, s), s;
+lt([
+  h({ attribute: !1 })
+], B.prototype, "hass", 2);
+lt([
+  h({ attribute: !1 })
+], B.prototype, "entities", 2);
+lt([
+  m()
+], B.prototype, "_graphAvailable", 2);
+B = lt([
+  w("comfort-band-insights-tab")
+], B);
+var qe = Object.defineProperty, Ve = Object.getOwnPropertyDescriptor, Gt = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Ve(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && qe(t, i, s), s;
 };
-const ke = [
+const Ke = 500, We = 1.5, Xe = 15, Dt = [0, 6, 12, 18, 24];
+function Mt(e) {
+  const t = /^(\d{1,2}):(\d{2})$/.exec(e);
+  return t ? parseInt(t[1], 10) * 60 + parseInt(t[2], 10) : 0;
+}
+function Ge(e) {
+  const t = Math.max(0, Math.min(1439, e)), i = Math.floor(t / 60), r = t % 60;
+  return `${i.toString().padStart(2, "0")}:${r.toString().padStart(2, "0")}`;
+}
+function pt(e) {
+  return e / (24 * 60) * 100;
+}
+function Ze(e, t) {
+  return Math.round(e / t) * t;
+}
+let rt = class extends v {
+  constructor() {
+    super(...arguments), this.transitions = [], this._longPressTimer = null, this._onTrackTap = (e) => {
+      if (e.target.classList.contains("point")) return;
+      const t = this.shadowRoot?.querySelector(".track");
+      if (!t) return;
+      const i = t.getBoundingClientRect(), r = this._xToMinutes(e.clientX, i);
+      for (const s of this.transitions) {
+        const o = Mt(s.at);
+        if (Math.abs(pt(o) - pt(r)) < We) return;
+      }
+      this.dispatchEvent(
+        new CustomEvent("transition-add", {
+          detail: { at: Ge(r) },
+          bubbles: !0,
+          composed: !0
+        })
+      );
+    }, this._onPointTap = (e) => {
+      this.dispatchEvent(
+        new CustomEvent("transition-edit", {
+          detail: { transition: e },
+          bubbles: !0,
+          composed: !0
+        })
+      );
+    }, this._onPointPointerDown = (e, t) => {
+      e.stopPropagation(), this._longPressTimer !== null && window.clearTimeout(this._longPressTimer);
+      const i = e.currentTarget;
+      let r = !1;
+      this._longPressTimer = window.setTimeout(() => {
+        r = !0, this._longPressTimer = null, this.dispatchEvent(
+          new CustomEvent("transition-delete", {
+            detail: { at: t.at },
+            bubbles: !0,
+            composed: !0
+          })
+        );
+      }, Ke);
+      const s = () => {
+        i.removeEventListener("pointerup", s), i.removeEventListener("pointercancel", s), i.removeEventListener("pointerleave", s), this._longPressTimer !== null && (window.clearTimeout(this._longPressTimer), this._longPressTimer = null, r || this._onPointTap(t));
+      };
+      i.addEventListener("pointerup", s), i.addEventListener("pointercancel", s), i.addEventListener("pointerleave", s);
+    }, this._onPointKeyDown = (e, t) => {
+      e.key === "Enter" || e.key === " " ? (e.preventDefault(), this._onPointTap(t)) : (e.key === "Delete" || e.key === "Backspace") && (e.preventDefault(), this.dispatchEvent(
+        new CustomEvent("transition-delete", {
+          detail: { at: t.at },
+          bubbles: !0,
+          composed: !0
+        })
+      ));
+    };
+  }
+  _xToMinutes(e, t) {
+    if (t.width === 0) return 0;
+    const i = Math.max(0, Math.min(1, (e - t.left) / t.width));
+    return Ze(i * 24 * 60, Xe);
+  }
+  render() {
+    return l`
+      <div class="ruler">
+        <div class="track" @click=${this._onTrackTap}></div>
+        ${Dt.map((e, t) => {
+      const i = t === 0 ? "hour-tick start" : t === Dt.length - 1 ? "hour-tick terminal" : "hour-tick";
+      return l`<div class=${i} style="left:${e / 24 * 100}%">${e}h</div>`;
+    })}
+        ${this.transitions.map((e) => {
+      const t = Mt(e.at), i = pt(t), r = `Transition at ${e.at}, low ${e.low.toFixed(1)} degrees, high ${e.high.toFixed(1)} degrees. Tap to edit, long-press or Delete to remove.`;
+      return l`
+            <button
+              class="point"
+              role="button"
+              style="left:${i}%"
+              tabindex="0"
+              aria-label=${r}
+              data-at=${e.at}
+              @pointerdown=${(s) => this._onPointPointerDown(s, e)}
+              @keydown=${(s) => this._onPointKeyDown(s, e)}
+            ></button>
+            <div class="point-label" style="left:${i}%">
+              ${e.at} · ${e.low.toFixed(1)}–${e.high.toFixed(1)}°
+            </div>
+          `;
+    })}
+      </div>
+      ${this.transitions.length === 0 ? l`<div class="empty-hint">Tap the timeline to add a transition.</div>` : null}
+    `;
+  }
+};
+rt.styles = [
+  x,
+  _`
+      :host {
+        display: block;
+      }
+      .ruler {
+        position: relative;
+        height: 80px;
+        margin: var(--cb-gap-md) 0;
+      }
+      .track {
+        position: absolute;
+        top: 36px;
+        left: 0;
+        right: 0;
+        height: 6px;
+        background: var(--cb-track-bg);
+        border-radius: 3px;
+        cursor: pointer;
+      }
+      .hour-tick {
+        position: absolute;
+        top: 18px;
+        font-size: 10px;
+        color: var(--cb-text-secondary);
+        transform: translateX(-50%);
+        font-variant-numeric: tabular-nums;
+      }
+      .hour-tick.terminal {
+        transform: translateX(-100%);
+      }
+      .hour-tick.start {
+        transform: translateX(0);
+      }
+      .point {
+        position: absolute;
+        top: 30px;
+        width: 18px;
+        height: 18px;
+        margin-left: -9px;
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        border: 2px solid var(--ha-card-background, #ffffff);
+        border-radius: 50%;
+        cursor: pointer;
+        touch-action: none;
+        z-index: 1;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+      }
+      .point:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 3px;
+      }
+      .point-label {
+        position: absolute;
+        top: 56px;
+        font-size: 10px;
+        color: var(--cb-text-secondary);
+        transform: translateX(-50%);
+        white-space: nowrap;
+        font-variant-numeric: tabular-nums;
+      }
+      .empty-hint {
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+        text-align: center;
+        margin-top: var(--cb-gap-sm);
+      }
+    `
+];
+Gt([
+  h({ type: Array })
+], rt.prototype, "transitions", 2);
+rt = Gt([
+  w("timeline-editor")
+], rt);
+var Je = Object.defineProperty, Ye = Object.getOwnPropertyDescriptor, z = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Ye(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && Je(t, i, s), s;
+};
+let A = class extends v {
+  constructor() {
+    super(...arguments), this.transition = null, this.isNew = !1, this._at = "06:00", this._low = 19, this._high = 22, this._error = null, this._onSave = () => {
+      this._validate() && this.dispatchEvent(
+        new CustomEvent("dialog-save", {
+          detail: { transition: { at: this._at, low: this._low, high: this._high } },
+          bubbles: !0,
+          composed: !0
+        })
+      );
+    }, this._onCancel = () => {
+      this.dispatchEvent(new CustomEvent("dialog-cancel", { bubbles: !0, composed: !0 }));
+    }, this._onDelete = () => {
+      this.transition && this.dispatchEvent(
+        new CustomEvent("dialog-delete", {
+          detail: { at: this.transition.at },
+          bubbles: !0,
+          composed: !0
+        })
+      );
+    };
+  }
+  willUpdate(e) {
+    e.has("transition") && this.transition && (this._at = this.transition.at, this._low = this.transition.low, this._high = this.transition.high, this._error = null);
+  }
+  firstUpdated() {
+    queueMicrotask(() => this._atInput?.focus());
+  }
+  _validate() {
+    return /^([01]\d|2[0-3]):[0-5]\d$/.test(this._at) ? Number.isNaN(this._low) || Number.isNaN(this._high) ? (this._error = "Low and high must be numbers.", !1) : this._low >= this._high ? (this._error = "Low must be less than high.", !1) : this._low < 10 || this._high > 35 ? (this._error = "Temperatures must be between 10 °C and 35 °C.", !1) : (this._error = null, !0) : (this._error = "Time must be HH:MM (24h, e.g. 06:00).", !1);
+  }
+  render() {
+    return l`
+      <h3>${this.isNew ? "Add transition" : "Edit transition"}</h3>
+      <label>
+        Time (HH:MM)
+        <input
+          name="at"
+          type="text"
+          inputmode="numeric"
+          .value=${this._at}
+          @input=${(e) => this._at = e.target.value}
+        />
+      </label>
+      <label>
+        Low (°C)
+        <input
+          name="low"
+          type="number"
+          step="0.5"
+          min="10"
+          max="35"
+          .value=${String(this._low)}
+          @input=${(e) => this._low = parseFloat(e.target.value)}
+        />
+      </label>
+      <label>
+        High (°C)
+        <input
+          name="high"
+          type="number"
+          step="0.5"
+          min="10"
+          max="35"
+          .value=${String(this._high)}
+          @input=${(e) => this._high = parseFloat(e.target.value)}
+        />
+      </label>
+      ${this._error ? l`<div class="error">${this._error}</div>` : null}
+      <div class="actions">
+        ${this.isNew ? null : l`<button class="button danger" @click=${this._onDelete}>Delete</button>`}
+        <div class="spacer"></div>
+        <button class="button secondary" @click=${this._onCancel}>Cancel</button>
+        <button class="button primary" @click=${this._onSave}>Save</button>
+      </div>
+    `;
+  }
+};
+A.styles = [
+  x,
+  _`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+        background: var(--ha-card-background, #ffffff);
+        border-radius: var(--cb-radius-card);
+      }
+      h3 {
+        margin: 0 0 var(--cb-gap-md);
+        font-size: 14px;
+        font-weight: 500;
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: var(--cb-gap-md);
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+      }
+      input {
+        font: inherit;
+        font-size: 14px;
+        padding: 8px;
+        border: 1px solid var(--divider-color, #cccccc);
+        border-radius: 6px;
+        color: var(--cb-text-primary);
+        background: transparent;
+      }
+      input:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 1px;
+      }
+      .error {
+        color: var(--error-color, #b71c1c);
+        font-size: 12px;
+        margin-bottom: var(--cb-gap-sm);
+      }
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--cb-gap-sm);
+      }
+      .actions .spacer {
+        flex: 1;
+      }
+      .button {
+        font: inherit;
+        padding: 6px 12px;
+        border-radius: var(--cb-radius-pill);
+        border: 1px solid transparent;
+        cursor: pointer;
+        font-size: 13px;
+      }
+      .button.primary {
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        color: #ffffff;
+      }
+      .button.secondary {
+        background: transparent;
+        border-color: var(--divider-color, #cccccc);
+        color: var(--cb-text-primary);
+      }
+      .button.danger {
+        background: transparent;
+        color: var(--error-color, #b71c1c);
+        border-color: var(--divider-color, #cccccc);
+      }
+    `
+];
+z([
+  h({ type: Object })
+], A.prototype, "transition", 2);
+z([
+  h({ type: Boolean })
+], A.prototype, "isNew", 2);
+z([
+  m()
+], A.prototype, "_at", 2);
+z([
+  m()
+], A.prototype, "_low", 2);
+z([
+  m()
+], A.prototype, "_high", 2);
+z([
+  m()
+], A.prototype, "_error", 2);
+z([
+  nt('input[name="at"]')
+], A.prototype, "_atInput", 2);
+A = z([
+  w("transition-edit-dialog")
+], A);
+var Qe = Object.defineProperty, ti = Object.getOwnPropertyDescriptor, S = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? ti(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && Qe(t, i, s), s;
+};
+let g = class extends v {
+  constructor() {
+    super(...arguments), this.zone = "", this._profile = "", this._transitions = [], this._loading = !0, this._error = null, this._mode = "list", this._editing = null, this._newAt = "06:00", this._onAdd = (e) => {
+      this._newAt = e.detail.at, this._editing = null, this._mode = "add";
+    }, this._onEdit = (e) => {
+      this._editing = e.detail.transition, this._mode = "edit";
+    }, this._onDelete = async (e) => {
+      if (!this.hass) return;
+      const t = this._transitions.filter((i) => i.at !== e.detail.at);
+      await this._writeSchedule(t);
+    }, this._onDialogSave = async (e) => {
+      const t = e.detail.transition, i = [];
+      if (this._mode === "edit" && this._editing) {
+        const r = this._editing.at;
+        for (const s of this._transitions)
+          s.at !== r && s.at !== t.at && i.push(s);
+        i.push(t);
+      } else {
+        for (const r of this._transitions)
+          r.at !== t.at && i.push(r);
+        i.push(t);
+      }
+      i.sort((r, s) => r.at.localeCompare(s.at)), await this._writeSchedule(i), this._mode = "list", this._editing = null;
+    }, this._onDialogDelete = async (e) => {
+      const t = this._transitions.filter((i) => i.at !== e.detail.at);
+      await this._writeSchedule(t), this._mode = "list", this._editing = null;
+    }, this._onDialogCancel = () => {
+      this._mode = "list", this._editing = null;
+    };
+  }
+  willUpdate(e) {
+    e.has("hass") && this.hass && this._profile === "" && (this._profile = Ht(this.hass) ?? "home", this._refresh());
+  }
+  updated(e) {
+    if (e.has("hass") && this.hass) {
+      const t = Ht(this.hass);
+      t && t !== this._profile && (this._profile = t, this._refresh());
+    }
+  }
+  async _refresh() {
+    if (!(!this.hass || !this.zone || !this._profile)) {
+      this._loading = !0, this._error = null;
+      try {
+        const e = await Ce(this.hass, {
+          zone: this.zone,
+          profile: this._profile
+        });
+        this._transitions = e?.baseline ? [...e.baseline] : [];
+      } catch (e) {
+        this._error = e instanceof Error ? e.message : "Failed to load schedule.";
+      } finally {
+        this._loading = !1;
+      }
+    }
+  }
+  async _writeSchedule(e) {
+    if (this.hass)
+      try {
+        await Te(this.hass, {
+          zone: this.zone,
+          profile: this._profile,
+          transitions: e
+        }), this._transitions = e, this._refresh();
+      } catch (t) {
+        this._error = t instanceof Error ? t.message : "Failed to save schedule.";
+      }
+  }
+  render() {
+    if (!this.hass) return p;
+    if (this._mode === "add" || this._mode === "edit") {
+      const e = this._mode === "edit" ? this._editing : {
+        at: this._newAt,
+        low: ei(this._transitions),
+        high: ii(this._transitions)
+      };
+      return l`
+        <transition-edit-dialog
+          .transition=${e}
+          .isNew=${this._mode === "add"}
+          @dialog-save=${this._onDialogSave}
+          @dialog-cancel=${this._onDialogCancel}
+          @dialog-delete=${this._onDialogDelete}
+        ></transition-edit-dialog>
+      `;
+    }
+    return l`
+      <div class="header">
+        <span class="profile-label">Active profile</span>
+        <span class="profile-value">${this._profile || "—"}</span>
+      </div>
+      ${this._loading ? l`<div class="loading">Loading schedule…</div>` : this._error ? l`<div class="error">${this._error}</div>` : l`
+              <timeline-editor
+                .transitions=${this._transitions}
+                @transition-add=${this._onAdd}
+                @transition-edit=${this._onEdit}
+                @transition-delete=${this._onDelete}
+              ></timeline-editor>
+              ${this._renderList()}
+            `}
+    `;
+  }
+  _renderList() {
+    return this._transitions.length === 0 ? p : l`
+      <ul class="list">
+        ${this._transitions.map(
+      (e) => l`
+            <li
+              @click=${() => this._onEdit(new CustomEvent("transition-edit", { detail: { transition: e } }))}
+            >
+              <span class="at">${e.at}</span>
+              <span>${e.low.toFixed(1)}° – ${e.high.toFixed(1)}°</span>
+            </li>
+          `
+    )}
+      </ul>
+    `;
+  }
+};
+g.styles = [
+  x,
+  _`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      .header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: var(--cb-gap-sm);
+      }
+      .profile-label {
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .profile-value {
+        font-size: 14px;
+        font-weight: 500;
+        text-transform: capitalize;
+        color: var(--cb-text-primary);
+      }
+      .loading,
+      .error {
+        text-align: center;
+        padding: var(--cb-gap-lg);
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+      }
+      .error {
+        color: var(--error-color, #b71c1c);
+      }
+      .list {
+        list-style: none;
+        padding: 0;
+        margin: var(--cb-gap-md) 0 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .list li {
+        display: flex;
+        justify-content: space-between;
+        font-size: 13px;
+        padding: 6px 8px;
+        border-radius: 6px;
+      }
+      .list li:hover {
+        background: var(--cb-track-bg);
+        cursor: pointer;
+      }
+      .list .at {
+        font-variant-numeric: tabular-nums;
+        font-weight: 500;
+      }
+    `
+];
+S([
+  h({ attribute: !1 })
+], g.prototype, "hass", 2);
+S([
+  h({ type: String })
+], g.prototype, "zone", 2);
+S([
+  m()
+], g.prototype, "_profile", 2);
+S([
+  m()
+], g.prototype, "_transitions", 2);
+S([
+  m()
+], g.prototype, "_loading", 2);
+S([
+  m()
+], g.prototype, "_error", 2);
+S([
+  m()
+], g.prototype, "_mode", 2);
+S([
+  m()
+], g.prototype, "_editing", 2);
+S([
+  m()
+], g.prototype, "_newAt", 2);
+g = S([
+  w("comfort-band-schedule-tab")
+], g);
+function Ht(e) {
+  const t = Wt(e);
+  return t ? e.states[t]?.state ?? null : null;
+}
+function ei(e) {
+  return e.length === 0 ? 19 : e[e.length - 1].low;
+}
+function ii(e) {
+  return e.length === 0 ? 22 : e[e.length - 1].high;
+}
+var ri = Object.defineProperty, si = Object.getOwnPropertyDescriptor, k = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? si(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && ri(t, i, s), s;
+};
+const oi = [
   { id: "now", label: "Now" },
   { id: "schedule", label: "Schedule" },
   { id: "profiles", label: "Profiles" },
   { id: "insights", label: "Insights" }
 ];
-let _ = class extends v {
+let E = class extends v {
   constructor() {
     super(...arguments), this.zone = "", this.zoneName = "", this._activeTab = "now", this._isOpen = !1, this._onClose = () => {
       this._isOpen = !1, this.dispatchEvent(
         new CustomEvent("comfort-band-modal-close", { bubbles: !0, composed: !0 })
       );
-    }, this._onSelectTab = (i) => {
-      this._activeTab = i;
+    }, this._onSelectTab = (e) => {
+      this._activeTab = e;
     };
   }
   open() {
@@ -1551,22 +2147,22 @@ let _ = class extends v {
   close() {
     this._dialog?.close();
   }
-  selectTab(i) {
-    this._activeTab = i;
+  selectTab(e) {
+    this._activeTab = e;
   }
   render() {
     if (!this._isOpen) return p;
-    const i = this.zoneName || this.zone || "Comfort Band";
-    return d`
+    const e = this.zoneName || this.zone || "Comfort Band";
+    return l`
       <dialog @close=${this._onClose}>
         <div class="frame">
           <header>
-            <h2>${i}</h2>
+            <h2>${e}</h2>
             <button class="close" @click=${this.close} aria-label="Close">×</button>
           </header>
           <nav role="tablist">
-            ${ke.map(
-      (t) => d`
+            ${oi.map(
+      (t) => l`
                 <button
                   role="tab"
                   aria-selected=${this._activeTab === t.id}
@@ -1585,26 +2181,29 @@ let _ = class extends v {
   _renderTab() {
     switch (this._activeTab) {
       case "now":
-        return d`<comfort-band-now-tab
+        return l`<comfort-band-now-tab
           .hass=${this.hass}
           .zone=${this.zone}
           .entities=${this.entities}
         ></comfort-band-now-tab>`;
       case "schedule":
-        return d`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
+        return l`<comfort-band-schedule-tab
+          .hass=${this.hass}
+          .zone=${this.zone}
+        ></comfort-band-schedule-tab>`;
       case "profiles":
-        return d`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
+        return l`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
       case "insights":
-        return d`<comfort-band-insights-tab
+        return l`<comfort-band-insights-tab
           .hass=${this.hass}
           .entities=${this.entities}
         ></comfort-band-insights-tab>`;
     }
   }
 };
-_.styles = [
-  C,
-  $`
+E.styles = [
+  x,
+  _`
       :host {
         --cb-modal-max-width: 480px;
       }
@@ -1683,60 +2282,60 @@ _.styles = [
       }
     `
 ];
-P([
-  l({ attribute: !1 })
-], _.prototype, "hass", 2);
-P([
-  l({ type: String })
-], _.prototype, "zone", 2);
-P([
-  l({ type: String })
-], _.prototype, "zoneName", 2);
-P([
-  l({ attribute: !1 })
-], _.prototype, "entities", 2);
-P([
-  H()
-], _.prototype, "_activeTab", 2);
-P([
-  H()
-], _.prototype, "_isOpen", 2);
-P([
-  pt("dialog")
-], _.prototype, "_dialog", 2);
-_ = P([
-  S("comfort-band-modal")
-], _);
-var Me = Object.defineProperty, De = Object.getOwnPropertyDescriptor, it = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? De(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && Me(t, e, s), s;
+k([
+  h({ attribute: !1 })
+], E.prototype, "hass", 2);
+k([
+  h({ type: String })
+], E.prototype, "zone", 2);
+k([
+  h({ type: String })
+], E.prototype, "zoneName", 2);
+k([
+  h({ attribute: !1 })
+], E.prototype, "entities", 2);
+k([
+  m()
+], E.prototype, "_activeTab", 2);
+k([
+  m()
+], E.prototype, "_isOpen", 2);
+k([
+  nt("dialog")
+], E.prototype, "_dialog", 2);
+E = k([
+  w("comfort-band-modal")
+], E);
+var ni = Object.defineProperty, ai = Object.getOwnPropertyDescriptor, ct = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? ai(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && ni(t, i, s), s;
 };
-let R = class extends v {
+let I = class extends v {
   constructor() {
     super(...arguments), this._onTileTap = () => {
       this._modal?.open();
     };
   }
-  setConfig(i) {
-    if (!i?.zone)
+  setConfig(e) {
+    if (!e?.zone)
       throw new Error("comfort-band-card: `zone` is required");
-    this._config = i;
+    this._config = e;
   }
   /** HA's panel/grid uses this to size the card. ~1 row per ~50 px of content. */
   getCardSize() {
     return 2;
   }
   render() {
-    if (!this._config || !this.hass) return d``;
-    const i = this._config.zone, t = Se(this.hass, i);
+    if (!this._config || !this.hass) return l``;
+    const e = this._config.zone, t = Re(this.hass, e);
     if (t.deviceId === null)
-      return d`<div class="placeholder">
-        Comfort Band zone <code>${i}</code> not found. Add it via Settings → Devices &
+      return l`<div class="placeholder">
+        Comfort Band zone <code>${e}</code> not found. Add it via Settings → Devices &
         Services.
       </div>`;
-    const e = this._config.compact === !0, r = this._buildView(this.hass, t);
-    return d`
+    const i = this._config.compact === !0, r = this._buildView(this.hass, t);
+    return l`
       <comfort-band-tile
         zoneName=${r.zoneName}
         .roomTemp=${r.roomTemp}
@@ -1745,20 +2344,20 @@ let R = class extends v {
         .action=${r.action}
         .overrideActive=${r.overrideActive}
         .overrideEnds=${r.overrideEnds}
-        .noExpand=${e}
+        .noExpand=${i}
         @comfort-band-tile-tap=${this._onTileTap}
       ></comfort-band-tile>
-      ${e ? null : d`<comfort-band-modal
+      ${i ? null : l`<comfort-band-modal
             .hass=${this.hass}
-            zone=${i}
+            zone=${e}
             zoneName=${r.zoneName}
             .entities=${t}
           ></comfort-band-modal>`}
     `;
   }
-  _buildView(i, t) {
-    const e = (s) => s !== null ? i.states[s] : void 0, r = (s) => {
-      const o = e(s);
+  _buildView(e, t) {
+    const i = (s) => s !== null ? e.states[s] : void 0, r = (s) => {
+      const o = i(s);
       if (!o) return NaN;
       const n = parseFloat(o.state);
       return Number.isFinite(n) ? n : NaN;
@@ -1768,15 +2367,15 @@ let R = class extends v {
       low: r(t.effectiveLow),
       high: r(t.effectiveHigh),
       roomTemp: r(t.roomTemperature),
-      action: e(t.currentAction)?.state ?? "unknown",
-      overrideActive: e(t.overrideActive)?.state === "on",
-      overrideEnds: e(t.overrideEnds)?.state ?? null
+      action: i(t.currentAction)?.state ?? "unknown",
+      overrideActive: i(t.overrideActive)?.state === "on",
+      overrideEnds: i(t.overrideEnds)?.state ?? null
     };
   }
 };
-R.styles = [
-  C,
-  $`
+I.styles = [
+  x,
+  _`
       :host {
         display: block;
       }
@@ -1790,18 +2389,18 @@ R.styles = [
       }
     `
 ];
-it([
-  l({ attribute: !1 })
-], R.prototype, "hass", 2);
-it([
-  H()
-], R.prototype, "_config", 2);
-it([
-  pt("comfort-band-modal")
-], R.prototype, "_modal", 2);
-R = it([
-  S("comfort-band-card")
-], R);
+ct([
+  h({ attribute: !1 })
+], I.prototype, "hass", 2);
+ct([
+  m()
+], I.prototype, "_config", 2);
+ct([
+  nt("comfort-band-modal")
+], I.prototype, "_modal", 2);
+I = ct([
+  w("comfort-band-card")
+], I);
 (window.customCards ??= []).push({
   type: "comfort-band-card",
   name: "Comfort Band",

--- a/dist/comfort-band-card.js
+++ b/dist/comfort-band-card.js
@@ -1,15 +1,15 @@
-const Z = globalThis, rt = Z.ShadowRoot && (Z.ShadyCSS === void 0 || Z.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, st = Symbol(), pt = /* @__PURE__ */ new WeakMap();
-let xt = class {
+const Z = globalThis, st = Z.ShadowRoot && (Z.ShadyCSS === void 0 || Z.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, ot = Symbol(), mt = /* @__PURE__ */ new WeakMap();
+let St = class {
   constructor(t, e, r) {
-    if (this._$cssResult$ = !0, r !== st) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    if (this._$cssResult$ = !0, r !== ot) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = t, this.t = e;
   }
   get styleSheet() {
     let t = this.o;
     const e = this.t;
-    if (rt && t === void 0) {
+    if (st && t === void 0) {
       const r = e !== void 0 && e.length === 1;
-      r && (t = pt.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && pt.set(e, t));
+      r && (t = mt.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && mt.set(e, t));
     }
     return t;
   }
@@ -17,28 +17,28 @@ let xt = class {
     return this.cssText;
   }
 };
-const Ht = (i) => new xt(typeof i == "string" ? i : i + "", void 0, st), O = (i, ...t) => {
+const Ut = (i) => new St(typeof i == "string" ? i : i + "", void 0, ot), E = (i, ...t) => {
   const e = i.length === 1 ? i[0] : t.reduce((r, s, o) => r + ((n) => {
     if (n._$cssResult$ === !0) return n.cssText;
     if (typeof n == "number") return n;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
   })(s) + i[o + 1], i[0]);
-  return new xt(e, i, st);
-}, kt = (i, t) => {
-  if (rt) i.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  return new St(e, i, ot);
+}, Rt = (i, t) => {
+  if (st) i.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
   else for (const e of t) {
     const r = document.createElement("style"), s = Z.litNonce;
     s !== void 0 && r.setAttribute("nonce", s), r.textContent = e.cssText, i.appendChild(r);
   }
-}, ut = rt ? (i) => i : (i) => i instanceof CSSStyleSheet ? ((t) => {
+}, vt = st ? (i) => i : (i) => i instanceof CSSStyleSheet ? ((t) => {
   let e = "";
   for (const r of t.cssRules) e += r.cssText;
-  return Ht(e);
+  return Ut(e);
 })(i) : i;
-const { is: Mt, defineProperty: Dt, getOwnPropertyDescriptor: Ut, getOwnPropertyNames: Rt, getOwnPropertySymbols: Lt, getPrototypeOf: jt } = Object, J = globalThis, ft = J.trustedTypes, Bt = ft ? ft.emptyScript : "", It = J.reactiveElementPolyfillSupport, j = (i, t) => i, G = { toAttribute(i, t) {
+const { is: Lt, defineProperty: jt, getOwnPropertyDescriptor: Bt, getOwnPropertyNames: It, getOwnPropertySymbols: Ft, getPrototypeOf: Vt } = Object, Y = globalThis, bt = Y.trustedTypes, qt = bt ? bt.emptyScript : "", Kt = Y.reactiveElementPolyfillSupport, j = (i, t) => i, G = { toAttribute(i, t) {
   switch (t) {
     case Boolean:
-      i = i ? Bt : null;
+      i = i ? qt : null;
       break;
     case Object:
     case Array:
@@ -63,23 +63,23 @@ const { is: Mt, defineProperty: Dt, getOwnPropertyDescriptor: Ut, getOwnProperty
       }
   }
   return e;
-} }, ot = (i, t) => !Mt(i, t), mt = { attribute: !0, type: String, converter: G, reflect: !1, useDefault: !1, hasChanged: ot };
-Symbol.metadata ??= Symbol("metadata"), J.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
-let T = class extends HTMLElement {
+} }, nt = (i, t) => !Lt(i, t), gt = { attribute: !0, type: String, converter: G, reflect: !1, useDefault: !1, hasChanged: nt };
+Symbol.metadata ??= Symbol("metadata"), Y.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
+let k = class extends HTMLElement {
   static addInitializer(t) {
     this._$Ei(), (this.l ??= []).push(t);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, e = mt) {
+  static createProperty(t, e = gt) {
     if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
       const r = Symbol(), s = this.getPropertyDescriptor(t, r, e);
-      s !== void 0 && Dt(this.prototype, t, s);
+      s !== void 0 && jt(this.prototype, t, s);
     }
   }
   static getPropertyDescriptor(t, e, r) {
-    const { get: s, set: o } = Ut(this.prototype, t) ?? { get() {
+    const { get: s, set: o } = Bt(this.prototype, t) ?? { get() {
       return this[e];
     }, set(n) {
       this[e] = n;
@@ -90,17 +90,17 @@ let T = class extends HTMLElement {
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? mt;
+    return this.elementProperties.get(t) ?? gt;
   }
   static _$Ei() {
     if (this.hasOwnProperty(j("elementProperties"))) return;
-    const t = jt(this);
+    const t = Vt(this);
     t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
     if (this.hasOwnProperty(j("finalized"))) return;
     if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(j("properties"))) {
-      const e = this.properties, r = [...Rt(e), ...Lt(e)];
+      const e = this.properties, r = [...It(e), ...Ft(e)];
       for (const s of r) this.createProperty(s, e[s]);
     }
     const t = this[Symbol.metadata];
@@ -119,8 +119,8 @@ let T = class extends HTMLElement {
     const e = [];
     if (Array.isArray(t)) {
       const r = new Set(t.flat(1 / 0).reverse());
-      for (const s of r) e.unshift(ut(s));
-    } else t !== void 0 && e.push(ut(t));
+      for (const s of r) e.unshift(vt(s));
+    } else t !== void 0 && e.push(vt(t));
     return e;
   }
   static _$Eu(t, e) {
@@ -146,7 +146,7 @@ let T = class extends HTMLElement {
   }
   createRenderRoot() {
     const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return kt(t, this.constructor.elementStyles), t;
+    return Rt(t, this.constructor.elementStyles), t;
   }
   connectedCallback() {
     this.renderRoot ??= this.createRenderRoot(), this.enableUpdating(!0), this._$EO?.forEach((t) => t.hostConnected?.());
@@ -178,7 +178,7 @@ let T = class extends HTMLElement {
   requestUpdate(t, e, r, s = !1, o) {
     if (t !== void 0) {
       const n = this.constructor;
-      if (s === !1 && (o = this[t]), r ??= n.getPropertyOptions(t), !((r.hasChanged ?? ot)(o, e) || r.useDefault && r.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, r)))) return;
+      if (s === !1 && (o = this[t]), r ??= n.getPropertyOptions(t), !((r.hasChanged ?? nt)(o, e) || r.useDefault && r.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, r)))) return;
       this.C(t, e, r);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
@@ -246,51 +246,51 @@ let T = class extends HTMLElement {
   firstUpdated(t) {
   }
 };
-T.elementStyles = [], T.shadowRootOptions = { mode: "open" }, T[j("elementProperties")] = /* @__PURE__ */ new Map(), T[j("finalized")] = /* @__PURE__ */ new Map(), It?.({ ReactiveElement: T }), (J.reactiveElementVersions ??= []).push("2.1.2");
-const nt = globalThis, vt = (i) => i, X = nt.trustedTypes, gt = X ? X.createPolicy("lit-html", { createHTML: (i) => i }) : void 0, At = "$lit$", x = `lit$${Math.random().toFixed(9).slice(2)}$`, Et = "?" + x, Ft = `<${Et}>`, C = document, B = () => C.createComment(""), I = (i) => i === null || typeof i != "object" && typeof i != "function", at = Array.isArray, Vt = (i) => at(i) || typeof i?.[Symbol.iterator] == "function", tt = `[ 	
-\f\r]`, L = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, bt = /-->/g, _t = />/g, S = RegExp(`>|${tt}(?:([^\\s"'>=/]+)(${tt}*=${tt}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), $t = /'/g, yt = /"/g, St = /^(?:script|style|textarea|title)$/i, Nt = (i) => (t, ...e) => ({ _$litType$: i, strings: t, values: e }), f = Nt(1), W = Nt(2), z = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), wt = /* @__PURE__ */ new WeakMap(), N = C.createTreeWalker(C, 129);
-function Ct(i, t) {
-  if (!at(i) || !i.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return gt !== void 0 ? gt.createHTML(t) : t;
+k.elementStyles = [], k.shadowRootOptions = { mode: "open" }, k[j("elementProperties")] = /* @__PURE__ */ new Map(), k[j("finalized")] = /* @__PURE__ */ new Map(), Kt?.({ ReactiveElement: k }), (Y.reactiveElementVersions ??= []).push("2.1.2");
+const at = globalThis, _t = (i) => i, X = at.trustedTypes, $t = X ? X.createPolicy("lit-html", { createHTML: (i) => i }) : void 0, Nt = "$lit$", x = `lit$${Math.random().toFixed(9).slice(2)}$`, Pt = "?" + x, Wt = `<${Pt}>`, C = document, B = () => C.createComment(""), I = (i) => i === null || typeof i != "object" && typeof i != "function", ct = Array.isArray, Zt = (i) => ct(i) || typeof i?.[Symbol.iterator] == "function", et = `[ 	
+\f\r]`, L = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, yt = /-->/g, wt = />/g, N = RegExp(`>|${et}(?:([^\\s"'>=/]+)(${et}*=${et}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), xt = /'/g, At = /"/g, Ct = /^(?:script|style|textarea|title)$/i, Ot = (i) => (t, ...e) => ({ _$litType$: i, strings: t, values: e }), p = Ot(1), W = Ot(2), H = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), Et = /* @__PURE__ */ new WeakMap(), P = C.createTreeWalker(C, 129);
+function Tt(i, t) {
+  if (!ct(i) || !i.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return $t !== void 0 ? $t.createHTML(t) : t;
 }
-const qt = (i, t) => {
+const Gt = (i, t) => {
   const e = i.length - 1, r = [];
   let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = L;
   for (let c = 0; c < e; c++) {
     const a = i[c];
-    let p, d, l = -1, m = 0;
-    for (; m < a.length && (n.lastIndex = m, d = n.exec(a), d !== null); ) m = n.lastIndex, n === L ? d[1] === "!--" ? n = bt : d[1] !== void 0 ? n = _t : d[2] !== void 0 ? (St.test(d[2]) && (s = RegExp("</" + d[2], "g")), n = S) : d[3] !== void 0 && (n = S) : n === S ? d[0] === ">" ? (n = s ?? L, l = -1) : d[1] === void 0 ? l = -2 : (l = n.lastIndex - d[2].length, p = d[1], n = d[3] === void 0 ? S : d[3] === '"' ? yt : $t) : n === yt || n === $t ? n = S : n === bt || n === _t ? n = L : (n = S, s = void 0);
-    const w = n === S && i[c + 1].startsWith("/>") ? " " : "";
-    o += n === L ? a + Ft : l >= 0 ? (r.push(p), a.slice(0, l) + At + a.slice(l) + x + w) : a + x + (l === -2 ? c : w);
+    let f, d, l = -1, m = 0;
+    for (; m < a.length && (n.lastIndex = m, d = n.exec(a), d !== null); ) m = n.lastIndex, n === L ? d[1] === "!--" ? n = yt : d[1] !== void 0 ? n = wt : d[2] !== void 0 ? (Ct.test(d[2]) && (s = RegExp("</" + d[2], "g")), n = N) : d[3] !== void 0 && (n = N) : n === N ? d[0] === ">" ? (n = s ?? L, l = -1) : d[1] === void 0 ? l = -2 : (l = n.lastIndex - d[2].length, f = d[1], n = d[3] === void 0 ? N : d[3] === '"' ? At : xt) : n === At || n === xt ? n = N : n === yt || n === wt ? n = L : (n = N, s = void 0);
+    const w = n === N && i[c + 1].startsWith("/>") ? " " : "";
+    o += n === L ? a + Wt : l >= 0 ? (r.push(f), a.slice(0, l) + Nt + a.slice(l) + x + w) : a + x + (l === -2 ? c : w);
   }
-  return [Ct(i, o + (i[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
+  return [Tt(i, o + (i[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
 };
 class F {
   constructor({ strings: t, _$litType$: e }, r) {
     let s;
     this.parts = [];
     let o = 0, n = 0;
-    const c = t.length - 1, a = this.parts, [p, d] = qt(t, e);
-    if (this.el = F.createElement(p, r), N.currentNode = this.el.content, e === 2 || e === 3) {
+    const c = t.length - 1, a = this.parts, [f, d] = Gt(t, e);
+    if (this.el = F.createElement(f, r), P.currentNode = this.el.content, e === 2 || e === 3) {
       const l = this.el.content.firstChild;
       l.replaceWith(...l.childNodes);
     }
-    for (; (s = N.nextNode()) !== null && a.length < c; ) {
+    for (; (s = P.nextNode()) !== null && a.length < c; ) {
       if (s.nodeType === 1) {
-        if (s.hasAttributes()) for (const l of s.getAttributeNames()) if (l.endsWith(At)) {
+        if (s.hasAttributes()) for (const l of s.getAttributeNames()) if (l.endsWith(Nt)) {
           const m = d[n++], w = s.getAttribute(l).split(x), K = /([.?@])?(.*)/.exec(m);
-          a.push({ type: 1, index: o, name: K[2], strings: w, ctor: K[1] === "." ? Wt : K[1] === "?" ? Zt : K[1] === "@" ? Gt : Y }), s.removeAttribute(l);
+          a.push({ type: 1, index: o, name: K[2], strings: w, ctor: K[1] === "." ? Jt : K[1] === "?" ? Yt : K[1] === "@" ? Qt : Q }), s.removeAttribute(l);
         } else l.startsWith(x) && (a.push({ type: 6, index: o }), s.removeAttribute(l));
-        if (St.test(s.tagName)) {
+        if (Ct.test(s.tagName)) {
           const l = s.textContent.split(x), m = l.length - 1;
           if (m > 0) {
             s.textContent = X ? X.emptyScript : "";
-            for (let w = 0; w < m; w++) s.append(l[w], B()), N.nextNode(), a.push({ type: 2, index: ++o });
+            for (let w = 0; w < m; w++) s.append(l[w], B()), P.nextNode(), a.push({ type: 2, index: ++o });
             s.append(l[m], B());
           }
         }
-      } else if (s.nodeType === 8) if (s.data === Et) a.push({ type: 2, index: o });
+      } else if (s.nodeType === 8) if (s.data === Pt) a.push({ type: 2, index: o });
       else {
         let l = -1;
         for (; (l = s.data.indexOf(x, l + 1)) !== -1; ) a.push({ type: 7, index: o }), l += x.length - 1;
@@ -303,13 +303,13 @@ class F {
     return r.innerHTML = t, r;
   }
 }
-function H(i, t, e = i, r) {
-  if (t === z) return t;
+function M(i, t, e = i, r) {
+  if (t === H) return t;
   let s = r !== void 0 ? e._$Co?.[r] : e._$Cl;
   const o = I(t) ? void 0 : t._$litDirective$;
-  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(i), s._$AT(i, e, r)), r !== void 0 ? (e._$Co ??= [])[r] = s : e._$Cl = s), s !== void 0 && (t = H(i, s._$AS(i, t.values), s, r)), t;
+  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(i), s._$AT(i, e, r)), r !== void 0 ? (e._$Co ??= [])[r] = s : e._$Cl = s), s !== void 0 && (t = M(i, s._$AS(i, t.values), s, r)), t;
 }
-class Kt {
+class Xt {
   constructor(t, e) {
     this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
   }
@@ -321,16 +321,16 @@ class Kt {
   }
   u(t) {
     const { el: { content: e }, parts: r } = this._$AD, s = (t?.creationScope ?? C).importNode(e, !0);
-    N.currentNode = s;
-    let o = N.nextNode(), n = 0, c = 0, a = r[0];
+    P.currentNode = s;
+    let o = P.nextNode(), n = 0, c = 0, a = r[0];
     for (; a !== void 0; ) {
       if (n === a.index) {
-        let p;
-        a.type === 2 ? p = new V(o, o.nextSibling, this, t) : a.type === 1 ? p = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (p = new Xt(o, this, t)), this._$AV.push(p), a = r[++c];
+        let f;
+        a.type === 2 ? f = new V(o, o.nextSibling, this, t) : a.type === 1 ? f = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (f = new te(o, this, t)), this._$AV.push(f), a = r[++c];
       }
-      n !== a?.index && (o = N.nextNode(), n++);
+      n !== a?.index && (o = P.nextNode(), n++);
     }
-    return N.currentNode = C, s;
+    return P.currentNode = C, s;
   }
   p(t) {
     let e = 0;
@@ -356,7 +356,7 @@ class V {
     return this._$AB;
   }
   _$AI(t, e = this) {
-    t = H(this, t, e), I(t) ? t === u || t == null || t === "" ? (this._$AH !== u && this._$AR(), this._$AH = u) : t !== this._$AH && t !== z && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Vt(t) ? this.k(t) : this._(t);
+    t = M(this, t, e), I(t) ? t === u || t == null || t === "" ? (this._$AH !== u && this._$AR(), this._$AH = u) : t !== this._$AH && t !== H && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Zt(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -368,19 +368,19 @@ class V {
     this._$AH !== u && I(this._$AH) ? this._$AA.nextSibling.data = t : this.T(C.createTextNode(t)), this._$AH = t;
   }
   $(t) {
-    const { values: e, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = F.createElement(Ct(r.h, r.h[0]), this.options)), r);
+    const { values: e, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = F.createElement(Tt(r.h, r.h[0]), this.options)), r);
     if (this._$AH?._$AD === s) this._$AH.p(e);
     else {
-      const o = new Kt(s, this), n = o.u(this.options);
+      const o = new Xt(s, this), n = o.u(this.options);
       o.p(e), this.T(n), this._$AH = o;
     }
   }
   _$AC(t) {
-    let e = wt.get(t.strings);
-    return e === void 0 && wt.set(t.strings, e = new F(t)), e;
+    let e = Et.get(t.strings);
+    return e === void 0 && Et.set(t.strings, e = new F(t)), e;
   }
   k(t) {
-    at(this._$AH) || (this._$AH = [], this._$AR());
+    ct(this._$AH) || (this._$AH = [], this._$AR());
     const e = this._$AH;
     let r, s = 0;
     for (const o of t) s === e.length ? e.push(r = new V(this.O(B()), this.O(B()), this, this.options)) : r = e[s], r._$AI(o), s++;
@@ -388,15 +388,15 @@ class V {
   }
   _$AR(t = this._$AA.nextSibling, e) {
     for (this._$AP?.(!1, !0, e); t !== this._$AB; ) {
-      const r = vt(t).nextSibling;
-      vt(t).remove(), t = r;
+      const r = _t(t).nextSibling;
+      _t(t).remove(), t = r;
     }
   }
   setConnected(t) {
     this._$AM === void 0 && (this._$Cv = t, this._$AP?.(t));
   }
 }
-class Y {
+class Q {
   get tagName() {
     return this.element.tagName;
   }
@@ -409,11 +409,11 @@ class Y {
   _$AI(t, e = this, r, s) {
     const o = this.strings;
     let n = !1;
-    if (o === void 0) t = H(this, t, e, 0), n = !I(t) || t !== this._$AH && t !== z, n && (this._$AH = t);
+    if (o === void 0) t = M(this, t, e, 0), n = !I(t) || t !== this._$AH && t !== H, n && (this._$AH = t);
     else {
       const c = t;
-      let a, p;
-      for (t = o[0], a = 0; a < o.length - 1; a++) p = H(this, c[r + a], e, a), p === z && (p = this._$AH[a]), n ||= !I(p) || p !== this._$AH[a], p === u ? t = u : t !== u && (t += (p ?? "") + o[a + 1]), this._$AH[a] = p;
+      let a, f;
+      for (t = o[0], a = 0; a < o.length - 1; a++) f = M(this, c[r + a], e, a), f === H && (f = this._$AH[a]), n ||= !I(f) || f !== this._$AH[a], f === u ? t = u : t !== u && (t += (f ?? "") + o[a + 1]), this._$AH[a] = f;
     }
     n && !s && this.j(t);
   }
@@ -421,7 +421,7 @@ class Y {
     t === u ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
 }
-class Wt extends Y {
+class Jt extends Q {
   constructor() {
     super(...arguments), this.type = 3;
   }
@@ -429,7 +429,7 @@ class Wt extends Y {
     this.element[this.name] = t === u ? void 0 : t;
   }
 }
-class Zt extends Y {
+class Yt extends Q {
   constructor() {
     super(...arguments), this.type = 4;
   }
@@ -437,12 +437,12 @@ class Zt extends Y {
     this.element.toggleAttribute(this.name, !!t && t !== u);
   }
 }
-class Gt extends Y {
+class Qt extends Q {
   constructor(t, e, r, s, o) {
     super(t, e, r, s, o), this.type = 5;
   }
   _$AI(t, e = this) {
-    if ((t = H(this, t, e, 0) ?? u) === z) return;
+    if ((t = M(this, t, e, 0) ?? u) === H) return;
     const r = this._$AH, s = t === u && r !== u || t.capture !== r.capture || t.once !== r.once || t.passive !== r.passive, o = t !== u && (r === u || s);
     s && this.element.removeEventListener(this.name, this, r), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
@@ -450,7 +450,7 @@ class Gt extends Y {
     typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class Xt {
+class te {
   constructor(t, e, r) {
     this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = r;
   }
@@ -458,12 +458,12 @@ class Xt {
     return this._$AM._$AU;
   }
   _$AI(t) {
-    H(this, t);
+    M(this, t);
   }
 }
-const Jt = nt.litHtmlPolyfillSupport;
-Jt?.(F, V), (nt.litHtmlVersions ??= []).push("3.3.2");
-const Yt = (i, t, e) => {
+const ee = at.litHtmlPolyfillSupport;
+ee?.(F, V), (at.litHtmlVersions ??= []).push("3.3.2");
+const ie = (i, t, e) => {
   const r = e?.renderBefore ?? t;
   let s = r._$litPart$;
   if (s === void 0) {
@@ -472,8 +472,8 @@ const Yt = (i, t, e) => {
   }
   return s._$AI(i), s;
 };
-const ct = globalThis;
-class b extends T {
+const lt = globalThis;
+class v extends k {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -483,7 +483,7 @@ class b extends T {
   }
   update(t) {
     const e = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Yt(e, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = ie(e, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     super.connectedCallback(), this._$Do?.setConnected(!0);
@@ -492,19 +492,19 @@ class b extends T {
     super.disconnectedCallback(), this._$Do?.setConnected(!1);
   }
   render() {
-    return z;
+    return H;
   }
 }
-b._$litElement$ = !0, b.finalized = !0, ct.litElementHydrateSupport?.({ LitElement: b });
-const Qt = ct.litElementPolyfillSupport;
-Qt?.({ LitElement: b });
-(ct.litElementVersions ??= []).push("4.2.2");
-const M = (i) => (t, e) => {
+v._$litElement$ = !0, v.finalized = !0, lt.litElementHydrateSupport?.({ LitElement: v });
+const re = lt.litElementPolyfillSupport;
+re?.({ LitElement: v });
+(lt.litElementVersions ??= []).push("4.2.2");
+const T = (i) => (t, e) => {
   e !== void 0 ? e.addInitializer(() => {
     customElements.define(i, t);
   }) : customElements.define(i, t);
 };
-const te = { attribute: !0, type: String, converter: G, reflect: !1, hasChanged: ot }, ee = (i = te, t, e) => {
+const se = { attribute: !0, type: String, converter: G, reflect: !1, hasChanged: nt }, oe = (i = se, t, e) => {
   const { kind: r, metadata: s } = e;
   let o = globalThis.litPropertyMetadata.get(s);
   if (o === void 0 && globalThis.litPropertyMetadata.set(s, o = /* @__PURE__ */ new Map()), r === "setter" && ((i = Object.create(i)).wrapped = !0), o.set(e.name, i), r === "accessor") {
@@ -526,24 +526,24 @@ const te = { attribute: !0, type: String, converter: G, reflect: !1, hasChanged:
   throw Error("Unsupported decorator location: " + r);
 };
 function h(i) {
-  return (t, e) => typeof e == "object" ? ee(i, t, e) : ((r, s, o) => {
+  return (t, e) => typeof e == "object" ? oe(i, t, e) : ((r, s, o) => {
     const n = s.hasOwnProperty(o);
     return s.constructor.createProperty(o, r), n ? Object.getOwnPropertyDescriptor(s, o) : void 0;
   })(i, t, e);
 }
-function D(i) {
+function U(i) {
   return h({ ...i, state: !0, attribute: !1 });
 }
-const ie = (i, t, e) => (e.configurable = !0, e.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(i, t, e), e);
-function lt(i, t) {
+const ne = (i, t, e) => (e.configurable = !0, e.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(i, t, e), e);
+function ht(i, t) {
   return (e, r, s) => {
     const o = (n) => n.renderRoot?.querySelector(i) ?? null;
-    return ie(e, r, { get() {
+    return ne(e, r, { get() {
       return o(this);
     } });
   };
 }
-const U = O`
+const z = E`
   :host {
     --cb-action-heating: var(--cb-color-heat, var(--state-climate-heat-color, #d9603f));
     --cb-action-cooling: var(--cb-color-cool, var(--state-climate-cool-color, #2f7fcc));
@@ -562,7 +562,7 @@ const U = O`
     --cb-gap-lg: 16px;
   }
 `;
-function ht(i) {
+function dt(i) {
   switch (i) {
     case "heating":
       return "var(--cb-action-heating)";
@@ -574,40 +574,40 @@ function ht(i) {
       return "var(--cb-action-unknown)";
   }
 }
-function dt(i) {
+function pt(i) {
   return i === "heating" || i === "cooling" || i === "idle" ? i : "unknown";
 }
-function Pt(i) {
+function zt(i) {
   return i.charAt(0).toUpperCase() + i.slice(1);
 }
-var re = Object.defineProperty, se = Object.getOwnPropertyDescriptor, q = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? se(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+var ae = Object.defineProperty, ce = Object.getOwnPropertyDescriptor, q = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? ce(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && re(t, e, s), s;
+  return r && s && ae(t, e, s), s;
 };
-const it = 15, Ot = 28, oe = Ot - it;
-function et(i) {
-  return Number.isNaN(i) || !Number.isFinite(i) ? 0 : (Math.max(it, Math.min(Ot, i)) - it) / oe * 100;
+const rt = 15, kt = 28, le = kt - rt;
+function it(i) {
+  return Number.isNaN(i) || !Number.isFinite(i) ? 0 : (Math.max(rt, Math.min(kt, i)) - rt) / le * 100;
 }
-let P = class extends b {
+let O = class extends v {
   constructor() {
     super(...arguments), this.low = NaN, this.high = NaN, this.room = NaN, this.action = "unknown";
   }
   render() {
-    const i = dt(this.action), t = ht(i), e = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = e ? et(this.low) : 0, n = r ? et(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), p = s ? et(this.room) : 50, d = (m) => Number.isFinite(m) ? `${m.toFixed(1)}°` : "—", l = `Comfort band gauge: low ${d(this.low)}, room ${d(this.room)}, high ${d(this.high)}, action ${i}`;
-    return f`
+    const i = pt(this.action), t = dt(i), e = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = e ? it(this.low) : 0, n = r ? it(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), f = s ? it(this.room) : 50, d = (m) => Number.isFinite(m) ? `${m.toFixed(1)}°` : "—", l = `Comfort band gauge: low ${d(this.low)}, room ${d(this.room)}, high ${d(this.high)}, action ${i}`;
+    return p`
       <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${l}>
         ${W`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
         ${e && r ? W`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
-        ${s ? W`<circle cx=${p} cy="12" r="4.5" fill=${t}></circle>` : null}
-        ${s ? W`<circle class="marker-ring" cx=${p} cy="12" r="3" stroke=${t}></circle>` : null}
+        ${s ? W`<circle cx=${f} cy="12" r="4.5" fill=${t}></circle>` : null}
+        ${s ? W`<circle class="marker-ring" cx=${f} cy="12" r="3" stroke=${t}></circle>` : null}
       </svg>
     `;
   }
 };
-P.styles = [
-  U,
-  O`
+O.styles = [
+  z,
+  E`
       :host {
         display: block;
         width: 100%;
@@ -637,25 +637,25 @@ P.styles = [
 ];
 q([
   h({ type: Number })
-], P.prototype, "low", 2);
+], O.prototype, "low", 2);
 q([
   h({ type: Number })
-], P.prototype, "high", 2);
+], O.prototype, "high", 2);
 q([
   h({ type: Number })
-], P.prototype, "room", 2);
+], O.prototype, "room", 2);
 q([
   h({ type: String })
-], P.prototype, "action", 2);
-P = q([
-  M("band-gauge")
-], P);
-var ne = Object.defineProperty, ae = Object.getOwnPropertyDescriptor, $ = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? ae(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+], O.prototype, "action", 2);
+O = q([
+  T("band-gauge")
+], O);
+var he = Object.defineProperty, de = Object.getOwnPropertyDescriptor, $ = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? de(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && ne(t, e, s), s;
+  return r && s && he(t, e, s), s;
 };
-let v = class extends b {
+let b = class extends v {
   constructor() {
     super(...arguments), this.zoneName = "", this.roomTemp = NaN, this.low = NaN, this.high = NaN, this.action = "unknown", this.overrideActive = !1, this.overrideEnds = null, this.noExpand = !1;
   }
@@ -667,19 +667,19 @@ let v = class extends b {
   }
   _renderOverridePill() {
     if (!this.overrideActive) return null;
-    const i = ce(this.overrideEnds);
-    return f`<div class="override-pill">Override${i ? ` · ${i}` : ""}</div>`;
+    const i = pe(this.overrideEnds);
+    return p`<div class="override-pill">Override${i ? ` · ${i}` : ""}</div>`;
   }
   _renderActionChip() {
-    const i = dt(this.action);
+    const i = pt(this.action);
     if (i === "idle" || i === "unknown") return null;
-    const t = ht(i);
-    return f`<span class="action-chip" style="background:${t}">
-      ${Pt(i)}
+    const t = dt(i);
+    return p`<span class="action-chip" style="background:${t}">
+      ${zt(i)}
     </span>`;
   }
   render() {
-    return f`
+    return p`
       <div
         class="tile ${this.noExpand ? "no-expand" : ""}"
         role="${this.noExpand ? "group" : "button"}"
@@ -707,9 +707,9 @@ let v = class extends b {
     `;
   }
 };
-v.styles = [
-  U,
-  O`
+b.styles = [
+  z,
+  E`
       :host {
         display: block;
       }
@@ -785,32 +785,32 @@ v.styles = [
 ];
 $([
   h({ type: String })
-], v.prototype, "zoneName", 2);
+], b.prototype, "zoneName", 2);
 $([
   h({ type: Number })
-], v.prototype, "roomTemp", 2);
+], b.prototype, "roomTemp", 2);
 $([
   h({ type: Number })
-], v.prototype, "low", 2);
+], b.prototype, "low", 2);
 $([
   h({ type: Number })
-], v.prototype, "high", 2);
+], b.prototype, "high", 2);
 $([
   h({ type: String })
-], v.prototype, "action", 2);
+], b.prototype, "action", 2);
 $([
   h({ type: Boolean })
-], v.prototype, "overrideActive", 2);
+], b.prototype, "overrideActive", 2);
 $([
   h({ type: String })
-], v.prototype, "overrideEnds", 2);
+], b.prototype, "overrideEnds", 2);
 $([
   h({ type: Boolean })
-], v.prototype, "noExpand", 2);
-v = $([
-  M("comfort-band-tile")
-], v);
-function ce(i) {
+], b.prototype, "noExpand", 2);
+b = $([
+  T("comfort-band-tile")
+], b);
+function pe(i) {
   if (!i) return "";
   const t = Date.parse(i);
   if (Number.isNaN(t)) return "";
@@ -821,12 +821,12 @@ function ce(i) {
   const s = Math.floor(r / 60), o = r % 60;
   return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-var le = Object.defineProperty, he = Object.getOwnPropertyDescriptor, y = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? he(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+var ue = Object.defineProperty, fe = Object.getOwnPropertyDescriptor, y = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? fe(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && le(t, e, s), s;
+  return r && s && ue(t, e, s), s;
 };
-let g = class extends b {
+let g = class extends v {
   constructor() {
     super(...arguments), this.min = 16, this.max = 26, this.step = 0.5, this.low = 19, this.high = 22, this.unit = "°", this._dragging = null, this._onThumbPointerDown = (i, t) => {
       i.preventDefault();
@@ -908,7 +908,7 @@ let g = class extends b {
   }
   render() {
     const i = this._pct(this.low), t = this._pct(this.high);
-    return f`
+    return p`
       <div class="track" @pointerdown=${this._onTrackPointerDown}>
         <div class="fill" style="left:${i}%; width:${t - i}%"></div>
         <div
@@ -946,8 +946,8 @@ let g = class extends b {
   }
 };
 g.styles = [
-  U,
-  O`
+  z,
+  E`
       :host {
         display: block;
         padding: 16px 12px;
@@ -1027,40 +1027,43 @@ y([
   h({ type: String })
 ], g.prototype, "unit", 2);
 y([
-  D()
+  U()
 ], g.prototype, "_dragging", 2);
 y([
-  lt(".track")
+  ht(".track")
 ], g.prototype, "_track", 2);
 g = y([
-  M("dual-handle-slider")
+  T("dual-handle-slider")
 ], g);
-const Tt = "comfort_band";
-function de(i, t) {
+const ut = "comfort_band";
+function me(i, t) {
   const e = { zone: t.zone };
-  return t.low !== void 0 && (e.low = t.low), t.high !== void 0 && (e.high = t.high), t.hours !== void 0 && (e.hours = t.hours), i.callService(Tt, "start_override", e);
+  return t.low !== void 0 && (e.low = t.low), t.high !== void 0 && (e.high = t.high), t.hours !== void 0 && (e.hours = t.hours), i.callService(ut, "start_override", e);
 }
-function pe(i, t) {
-  return i.callService(Tt, "cancel_override", { ...t });
+function ve(i, t) {
+  return i.callService(ut, "cancel_override", { ...t });
 }
-var ue = Object.defineProperty, fe = Object.getOwnPropertyDescriptor, R = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? fe(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+function be(i, t) {
+  return i.callService(ut, "set_profile", { ...t });
+}
+var ge = Object.defineProperty, _e = Object.getOwnPropertyDescriptor, R = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? _e(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && ue(t, e, s), s;
+  return r && s && ge(t, e, s), s;
 };
-const me = [1, 3, 6];
-let A = class extends b {
+const $e = [1, 3, 6];
+let A = class extends v {
   constructor() {
     super(...arguments), this.zone = "", this._pendingLow = null, this._pendingHigh = null, this._onSliderInput = (i) => {
       this._pendingLow = i.detail.low, this._pendingHigh = i.detail.high;
     }, this._onSliderChange = (i) => {
-      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, de(this.hass, {
+      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, me(this.hass, {
         zone: this.zone,
         low: i.detail.low,
         high: i.detail.high
       }));
     }, this._onCancel = () => {
-      !this.hass || !this.zone || pe(this.hass, { zone: this.zone });
+      !this.hass || !this.zone || ve(this.hass, { zone: this.zone });
     }, this._onPickHours = (i) => {
       !this.hass || !this.entities?.overrideHours || this.hass.callService("number", "set_value", {
         entity_id: this.entities.overrideHours,
@@ -1080,12 +1083,12 @@ let A = class extends b {
   }
   render() {
     if (!this.hass || !this.entities) return u;
-    const i = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), e = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", c = this._stateOf(this.entities.overrideActive)?.state === "on", a = this._pendingLow ?? (Number.isFinite(i) ? i : 19), p = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), d = dt(n), l = d !== "idle" && d !== "unknown";
-    return f`
+    const i = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), e = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", c = this._stateOf(this.entities.overrideActive)?.state === "on", a = this._pendingLow ?? (Number.isFinite(i) ? i : 19), f = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), d = pt(n), l = d !== "idle" && d !== "unknown";
+    return p`
       <div class="header-row">
         <div class="room-temp">${Number.isFinite(s) ? `${s.toFixed(1)}°` : "—"}</div>
-        ${l ? f`<span class="action-chip" style="background:${ht(d)}"
-              >${Pt(d)}</span
+        ${l ? p`<span class="action-chip" style="background:${dt(d)}"
+              >${zt(d)}</span
             >` : u}
       </div>
       <div class="gauge-row">
@@ -1099,7 +1102,7 @@ let A = class extends b {
           .max=${26}
           .step=${0.5}
           .low=${a}
-          .high=${p}
+          .high=${f}
           @input=${this._onSliderInput}
           @change=${this._onSliderChange}
         ></dual-handle-slider>
@@ -1110,8 +1113,8 @@ let A = class extends b {
   }
   _renderOverrideSection(i) {
     if (!i) return u;
-    const t = this._stateOf(this.entities.overrideEnds)?.state, e = ve(t ?? null);
-    return f`
+    const t = this._stateOf(this.entities.overrideEnds)?.state, e = ye(t ?? null);
+    return p`
       <section>
         <h3>Override</h3>
         <div class="override-row">
@@ -1122,12 +1125,12 @@ let A = class extends b {
     `;
   }
   _renderHoursSection(i) {
-    return this.entities?.overrideHours ? f`
+    return this.entities?.overrideHours ? p`
       <section>
         <h3>Override duration</h3>
         <div class="preset-row">
-          ${me.map(
-      (t) => f`
+          ${$e.map(
+      (t) => p`
               <button
                 class="preset ${i === t ? "active" : ""}"
                 @click=${() => this._onPickHours(t)}
@@ -1142,8 +1145,8 @@ let A = class extends b {
   }
 };
 A.styles = [
-  U,
-  O`
+  z,
+  E`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1239,15 +1242,15 @@ R([
   h({ attribute: !1 })
 ], A.prototype, "entities", 2);
 R([
-  D()
+  U()
 ], A.prototype, "_pendingLow", 2);
 R([
-  D()
+  U()
 ], A.prototype, "_pendingHigh", 2);
 A = R([
-  M("comfort-band-now-tab")
+  T("comfort-band-now-tab")
 ], A);
-function ve(i) {
+function ye(i) {
   if (!i) return "";
   const t = Date.parse(i);
   if (Number.isNaN(t)) return "";
@@ -1258,18 +1261,189 @@ function ve(i) {
   const s = Math.floor(r / 60), o = r % 60;
   return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-var ge = Object.defineProperty, be = Object.getOwnPropertyDescriptor, E = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? be(t, e) : t, o = i.length - 1, n; o >= 0; o--)
-    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && ge(t, e, s), s;
+const ft = "comfort_band", we = {
+  effective_low: "effectiveLow",
+  effective_high: "effectiveHigh",
+  room_temperature: "roomTemperature",
+  override_ends: "overrideEnds",
+  current_action: "currentAction",
+  override_active: "overrideActive",
+  manual_low: "manualLow",
+  manual_high: "manualHigh",
+  override_hours: "overrideHours",
+  deadband_below: "deadbandBelow",
+  deadband_above: "deadbandAbove",
+  min_cycle_minutes: "minCycleMinutes",
+  cancel_override: "cancelOverride",
+  enabled: "enabled"
 };
-const _e = [
+function xe() {
+  return {
+    effectiveLow: null,
+    effectiveHigh: null,
+    roomTemperature: null,
+    overrideEnds: null,
+    currentAction: null,
+    overrideActive: null,
+    manualLow: null,
+    manualHigh: null,
+    overrideHours: null,
+    deadbandBelow: null,
+    deadbandAbove: null,
+    minCycleMinutes: null,
+    cancelOverride: null,
+    enabled: null,
+    deviceId: null,
+    deviceName: null
+  };
+}
+function Ht(i, t) {
+  for (const e of Object.values(i.devices))
+    for (const [r, s] of e.identifiers)
+      if (r === t[0] && s === t[1])
+        return e;
+  return null;
+}
+function Mt(i, t) {
+  return Object.values(i.entities).filter(
+    (e) => e.device_id === t && e.platform === ft
+  );
+}
+function Ae(i, t) {
+  const e = xe(), r = Ht(i, [ft, `zone:${t}`]);
+  if (r === null) return e;
+  e.deviceId = r.id, e.deviceName = r.name_by_user ?? r.name;
+  const s = `${t}_`;
+  for (const o of Mt(i, r.id)) {
+    if (!o.unique_id.startsWith(s)) continue;
+    const n = o.unique_id.slice(s.length), c = we[n];
+    c !== void 0 && (e[c] = o.entity_id);
+  }
+  return e;
+}
+function Ee(i) {
+  const t = Ht(i, [ft, "profile_manager"]);
+  if (t === null) return null;
+  for (const e of Mt(i, t.id))
+    if (e.unique_id === "profile_manager_active_profile")
+      return e.entity_id;
+  return null;
+}
+var Se = Object.defineProperty, Ne = Object.getOwnPropertyDescriptor, Dt = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? Ne(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && Se(t, e, s), s;
+};
+let J = class extends v {
+  _onSelect(i) {
+    this.hass && be(this.hass, { profile: i });
+  }
+  render() {
+    if (!this.hass) return u;
+    const i = Ee(this.hass);
+    if (i === null)
+      return p`<div class="empty">Profile manager not registered yet.</div>`;
+    const t = this.hass.states[i], e = t?.attributes.options, r = Array.isArray(e) ? e.filter((o) => typeof o == "string") : [], s = t?.state ?? "";
+    return r.length === 0 ? p`<div class="empty">No profiles configured.</div>` : p`
+      <ul role="listbox" aria-label="Profiles">
+        ${r.map(
+      (o) => p`
+            <li
+              role="option"
+              tabindex="0"
+              class=${o === s ? "active" : ""}
+              aria-selected=${o === s}
+              @click=${() => this._onSelect(o)}
+              @keydown=${(n) => {
+        (n.key === "Enter" || n.key === " ") && (n.preventDefault(), this._onSelect(o));
+      }}
+            >
+              <span class="name">${o}</span>
+              ${o === s ? p`<span class="badge">Active</span>` : u}
+            </li>
+          `
+    )}
+      </ul>
+      <div class="footer">Create / rename / delete profiles in a future release.</div>
+    `;
+  }
+};
+J.styles = [
+  z,
+  E`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      .empty {
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+        text-align: center;
+        padding: var(--cb-gap-lg);
+      }
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--cb-gap-sm);
+      }
+      li {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--cb-gap-sm) var(--cb-gap-md);
+        border-radius: var(--cb-radius-card);
+        background: var(--cb-track-bg);
+        cursor: pointer;
+        font-size: 14px;
+        color: var(--cb-text-primary);
+      }
+      li.active {
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        color: #ffffff;
+      }
+      li:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 2px;
+      }
+      .name {
+        font-weight: 500;
+        text-transform: capitalize;
+      }
+      .badge {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        opacity: 0.85;
+      }
+      .footer {
+        margin-top: var(--cb-gap-md);
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+        text-align: center;
+      }
+    `
+];
+Dt([
+  h({ attribute: !1 })
+], J.prototype, "hass", 2);
+J = Dt([
+  T("comfort-band-profiles-tab")
+], J);
+var Pe = Object.defineProperty, Ce = Object.getOwnPropertyDescriptor, S = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? Ce(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && Pe(t, e, s), s;
+};
+const Oe = [
   { id: "now", label: "Now" },
   { id: "schedule", label: "Schedule" },
   { id: "profiles", label: "Profiles" },
   { id: "insights", label: "Insights" }
 ];
-let _ = class extends b {
+let _ = class extends v {
   constructor() {
     super(...arguments), this.zone = "", this.zoneName = "", this._activeTab = "now", this._isOpen = !1, this._onClose = () => {
       this._isOpen = !1, this.dispatchEvent(
@@ -1291,7 +1465,7 @@ let _ = class extends b {
   render() {
     if (!this._isOpen) return u;
     const i = this.zoneName || this.zone || "Comfort Band";
-    return f`
+    return p`
       <dialog @close=${this._onClose}>
         <div class="frame">
           <header>
@@ -1299,8 +1473,8 @@ let _ = class extends b {
             <button class="close" @click=${this.close} aria-label="Close">×</button>
           </header>
           <nav role="tablist">
-            ${_e.map(
-      (t) => f`
+            ${Oe.map(
+      (t) => p`
                 <button
                   role="tab"
                   aria-selected=${this._activeTab === t.id}
@@ -1319,23 +1493,23 @@ let _ = class extends b {
   _renderTab() {
     switch (this._activeTab) {
       case "now":
-        return f`<comfort-band-now-tab
+        return p`<comfort-band-now-tab
           .hass=${this.hass}
           .zone=${this.zone}
           .entities=${this.entities}
         ></comfort-band-now-tab>`;
       case "schedule":
-        return f`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
+        return p`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
       case "profiles":
-        return f`<div class="placeholder">Profiles — landing in commit 5.</div>`;
+        return p`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
       case "insights":
-        return f`<div class="placeholder">Insights — landing in commit 6.</div>`;
+        return p`<div class="placeholder">Insights — landing in commit 6.</div>`;
     }
   }
 };
 _.styles = [
-  U,
-  O`
+  z,
+  E`
       :host {
         --cb-modal-max-width: 480px;
       }
@@ -1414,96 +1588,36 @@ _.styles = [
       }
     `
 ];
-E([
+S([
   h({ attribute: !1 })
 ], _.prototype, "hass", 2);
-E([
+S([
   h({ type: String })
 ], _.prototype, "zone", 2);
-E([
+S([
   h({ type: String })
 ], _.prototype, "zoneName", 2);
-E([
+S([
   h({ attribute: !1 })
 ], _.prototype, "entities", 2);
-E([
-  D()
+S([
+  U()
 ], _.prototype, "_activeTab", 2);
-E([
-  D()
+S([
+  U()
 ], _.prototype, "_isOpen", 2);
-E([
-  lt("dialog")
+S([
+  ht("dialog")
 ], _.prototype, "_dialog", 2);
-_ = E([
-  M("comfort-band-modal")
+_ = S([
+  T("comfort-band-modal")
 ], _);
-const zt = "comfort_band", $e = {
-  effective_low: "effectiveLow",
-  effective_high: "effectiveHigh",
-  room_temperature: "roomTemperature",
-  override_ends: "overrideEnds",
-  current_action: "currentAction",
-  override_active: "overrideActive",
-  manual_low: "manualLow",
-  manual_high: "manualHigh",
-  override_hours: "overrideHours",
-  deadband_below: "deadbandBelow",
-  deadband_above: "deadbandAbove",
-  min_cycle_minutes: "minCycleMinutes",
-  cancel_override: "cancelOverride",
-  enabled: "enabled"
-};
-function ye() {
-  return {
-    effectiveLow: null,
-    effectiveHigh: null,
-    roomTemperature: null,
-    overrideEnds: null,
-    currentAction: null,
-    overrideActive: null,
-    manualLow: null,
-    manualHigh: null,
-    overrideHours: null,
-    deadbandBelow: null,
-    deadbandAbove: null,
-    minCycleMinutes: null,
-    cancelOverride: null,
-    enabled: null,
-    deviceId: null,
-    deviceName: null
-  };
-}
-function we(i, t) {
-  for (const e of Object.values(i.devices))
-    for (const [r, s] of e.identifiers)
-      if (r === t[0] && s === t[1])
-        return e;
-  return null;
-}
-function xe(i, t) {
-  return Object.values(i.entities).filter(
-    (e) => e.device_id === t && e.platform === zt
-  );
-}
-function Ae(i, t) {
-  const e = ye(), r = we(i, [zt, `zone:${t}`]);
-  if (r === null) return e;
-  e.deviceId = r.id, e.deviceName = r.name_by_user ?? r.name;
-  const s = `${t}_`;
-  for (const o of xe(i, r.id)) {
-    if (!o.unique_id.startsWith(s)) continue;
-    const n = o.unique_id.slice(s.length), c = $e[n];
-    c !== void 0 && (e[c] = o.entity_id);
-  }
-  return e;
-}
-var Ee = Object.defineProperty, Se = Object.getOwnPropertyDescriptor, Q = (i, t, e, r) => {
-  for (var s = r > 1 ? void 0 : r ? Se(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+var Te = Object.defineProperty, ze = Object.getOwnPropertyDescriptor, tt = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? ze(t, e) : t, o = i.length - 1, n; o >= 0; o--)
     (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
-  return r && s && Ee(t, e, s), s;
+  return r && s && Te(t, e, s), s;
 };
-let k = class extends b {
+let D = class extends v {
   constructor() {
     super(...arguments), this._onTileTap = () => {
       this._modal?.open();
@@ -1519,15 +1633,15 @@ let k = class extends b {
     return 2;
   }
   render() {
-    if (!this._config || !this.hass) return f``;
+    if (!this._config || !this.hass) return p``;
     const i = this._config.zone, t = Ae(this.hass, i);
     if (t.deviceId === null)
-      return f`<div class="placeholder">
+      return p`<div class="placeholder">
         Comfort Band zone <code>${i}</code> not found. Add it via Settings → Devices &
         Services.
       </div>`;
     const e = this._config.compact === !0, r = this._buildView(this.hass, t);
-    return f`
+    return p`
       <comfort-band-tile
         zoneName=${r.zoneName}
         .roomTemp=${r.roomTemp}
@@ -1539,7 +1653,7 @@ let k = class extends b {
         .noExpand=${e}
         @comfort-band-tile-tap=${this._onTileTap}
       ></comfort-band-tile>
-      ${e ? null : f`<comfort-band-modal
+      ${e ? null : p`<comfort-band-modal
             .hass=${this.hass}
             zone=${i}
             zoneName=${r.zoneName}
@@ -1565,9 +1679,9 @@ let k = class extends b {
     };
   }
 };
-k.styles = [
-  U,
-  O`
+D.styles = [
+  z,
+  E`
       :host {
         display: block;
       }
@@ -1581,18 +1695,18 @@ k.styles = [
       }
     `
 ];
-Q([
+tt([
   h({ attribute: !1 })
-], k.prototype, "hass", 2);
-Q([
-  D()
-], k.prototype, "_config", 2);
-Q([
-  lt("comfort-band-modal")
-], k.prototype, "_modal", 2);
-k = Q([
-  M("comfort-band-card")
-], k);
+], D.prototype, "hass", 2);
+tt([
+  U()
+], D.prototype, "_config", 2);
+tt([
+  ht("comfort-band-modal")
+], D.prototype, "_modal", 2);
+D = tt([
+  T("comfort-band-card")
+], D);
 (window.customCards ??= []).push({
   type: "comfort-band-card",
   name: "Comfort Band",

--- a/dist/comfort-band-card.js
+++ b/dist/comfort-band-card.js
@@ -1,0 +1,587 @@
+const M = globalThis, k = M.ShadowRoot && (M.ShadyCSS === void 0 || M.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, z = Symbol(), V = /* @__PURE__ */ new WeakMap();
+let st = class {
+  constructor(t, e, s) {
+    if (this._$cssResult$ = !0, s !== z) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    this.cssText = t, this.t = e;
+  }
+  get styleSheet() {
+    let t = this.o;
+    const e = this.t;
+    if (k && t === void 0) {
+      const s = e !== void 0 && e.length === 1;
+      s && (t = V.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), s && V.set(e, t));
+    }
+    return t;
+  }
+  toString() {
+    return this.cssText;
+  }
+};
+const at = (r) => new st(typeof r == "string" ? r : r + "", void 0, z), lt = (r, ...t) => {
+  const e = r.length === 1 ? r[0] : t.reduce((s, i, o) => s + ((n) => {
+    if (n._$cssResult$ === !0) return n.cssText;
+    if (typeof n == "number") return n;
+    throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
+  })(i) + r[o + 1], r[0]);
+  return new st(e, r, z);
+}, ct = (r, t) => {
+  if (k) r.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  else for (const e of t) {
+    const s = document.createElement("style"), i = M.litNonce;
+    i !== void 0 && s.setAttribute("nonce", i), s.textContent = e.cssText, r.appendChild(s);
+  }
+}, W = k ? (r) => r : (r) => r instanceof CSSStyleSheet ? ((t) => {
+  let e = "";
+  for (const s of t.cssRules) e += s.cssText;
+  return at(e);
+})(r) : r;
+const { is: dt, defineProperty: pt, getOwnPropertyDescriptor: ut, getOwnPropertyNames: $t, getOwnPropertySymbols: ft, getPrototypeOf: _t } = Object, N = globalThis, F = N.trustedTypes, mt = F ? F.emptyScript : "", At = N.reactiveElementPolyfillSupport, E = (r, t) => r, H = { toAttribute(r, t) {
+  switch (t) {
+    case Boolean:
+      r = r ? mt : null;
+      break;
+    case Object:
+    case Array:
+      r = r == null ? r : JSON.stringify(r);
+  }
+  return r;
+}, fromAttribute(r, t) {
+  let e = r;
+  switch (t) {
+    case Boolean:
+      e = r !== null;
+      break;
+    case Number:
+      e = r === null ? null : Number(r);
+      break;
+    case Object:
+    case Array:
+      try {
+        e = JSON.parse(r);
+      } catch {
+        e = null;
+      }
+  }
+  return e;
+} }, j = (r, t) => !dt(r, t), Z = { attribute: !0, type: String, converter: H, reflect: !1, useDefault: !1, hasChanged: j };
+Symbol.metadata ??= Symbol("metadata"), N.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
+let g = class extends HTMLElement {
+  static addInitializer(t) {
+    this._$Ei(), (this.l ??= []).push(t);
+  }
+  static get observedAttributes() {
+    return this.finalize(), this._$Eh && [...this._$Eh.keys()];
+  }
+  static createProperty(t, e = Z) {
+    if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
+      const s = Symbol(), i = this.getPropertyDescriptor(t, s, e);
+      i !== void 0 && pt(this.prototype, t, i);
+    }
+  }
+  static getPropertyDescriptor(t, e, s) {
+    const { get: i, set: o } = ut(this.prototype, t) ?? { get() {
+      return this[e];
+    }, set(n) {
+      this[e] = n;
+    } };
+    return { get: i, set(n) {
+      const a = i?.call(this);
+      o?.call(this, n), this.requestUpdate(t, a, s);
+    }, configurable: !0, enumerable: !0 };
+  }
+  static getPropertyOptions(t) {
+    return this.elementProperties.get(t) ?? Z;
+  }
+  static _$Ei() {
+    if (this.hasOwnProperty(E("elementProperties"))) return;
+    const t = _t(this);
+    t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
+  }
+  static finalize() {
+    if (this.hasOwnProperty(E("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(E("properties"))) {
+      const e = this.properties, s = [...$t(e), ...ft(e)];
+      for (const i of s) this.createProperty(i, e[i]);
+    }
+    const t = this[Symbol.metadata];
+    if (t !== null) {
+      const e = litPropertyMetadata.get(t);
+      if (e !== void 0) for (const [s, i] of e) this.elementProperties.set(s, i);
+    }
+    this._$Eh = /* @__PURE__ */ new Map();
+    for (const [e, s] of this.elementProperties) {
+      const i = this._$Eu(e, s);
+      i !== void 0 && this._$Eh.set(i, e);
+    }
+    this.elementStyles = this.finalizeStyles(this.styles);
+  }
+  static finalizeStyles(t) {
+    const e = [];
+    if (Array.isArray(t)) {
+      const s = new Set(t.flat(1 / 0).reverse());
+      for (const i of s) e.unshift(W(i));
+    } else t !== void 0 && e.push(W(t));
+    return e;
+  }
+  static _$Eu(t, e) {
+    const s = e.attribute;
+    return s === !1 ? void 0 : typeof s == "string" ? s : typeof t == "string" ? t.toLowerCase() : void 0;
+  }
+  constructor() {
+    super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
+  }
+  _$Ev() {
+    this._$ES = new Promise((t) => this.enableUpdating = t), this._$AL = /* @__PURE__ */ new Map(), this._$E_(), this.requestUpdate(), this.constructor.l?.forEach((t) => t(this));
+  }
+  addController(t) {
+    (this._$EO ??= /* @__PURE__ */ new Set()).add(t), this.renderRoot !== void 0 && this.isConnected && t.hostConnected?.();
+  }
+  removeController(t) {
+    this._$EO?.delete(t);
+  }
+  _$E_() {
+    const t = /* @__PURE__ */ new Map(), e = this.constructor.elementProperties;
+    for (const s of e.keys()) this.hasOwnProperty(s) && (t.set(s, this[s]), delete this[s]);
+    t.size > 0 && (this._$Ep = t);
+  }
+  createRenderRoot() {
+    const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
+    return ct(t, this.constructor.elementStyles), t;
+  }
+  connectedCallback() {
+    this.renderRoot ??= this.createRenderRoot(), this.enableUpdating(!0), this._$EO?.forEach((t) => t.hostConnected?.());
+  }
+  enableUpdating(t) {
+  }
+  disconnectedCallback() {
+    this._$EO?.forEach((t) => t.hostDisconnected?.());
+  }
+  attributeChangedCallback(t, e, s) {
+    this._$AK(t, s);
+  }
+  _$ET(t, e) {
+    const s = this.constructor.elementProperties.get(t), i = this.constructor._$Eu(t, s);
+    if (i !== void 0 && s.reflect === !0) {
+      const o = (s.converter?.toAttribute !== void 0 ? s.converter : H).toAttribute(e, s.type);
+      this._$Em = t, o == null ? this.removeAttribute(i) : this.setAttribute(i, o), this._$Em = null;
+    }
+  }
+  _$AK(t, e) {
+    const s = this.constructor, i = s._$Eh.get(t);
+    if (i !== void 0 && this._$Em !== i) {
+      const o = s.getPropertyOptions(i), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : H;
+      this._$Em = i;
+      const a = n.fromAttribute(e, o.type);
+      this[i] = a ?? this._$Ej?.get(i) ?? a, this._$Em = null;
+    }
+  }
+  requestUpdate(t, e, s, i = !1, o) {
+    if (t !== void 0) {
+      const n = this.constructor;
+      if (i === !1 && (o = this[t]), s ??= n.getPropertyOptions(t), !((s.hasChanged ?? j)(o, e) || s.useDefault && s.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, s)))) return;
+      this.C(t, e, s);
+    }
+    this.isUpdatePending === !1 && (this._$ES = this._$EP());
+  }
+  C(t, e, { useDefault: s, reflect: i, wrapped: o }, n) {
+    s && !(this._$Ej ??= /* @__PURE__ */ new Map()).has(t) && (this._$Ej.set(t, n ?? e ?? this[t]), o !== !0 || n !== void 0) || (this._$AL.has(t) || (this.hasUpdated || s || (e = void 0), this._$AL.set(t, e)), i === !0 && this._$Em !== t && (this._$Eq ??= /* @__PURE__ */ new Set()).add(t));
+  }
+  async _$EP() {
+    this.isUpdatePending = !0;
+    try {
+      await this._$ES;
+    } catch (e) {
+      Promise.reject(e);
+    }
+    const t = this.scheduleUpdate();
+    return t != null && await t, !this.isUpdatePending;
+  }
+  scheduleUpdate() {
+    return this.performUpdate();
+  }
+  performUpdate() {
+    if (!this.isUpdatePending) return;
+    if (!this.hasUpdated) {
+      if (this.renderRoot ??= this.createRenderRoot(), this._$Ep) {
+        for (const [i, o] of this._$Ep) this[i] = o;
+        this._$Ep = void 0;
+      }
+      const s = this.constructor.elementProperties;
+      if (s.size > 0) for (const [i, o] of s) {
+        const { wrapped: n } = o, a = this[i];
+        n !== !0 || this._$AL.has(i) || a === void 0 || this.C(i, void 0, o, a);
+      }
+    }
+    let t = !1;
+    const e = this._$AL;
+    try {
+      t = this.shouldUpdate(e), t ? (this.willUpdate(e), this._$EO?.forEach((s) => s.hostUpdate?.()), this.update(e)) : this._$EM();
+    } catch (s) {
+      throw t = !1, this._$EM(), s;
+    }
+    t && this._$AE(e);
+  }
+  willUpdate(t) {
+  }
+  _$AE(t) {
+    this._$EO?.forEach((e) => e.hostUpdated?.()), this.hasUpdated || (this.hasUpdated = !0, this.firstUpdated(t)), this.updated(t);
+  }
+  _$EM() {
+    this._$AL = /* @__PURE__ */ new Map(), this.isUpdatePending = !1;
+  }
+  get updateComplete() {
+    return this.getUpdateComplete();
+  }
+  getUpdateComplete() {
+    return this._$ES;
+  }
+  shouldUpdate(t) {
+    return !0;
+  }
+  update(t) {
+    this._$Eq &&= this._$Eq.forEach((e) => this._$ET(e, this[e])), this._$EM();
+  }
+  updated(t) {
+  }
+  firstUpdated(t) {
+  }
+};
+g.elementStyles = [], g.shadowRootOptions = { mode: "open" }, g[E("elementProperties")] = /* @__PURE__ */ new Map(), g[E("finalized")] = /* @__PURE__ */ new Map(), At?.({ ReactiveElement: g }), (N.reactiveElementVersions ??= []).push("2.1.2");
+const B = globalThis, J = (r) => r, T = B.trustedTypes, K = T ? T.createPolicy("lit-html", { createHTML: (r) => r }) : void 0, it = "$lit$", f = `lit$${Math.random().toFixed(9).slice(2)}$`, rt = "?" + f, gt = `<${rt}>`, A = document, w = () => A.createComment(""), C = (r) => r === null || typeof r != "object" && typeof r != "function", L = Array.isArray, yt = (r) => L(r) || typeof r?.[Symbol.iterator] == "function", D = `[ 	
+\f\r]`, b = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, G = /-->/g, Q = />/g, _ = RegExp(`>|${D}(?:([^\\s"'>=/]+)(${D}*=${D}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), X = /'/g, Y = /"/g, ot = /^(?:script|style|textarea|title)$/i, vt = (r) => (t, ...e) => ({ _$litType$: r, strings: t, values: e }), tt = vt(1), y = Symbol.for("lit-noChange"), d = Symbol.for("lit-nothing"), et = /* @__PURE__ */ new WeakMap(), m = A.createTreeWalker(A, 129);
+function nt(r, t) {
+  if (!L(r) || !r.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return K !== void 0 ? K.createHTML(t) : t;
+}
+const bt = (r, t) => {
+  const e = r.length - 1, s = [];
+  let i, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = b;
+  for (let a = 0; a < e; a++) {
+    const h = r[a];
+    let c, p, l = -1, u = 0;
+    for (; u < h.length && (n.lastIndex = u, p = n.exec(h), p !== null); ) u = n.lastIndex, n === b ? p[1] === "!--" ? n = G : p[1] !== void 0 ? n = Q : p[2] !== void 0 ? (ot.test(p[2]) && (i = RegExp("</" + p[2], "g")), n = _) : p[3] !== void 0 && (n = _) : n === _ ? p[0] === ">" ? (n = i ?? b, l = -1) : p[1] === void 0 ? l = -2 : (l = n.lastIndex - p[2].length, c = p[1], n = p[3] === void 0 ? _ : p[3] === '"' ? Y : X) : n === Y || n === X ? n = _ : n === G || n === Q ? n = b : (n = _, i = void 0);
+    const $ = n === _ && r[a + 1].startsWith("/>") ? " " : "";
+    o += n === b ? h + gt : l >= 0 ? (s.push(c), h.slice(0, l) + it + h.slice(l) + f + $) : h + f + (l === -2 ? a : $);
+  }
+  return [nt(r, o + (r[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), s];
+};
+class P {
+  constructor({ strings: t, _$litType$: e }, s) {
+    let i;
+    this.parts = [];
+    let o = 0, n = 0;
+    const a = t.length - 1, h = this.parts, [c, p] = bt(t, e);
+    if (this.el = P.createElement(c, s), m.currentNode = this.el.content, e === 2 || e === 3) {
+      const l = this.el.content.firstChild;
+      l.replaceWith(...l.childNodes);
+    }
+    for (; (i = m.nextNode()) !== null && h.length < a; ) {
+      if (i.nodeType === 1) {
+        if (i.hasAttributes()) for (const l of i.getAttributeNames()) if (l.endsWith(it)) {
+          const u = p[n++], $ = i.getAttribute(l).split(f), U = /([.?@])?(.*)/.exec(u);
+          h.push({ type: 1, index: o, name: U[2], strings: $, ctor: U[1] === "." ? St : U[1] === "?" ? wt : U[1] === "@" ? Ct : R }), i.removeAttribute(l);
+        } else l.startsWith(f) && (h.push({ type: 6, index: o }), i.removeAttribute(l));
+        if (ot.test(i.tagName)) {
+          const l = i.textContent.split(f), u = l.length - 1;
+          if (u > 0) {
+            i.textContent = T ? T.emptyScript : "";
+            for (let $ = 0; $ < u; $++) i.append(l[$], w()), m.nextNode(), h.push({ type: 2, index: ++o });
+            i.append(l[u], w());
+          }
+        }
+      } else if (i.nodeType === 8) if (i.data === rt) h.push({ type: 2, index: o });
+      else {
+        let l = -1;
+        for (; (l = i.data.indexOf(f, l + 1)) !== -1; ) h.push({ type: 7, index: o }), l += f.length - 1;
+      }
+      o++;
+    }
+  }
+  static createElement(t, e) {
+    const s = A.createElement("template");
+    return s.innerHTML = t, s;
+  }
+}
+function v(r, t, e = r, s) {
+  if (t === y) return t;
+  let i = s !== void 0 ? e._$Co?.[s] : e._$Cl;
+  const o = C(t) ? void 0 : t._$litDirective$;
+  return i?.constructor !== o && (i?._$AO?.(!1), o === void 0 ? i = void 0 : (i = new o(r), i._$AT(r, e, s)), s !== void 0 ? (e._$Co ??= [])[s] = i : e._$Cl = i), i !== void 0 && (t = v(r, i._$AS(r, t.values), i, s)), t;
+}
+class Et {
+  constructor(t, e) {
+    this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
+  }
+  get parentNode() {
+    return this._$AM.parentNode;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  u(t) {
+    const { el: { content: e }, parts: s } = this._$AD, i = (t?.creationScope ?? A).importNode(e, !0);
+    m.currentNode = i;
+    let o = m.nextNode(), n = 0, a = 0, h = s[0];
+    for (; h !== void 0; ) {
+      if (n === h.index) {
+        let c;
+        h.type === 2 ? c = new O(o, o.nextSibling, this, t) : h.type === 1 ? c = new h.ctor(o, h.name, h.strings, this, t) : h.type === 6 && (c = new Pt(o, this, t)), this._$AV.push(c), h = s[++a];
+      }
+      n !== h?.index && (o = m.nextNode(), n++);
+    }
+    return m.currentNode = A, i;
+  }
+  p(t) {
+    let e = 0;
+    for (const s of this._$AV) s !== void 0 && (s.strings !== void 0 ? (s._$AI(t, s, e), e += s.strings.length - 2) : s._$AI(t[e])), e++;
+  }
+}
+class O {
+  get _$AU() {
+    return this._$AM?._$AU ?? this._$Cv;
+  }
+  constructor(t, e, s, i) {
+    this.type = 2, this._$AH = d, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = s, this.options = i, this._$Cv = i?.isConnected ?? !0;
+  }
+  get parentNode() {
+    let t = this._$AA.parentNode;
+    const e = this._$AM;
+    return e !== void 0 && t?.nodeType === 11 && (t = e.parentNode), t;
+  }
+  get startNode() {
+    return this._$AA;
+  }
+  get endNode() {
+    return this._$AB;
+  }
+  _$AI(t, e = this) {
+    t = v(this, t, e), C(t) ? t === d || t == null || t === "" ? (this._$AH !== d && this._$AR(), this._$AH = d) : t !== this._$AH && t !== y && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : yt(t) ? this.k(t) : this._(t);
+  }
+  O(t) {
+    return this._$AA.parentNode.insertBefore(t, this._$AB);
+  }
+  T(t) {
+    this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
+  }
+  _(t) {
+    this._$AH !== d && C(this._$AH) ? this._$AA.nextSibling.data = t : this.T(A.createTextNode(t)), this._$AH = t;
+  }
+  $(t) {
+    const { values: e, _$litType$: s } = t, i = typeof s == "number" ? this._$AC(t) : (s.el === void 0 && (s.el = P.createElement(nt(s.h, s.h[0]), this.options)), s);
+    if (this._$AH?._$AD === i) this._$AH.p(e);
+    else {
+      const o = new Et(i, this), n = o.u(this.options);
+      o.p(e), this.T(n), this._$AH = o;
+    }
+  }
+  _$AC(t) {
+    let e = et.get(t.strings);
+    return e === void 0 && et.set(t.strings, e = new P(t)), e;
+  }
+  k(t) {
+    L(this._$AH) || (this._$AH = [], this._$AR());
+    const e = this._$AH;
+    let s, i = 0;
+    for (const o of t) i === e.length ? e.push(s = new O(this.O(w()), this.O(w()), this, this.options)) : s = e[i], s._$AI(o), i++;
+    i < e.length && (this._$AR(s && s._$AB.nextSibling, i), e.length = i);
+  }
+  _$AR(t = this._$AA.nextSibling, e) {
+    for (this._$AP?.(!1, !0, e); t !== this._$AB; ) {
+      const s = J(t).nextSibling;
+      J(t).remove(), t = s;
+    }
+  }
+  setConnected(t) {
+    this._$AM === void 0 && (this._$Cv = t, this._$AP?.(t));
+  }
+}
+class R {
+  get tagName() {
+    return this.element.tagName;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  constructor(t, e, s, i, o) {
+    this.type = 1, this._$AH = d, this._$AN = void 0, this.element = t, this.name = e, this._$AM = i, this.options = o, s.length > 2 || s[0] !== "" || s[1] !== "" ? (this._$AH = Array(s.length - 1).fill(new String()), this.strings = s) : this._$AH = d;
+  }
+  _$AI(t, e = this, s, i) {
+    const o = this.strings;
+    let n = !1;
+    if (o === void 0) t = v(this, t, e, 0), n = !C(t) || t !== this._$AH && t !== y, n && (this._$AH = t);
+    else {
+      const a = t;
+      let h, c;
+      for (t = o[0], h = 0; h < o.length - 1; h++) c = v(this, a[s + h], e, h), c === y && (c = this._$AH[h]), n ||= !C(c) || c !== this._$AH[h], c === d ? t = d : t !== d && (t += (c ?? "") + o[h + 1]), this._$AH[h] = c;
+    }
+    n && !i && this.j(t);
+  }
+  j(t) {
+    t === d ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+  }
+}
+class St extends R {
+  constructor() {
+    super(...arguments), this.type = 3;
+  }
+  j(t) {
+    this.element[this.name] = t === d ? void 0 : t;
+  }
+}
+class wt extends R {
+  constructor() {
+    super(...arguments), this.type = 4;
+  }
+  j(t) {
+    this.element.toggleAttribute(this.name, !!t && t !== d);
+  }
+}
+class Ct extends R {
+  constructor(t, e, s, i, o) {
+    super(t, e, s, i, o), this.type = 5;
+  }
+  _$AI(t, e = this) {
+    if ((t = v(this, t, e, 0) ?? d) === y) return;
+    const s = this._$AH, i = t === d && s !== d || t.capture !== s.capture || t.once !== s.once || t.passive !== s.passive, o = t !== d && (s === d || i);
+    i && this.element.removeEventListener(this.name, this, s), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
+  }
+  handleEvent(t) {
+    typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, t) : this._$AH.handleEvent(t);
+  }
+}
+class Pt {
+  constructor(t, e, s) {
+    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = s;
+  }
+  get _$AU() {
+    return this._$AM._$AU;
+  }
+  _$AI(t) {
+    v(this, t);
+  }
+}
+const xt = B.litHtmlPolyfillSupport;
+xt?.(P, O), (B.litHtmlVersions ??= []).push("3.3.2");
+const Ot = (r, t, e) => {
+  const s = e?.renderBefore ?? t;
+  let i = s._$litPart$;
+  if (i === void 0) {
+    const o = e?.renderBefore ?? null;
+    s._$litPart$ = i = new O(t.insertBefore(w(), o), o, void 0, e ?? {});
+  }
+  return i._$AI(r), i;
+};
+const I = globalThis;
+class S extends g {
+  constructor() {
+    super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
+  }
+  createRenderRoot() {
+    const t = super.createRenderRoot();
+    return this.renderOptions.renderBefore ??= t.firstChild, t;
+  }
+  update(t) {
+    const e = this.render();
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Ot(e, this.renderRoot, this.renderOptions);
+  }
+  connectedCallback() {
+    super.connectedCallback(), this._$Do?.setConnected(!0);
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback(), this._$Do?.setConnected(!1);
+  }
+  render() {
+    return y;
+  }
+}
+S._$litElement$ = !0, S.finalized = !0, I.litElementHydrateSupport?.({ LitElement: S });
+const Ut = I.litElementPolyfillSupport;
+Ut?.({ LitElement: S });
+(I.litElementVersions ??= []).push("4.2.2");
+const Mt = (r) => (t, e) => {
+  e !== void 0 ? e.addInitializer(() => {
+    customElements.define(r, t);
+  }) : customElements.define(r, t);
+};
+const Ht = { attribute: !0, type: String, converter: H, reflect: !1, hasChanged: j }, Tt = (r = Ht, t, e) => {
+  const { kind: s, metadata: i } = e;
+  let o = globalThis.litPropertyMetadata.get(i);
+  if (o === void 0 && globalThis.litPropertyMetadata.set(i, o = /* @__PURE__ */ new Map()), s === "setter" && ((r = Object.create(r)).wrapped = !0), o.set(e.name, r), s === "accessor") {
+    const { name: n } = e;
+    return { set(a) {
+      const h = t.get.call(this);
+      t.set.call(this, a), this.requestUpdate(n, h, r, !0, a);
+    }, init(a) {
+      return a !== void 0 && this.C(n, void 0, r, a), a;
+    } };
+  }
+  if (s === "setter") {
+    const { name: n } = e;
+    return function(a) {
+      const h = this[n];
+      t.call(this, a), this.requestUpdate(n, h, r, !0, a);
+    };
+  }
+  throw Error("Unsupported decorator location: " + s);
+};
+function ht(r) {
+  return (t, e) => typeof e == "object" ? Tt(r, t, e) : ((s, i, o) => {
+    const n = i.hasOwnProperty(o);
+    return i.constructor.createProperty(o, s), n ? Object.getOwnPropertyDescriptor(i, o) : void 0;
+  })(r, t, e);
+}
+function Nt(r) {
+  return ht({ ...r, state: !0, attribute: !1 });
+}
+var Rt = Object.defineProperty, Dt = Object.getOwnPropertyDescriptor, q = (r, t, e, s) => {
+  for (var i = s > 1 ? void 0 : s ? Dt(t, e) : t, o = r.length - 1, n; o >= 0; o--)
+    (n = r[o]) && (i = (s ? n(t, e, i) : n(i)) || i);
+  return s && i && Rt(t, e, i), i;
+};
+let x = class extends S {
+  setConfig(r) {
+    if (!r?.zone)
+      throw new Error("comfort-band-card: `zone` is required");
+    this._config = r;
+  }
+  render() {
+    return this._config ? tt`<div class="stub">comfort-band-card · zone: ${this._config.zone}</div>` : tt``;
+  }
+};
+x.styles = lt`
+    :host {
+      display: block;
+      padding: 12px;
+      border-radius: 12px;
+      background: var(--ha-card-background, var(--card-background-color, #fff));
+      box-shadow: var(--ha-card-box-shadow, none);
+    }
+    .stub {
+      color: var(--primary-text-color, #000);
+      font-family: var(--paper-font-body1_-_font-family, sans-serif);
+    }
+  `;
+q([
+  ht({ attribute: !1 })
+], x.prototype, "hass", 2);
+q([
+  Nt()
+], x.prototype, "_config", 2);
+x = q([
+  Mt("comfort-band-card")
+], x);
+(window.customCards ??= []).push({
+  type: "comfort-band-card",
+  name: "Comfort Band",
+  description: "Schedule editor and live status for a Comfort Band zone.",
+  preview: !1
+});
+console.info(
+  "%c COMFORT-BAND-CARD %c v0.1.0-dev ",
+  "color:white;background:#2196F3;padding:2px 4px;border-radius:3px",
+  "color:#000;background:#fff;padding:2px 4px;border-radius:3px"
+);
+export {
+  x as ComfortBandCard
+};

--- a/dist/comfort-band-card.js
+++ b/dist/comfort-band-card.js
@@ -1,15 +1,15 @@
-const D = globalThis, K = D.ShadowRoot && (D.ShadyCSS === void 0 || D.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, Z = Symbol(), it = /* @__PURE__ */ new WeakMap();
-let ut = class {
-  constructor(t, e, i) {
-    if (this._$cssResult$ = !0, i !== Z) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+const Z = globalThis, rt = Z.ShadowRoot && (Z.ShadyCSS === void 0 || Z.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, st = Symbol(), pt = /* @__PURE__ */ new WeakMap();
+let xt = class {
+  constructor(t, e, r) {
+    if (this._$cssResult$ = !0, r !== st) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = t, this.t = e;
   }
   get styleSheet() {
     let t = this.o;
     const e = this.t;
-    if (K && t === void 0) {
-      const i = e !== void 0 && e.length === 1;
-      i && (t = it.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), i && it.set(e, t));
+    if (rt && t === void 0) {
+      const r = e !== void 0 && e.length === 1;
+      r && (t = pt.get(e)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && pt.set(e, t));
     }
     return t;
   }
@@ -17,115 +17,115 @@ let ut = class {
     return this.cssText;
   }
 };
-const wt = (s) => new ut(typeof s == "string" ? s : s + "", void 0, Z), L = (s, ...t) => {
-  const e = s.length === 1 ? s[0] : t.reduce((i, r, o) => i + ((n) => {
+const Ht = (i) => new xt(typeof i == "string" ? i : i + "", void 0, st), O = (i, ...t) => {
+  const e = i.length === 1 ? i[0] : t.reduce((r, s, o) => r + ((n) => {
     if (n._$cssResult$ === !0) return n.cssText;
     if (typeof n == "number") return n;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-  })(r) + s[o + 1], s[0]);
-  return new ut(e, s, Z);
-}, xt = (s, t) => {
-  if (K) s.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+  })(s) + i[o + 1], i[0]);
+  return new xt(e, i, st);
+}, kt = (i, t) => {
+  if (rt) i.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
   else for (const e of t) {
-    const i = document.createElement("style"), r = D.litNonce;
-    r !== void 0 && i.setAttribute("nonce", r), i.textContent = e.cssText, s.appendChild(i);
+    const r = document.createElement("style"), s = Z.litNonce;
+    s !== void 0 && r.setAttribute("nonce", s), r.textContent = e.cssText, i.appendChild(r);
   }
-}, rt = K ? (s) => s : (s) => s instanceof CSSStyleSheet ? ((t) => {
+}, ut = rt ? (i) => i : (i) => i instanceof CSSStyleSheet ? ((t) => {
   let e = "";
-  for (const i of t.cssRules) e += i.cssText;
-  return wt(e);
-})(s) : s;
-const { is: Et, defineProperty: St, getOwnPropertyDescriptor: Nt, getOwnPropertyNames: Ct, getOwnPropertySymbols: Pt, getPrototypeOf: Ot } = Object, I = globalThis, st = I.trustedTypes, Tt = st ? st.emptyScript : "", Mt = I.reactiveElementPolyfillSupport, P = (s, t) => s, j = { toAttribute(s, t) {
+  for (const r of t.cssRules) e += r.cssText;
+  return Ht(e);
+})(i) : i;
+const { is: Mt, defineProperty: Dt, getOwnPropertyDescriptor: Ut, getOwnPropertyNames: Rt, getOwnPropertySymbols: Lt, getPrototypeOf: jt } = Object, J = globalThis, ft = J.trustedTypes, Bt = ft ? ft.emptyScript : "", It = J.reactiveElementPolyfillSupport, j = (i, t) => i, G = { toAttribute(i, t) {
   switch (t) {
     case Boolean:
-      s = s ? Tt : null;
+      i = i ? Bt : null;
       break;
     case Object:
     case Array:
-      s = s == null ? s : JSON.stringify(s);
+      i = i == null ? i : JSON.stringify(i);
   }
-  return s;
-}, fromAttribute(s, t) {
-  let e = s;
+  return i;
+}, fromAttribute(i, t) {
+  let e = i;
   switch (t) {
     case Boolean:
-      e = s !== null;
+      e = i !== null;
       break;
     case Number:
-      e = s === null ? null : Number(s);
+      e = i === null ? null : Number(i);
       break;
     case Object:
     case Array:
       try {
-        e = JSON.parse(s);
+        e = JSON.parse(i);
       } catch {
         e = null;
       }
   }
   return e;
-} }, G = (s, t) => !Et(s, t), ot = { attribute: !0, type: String, converter: j, reflect: !1, useDefault: !1, hasChanged: G };
-Symbol.metadata ??= Symbol("metadata"), I.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
-let E = class extends HTMLElement {
+} }, ot = (i, t) => !Mt(i, t), mt = { attribute: !0, type: String, converter: G, reflect: !1, useDefault: !1, hasChanged: ot };
+Symbol.metadata ??= Symbol("metadata"), J.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
+let T = class extends HTMLElement {
   static addInitializer(t) {
     this._$Ei(), (this.l ??= []).push(t);
   }
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, e = ot) {
+  static createProperty(t, e = mt) {
     if (e.state && (e.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((e = Object.create(e)).wrapped = !0), this.elementProperties.set(t, e), !e.noAccessor) {
-      const i = Symbol(), r = this.getPropertyDescriptor(t, i, e);
-      r !== void 0 && St(this.prototype, t, r);
+      const r = Symbol(), s = this.getPropertyDescriptor(t, r, e);
+      s !== void 0 && Dt(this.prototype, t, s);
     }
   }
-  static getPropertyDescriptor(t, e, i) {
-    const { get: r, set: o } = Nt(this.prototype, t) ?? { get() {
+  static getPropertyDescriptor(t, e, r) {
+    const { get: s, set: o } = Ut(this.prototype, t) ?? { get() {
       return this[e];
     }, set(n) {
       this[e] = n;
     } };
-    return { get: r, set(n) {
-      const c = r?.call(this);
-      o?.call(this, n), this.requestUpdate(t, c, i);
+    return { get: s, set(n) {
+      const c = s?.call(this);
+      o?.call(this, n), this.requestUpdate(t, c, r);
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? ot;
+    return this.elementProperties.get(t) ?? mt;
   }
   static _$Ei() {
-    if (this.hasOwnProperty(P("elementProperties"))) return;
-    const t = Ot(this);
+    if (this.hasOwnProperty(j("elementProperties"))) return;
+    const t = jt(this);
     t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
-    if (this.hasOwnProperty(P("finalized"))) return;
-    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(P("properties"))) {
-      const e = this.properties, i = [...Ct(e), ...Pt(e)];
-      for (const r of i) this.createProperty(r, e[r]);
+    if (this.hasOwnProperty(j("finalized"))) return;
+    if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(j("properties"))) {
+      const e = this.properties, r = [...Rt(e), ...Lt(e)];
+      for (const s of r) this.createProperty(s, e[s]);
     }
     const t = this[Symbol.metadata];
     if (t !== null) {
       const e = litPropertyMetadata.get(t);
-      if (e !== void 0) for (const [i, r] of e) this.elementProperties.set(i, r);
+      if (e !== void 0) for (const [r, s] of e) this.elementProperties.set(r, s);
     }
     this._$Eh = /* @__PURE__ */ new Map();
-    for (const [e, i] of this.elementProperties) {
-      const r = this._$Eu(e, i);
-      r !== void 0 && this._$Eh.set(r, e);
+    for (const [e, r] of this.elementProperties) {
+      const s = this._$Eu(e, r);
+      s !== void 0 && this._$Eh.set(s, e);
     }
     this.elementStyles = this.finalizeStyles(this.styles);
   }
   static finalizeStyles(t) {
     const e = [];
     if (Array.isArray(t)) {
-      const i = new Set(t.flat(1 / 0).reverse());
-      for (const r of i) e.unshift(rt(r));
-    } else t !== void 0 && e.push(rt(t));
+      const r = new Set(t.flat(1 / 0).reverse());
+      for (const s of r) e.unshift(ut(s));
+    } else t !== void 0 && e.push(ut(t));
     return e;
   }
   static _$Eu(t, e) {
-    const i = e.attribute;
-    return i === !1 ? void 0 : typeof i == "string" ? i : typeof t == "string" ? t.toLowerCase() : void 0;
+    const r = e.attribute;
+    return r === !1 ? void 0 : typeof r == "string" ? r : typeof t == "string" ? t.toLowerCase() : void 0;
   }
   constructor() {
     super(), this._$Ep = void 0, this.isUpdatePending = !1, this.hasUpdated = !1, this._$Em = null, this._$Ev();
@@ -141,12 +141,12 @@ let E = class extends HTMLElement {
   }
   _$E_() {
     const t = /* @__PURE__ */ new Map(), e = this.constructor.elementProperties;
-    for (const i of e.keys()) this.hasOwnProperty(i) && (t.set(i, this[i]), delete this[i]);
+    for (const r of e.keys()) this.hasOwnProperty(r) && (t.set(r, this[r]), delete this[r]);
     t.size > 0 && (this._$Ep = t);
   }
   createRenderRoot() {
     const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return xt(t, this.constructor.elementStyles), t;
+    return kt(t, this.constructor.elementStyles), t;
   }
   connectedCallback() {
     this.renderRoot ??= this.createRenderRoot(), this.enableUpdating(!0), this._$EO?.forEach((t) => t.hostConnected?.());
@@ -156,35 +156,35 @@ let E = class extends HTMLElement {
   disconnectedCallback() {
     this._$EO?.forEach((t) => t.hostDisconnected?.());
   }
-  attributeChangedCallback(t, e, i) {
-    this._$AK(t, i);
+  attributeChangedCallback(t, e, r) {
+    this._$AK(t, r);
   }
   _$ET(t, e) {
-    const i = this.constructor.elementProperties.get(t), r = this.constructor._$Eu(t, i);
-    if (r !== void 0 && i.reflect === !0) {
-      const o = (i.converter?.toAttribute !== void 0 ? i.converter : j).toAttribute(e, i.type);
-      this._$Em = t, o == null ? this.removeAttribute(r) : this.setAttribute(r, o), this._$Em = null;
+    const r = this.constructor.elementProperties.get(t), s = this.constructor._$Eu(t, r);
+    if (s !== void 0 && r.reflect === !0) {
+      const o = (r.converter?.toAttribute !== void 0 ? r.converter : G).toAttribute(e, r.type);
+      this._$Em = t, o == null ? this.removeAttribute(s) : this.setAttribute(s, o), this._$Em = null;
     }
   }
   _$AK(t, e) {
-    const i = this.constructor, r = i._$Eh.get(t);
-    if (r !== void 0 && this._$Em !== r) {
-      const o = i.getPropertyOptions(r), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : j;
-      this._$Em = r;
+    const r = this.constructor, s = r._$Eh.get(t);
+    if (s !== void 0 && this._$Em !== s) {
+      const o = r.getPropertyOptions(s), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : G;
+      this._$Em = s;
       const c = n.fromAttribute(e, o.type);
-      this[r] = c ?? this._$Ej?.get(r) ?? c, this._$Em = null;
+      this[s] = c ?? this._$Ej?.get(s) ?? c, this._$Em = null;
     }
   }
-  requestUpdate(t, e, i, r = !1, o) {
+  requestUpdate(t, e, r, s = !1, o) {
     if (t !== void 0) {
       const n = this.constructor;
-      if (r === !1 && (o = this[t]), i ??= n.getPropertyOptions(t), !((i.hasChanged ?? G)(o, e) || i.useDefault && i.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, i)))) return;
-      this.C(t, e, i);
+      if (s === !1 && (o = this[t]), r ??= n.getPropertyOptions(t), !((r.hasChanged ?? ot)(o, e) || r.useDefault && r.reflect && o === this._$Ej?.get(t) && !this.hasAttribute(n._$Eu(t, r)))) return;
+      this.C(t, e, r);
     }
     this.isUpdatePending === !1 && (this._$ES = this._$EP());
   }
-  C(t, e, { useDefault: i, reflect: r, wrapped: o }, n) {
-    i && !(this._$Ej ??= /* @__PURE__ */ new Map()).has(t) && (this._$Ej.set(t, n ?? e ?? this[t]), o !== !0 || n !== void 0) || (this._$AL.has(t) || (this.hasUpdated || i || (e = void 0), this._$AL.set(t, e)), r === !0 && this._$Em !== t && (this._$Eq ??= /* @__PURE__ */ new Set()).add(t));
+  C(t, e, { useDefault: r, reflect: s, wrapped: o }, n) {
+    r && !(this._$Ej ??= /* @__PURE__ */ new Map()).has(t) && (this._$Ej.set(t, n ?? e ?? this[t]), o !== !0 || n !== void 0) || (this._$AL.has(t) || (this.hasUpdated || r || (e = void 0), this._$AL.set(t, e)), s === !0 && this._$Em !== t && (this._$Eq ??= /* @__PURE__ */ new Set()).add(t));
   }
   async _$EP() {
     this.isUpdatePending = !0;
@@ -203,21 +203,21 @@ let E = class extends HTMLElement {
     if (!this.isUpdatePending) return;
     if (!this.hasUpdated) {
       if (this.renderRoot ??= this.createRenderRoot(), this._$Ep) {
-        for (const [r, o] of this._$Ep) this[r] = o;
+        for (const [s, o] of this._$Ep) this[s] = o;
         this._$Ep = void 0;
       }
-      const i = this.constructor.elementProperties;
-      if (i.size > 0) for (const [r, o] of i) {
-        const { wrapped: n } = o, c = this[r];
-        n !== !0 || this._$AL.has(r) || c === void 0 || this.C(r, void 0, o, c);
+      const r = this.constructor.elementProperties;
+      if (r.size > 0) for (const [s, o] of r) {
+        const { wrapped: n } = o, c = this[s];
+        n !== !0 || this._$AL.has(s) || c === void 0 || this.C(s, void 0, o, c);
       }
     }
     let t = !1;
     const e = this._$AL;
     try {
-      t = this.shouldUpdate(e), t ? (this.willUpdate(e), this._$EO?.forEach((i) => i.hostUpdate?.()), this.update(e)) : this._$EM();
-    } catch (i) {
-      throw t = !1, this._$EM(), i;
+      t = this.shouldUpdate(e), t ? (this.willUpdate(e), this._$EO?.forEach((r) => r.hostUpdate?.()), this.update(e)) : this._$EM();
+    } catch (r) {
+      throw t = !1, this._$EM(), r;
     }
     t && this._$AE(e);
   }
@@ -246,70 +246,70 @@ let E = class extends HTMLElement {
   firstUpdated(t) {
   }
 };
-E.elementStyles = [], E.shadowRootOptions = { mode: "open" }, E[P("elementProperties")] = /* @__PURE__ */ new Map(), E[P("finalized")] = /* @__PURE__ */ new Map(), Mt?.({ ReactiveElement: E }), (I.reactiveElementVersions ??= []).push("2.1.2");
-const J = globalThis, nt = (s) => s, B = J.trustedTypes, at = B ? B.createPolicy("lit-html", { createHTML: (s) => s }) : void 0, ft = "$lit$", _ = `lit$${Math.random().toFixed(9).slice(2)}$`, $t = "?" + _, Ut = `<${$t}>`, w = document, O = () => w.createComment(""), T = (s) => s === null || typeof s != "object" && typeof s != "function", X = Array.isArray, kt = (s) => X(s) || typeof s?.[Symbol.iterator] == "function", q = `[ 	
-\f\r]`, C = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, ct = /-->/g, lt = />/g, g = RegExp(`>|${q}(?:([^\\s"'>=/]+)(${q}*=${q}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), ht = /'/g, dt = /"/g, mt = /^(?:script|style|textarea|title)$/i, vt = (s) => (t, ...e) => ({ _$litType$: s, strings: t, values: e }), y = vt(1), z = vt(2), S = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), pt = /* @__PURE__ */ new WeakMap(), b = w.createTreeWalker(w, 129);
-function _t(s, t) {
-  if (!X(s) || !s.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return at !== void 0 ? at.createHTML(t) : t;
+T.elementStyles = [], T.shadowRootOptions = { mode: "open" }, T[j("elementProperties")] = /* @__PURE__ */ new Map(), T[j("finalized")] = /* @__PURE__ */ new Map(), It?.({ ReactiveElement: T }), (J.reactiveElementVersions ??= []).push("2.1.2");
+const nt = globalThis, vt = (i) => i, X = nt.trustedTypes, gt = X ? X.createPolicy("lit-html", { createHTML: (i) => i }) : void 0, At = "$lit$", x = `lit$${Math.random().toFixed(9).slice(2)}$`, Et = "?" + x, Ft = `<${Et}>`, C = document, B = () => C.createComment(""), I = (i) => i === null || typeof i != "object" && typeof i != "function", at = Array.isArray, Vt = (i) => at(i) || typeof i?.[Symbol.iterator] == "function", tt = `[ 	
+\f\r]`, L = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, bt = /-->/g, _t = />/g, S = RegExp(`>|${tt}(?:([^\\s"'>=/]+)(${tt}*=${tt}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), $t = /'/g, yt = /"/g, St = /^(?:script|style|textarea|title)$/i, Nt = (i) => (t, ...e) => ({ _$litType$: i, strings: t, values: e }), f = Nt(1), W = Nt(2), z = Symbol.for("lit-noChange"), u = Symbol.for("lit-nothing"), wt = /* @__PURE__ */ new WeakMap(), N = C.createTreeWalker(C, 129);
+function Ct(i, t) {
+  if (!at(i) || !i.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return gt !== void 0 ? gt.createHTML(t) : t;
 }
-const Ht = (s, t) => {
-  const e = s.length - 1, i = [];
-  let r, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = C;
+const qt = (i, t) => {
+  const e = i.length - 1, r = [];
+  let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = L;
   for (let c = 0; c < e; c++) {
-    const a = s[c];
-    let h, d, l = -1, f = 0;
-    for (; f < a.length && (n.lastIndex = f, d = n.exec(a), d !== null); ) f = n.lastIndex, n === C ? d[1] === "!--" ? n = ct : d[1] !== void 0 ? n = lt : d[2] !== void 0 ? (mt.test(d[2]) && (r = RegExp("</" + d[2], "g")), n = g) : d[3] !== void 0 && (n = g) : n === g ? d[0] === ">" ? (n = r ?? C, l = -1) : d[1] === void 0 ? l = -2 : (l = n.lastIndex - d[2].length, h = d[1], n = d[3] === void 0 ? g : d[3] === '"' ? dt : ht) : n === dt || n === ht ? n = g : n === ct || n === lt ? n = C : (n = g, r = void 0);
-    const v = n === g && s[c + 1].startsWith("/>") ? " " : "";
-    o += n === C ? a + Ut : l >= 0 ? (i.push(h), a.slice(0, l) + ft + a.slice(l) + _ + v) : a + _ + (l === -2 ? c : v);
+    const a = i[c];
+    let p, d, l = -1, m = 0;
+    for (; m < a.length && (n.lastIndex = m, d = n.exec(a), d !== null); ) m = n.lastIndex, n === L ? d[1] === "!--" ? n = bt : d[1] !== void 0 ? n = _t : d[2] !== void 0 ? (St.test(d[2]) && (s = RegExp("</" + d[2], "g")), n = S) : d[3] !== void 0 && (n = S) : n === S ? d[0] === ">" ? (n = s ?? L, l = -1) : d[1] === void 0 ? l = -2 : (l = n.lastIndex - d[2].length, p = d[1], n = d[3] === void 0 ? S : d[3] === '"' ? yt : $t) : n === yt || n === $t ? n = S : n === bt || n === _t ? n = L : (n = S, s = void 0);
+    const w = n === S && i[c + 1].startsWith("/>") ? " " : "";
+    o += n === L ? a + Ft : l >= 0 ? (r.push(p), a.slice(0, l) + At + a.slice(l) + x + w) : a + x + (l === -2 ? c : w);
   }
-  return [_t(s, o + (s[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), i];
+  return [Ct(i, o + (i[e] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
 };
-class M {
-  constructor({ strings: t, _$litType$: e }, i) {
-    let r;
+class F {
+  constructor({ strings: t, _$litType$: e }, r) {
+    let s;
     this.parts = [];
     let o = 0, n = 0;
-    const c = t.length - 1, a = this.parts, [h, d] = Ht(t, e);
-    if (this.el = M.createElement(h, i), b.currentNode = this.el.content, e === 2 || e === 3) {
+    const c = t.length - 1, a = this.parts, [p, d] = qt(t, e);
+    if (this.el = F.createElement(p, r), N.currentNode = this.el.content, e === 2 || e === 3) {
       const l = this.el.content.firstChild;
       l.replaceWith(...l.childNodes);
     }
-    for (; (r = b.nextNode()) !== null && a.length < c; ) {
-      if (r.nodeType === 1) {
-        if (r.hasAttributes()) for (const l of r.getAttributeNames()) if (l.endsWith(ft)) {
-          const f = d[n++], v = r.getAttribute(l).split(_), R = /([.?@])?(.*)/.exec(f);
-          a.push({ type: 1, index: o, name: R[2], strings: v, ctor: R[1] === "." ? zt : R[1] === "?" ? Dt : R[1] === "@" ? jt : F }), r.removeAttribute(l);
-        } else l.startsWith(_) && (a.push({ type: 6, index: o }), r.removeAttribute(l));
-        if (mt.test(r.tagName)) {
-          const l = r.textContent.split(_), f = l.length - 1;
-          if (f > 0) {
-            r.textContent = B ? B.emptyScript : "";
-            for (let v = 0; v < f; v++) r.append(l[v], O()), b.nextNode(), a.push({ type: 2, index: ++o });
-            r.append(l[f], O());
+    for (; (s = N.nextNode()) !== null && a.length < c; ) {
+      if (s.nodeType === 1) {
+        if (s.hasAttributes()) for (const l of s.getAttributeNames()) if (l.endsWith(At)) {
+          const m = d[n++], w = s.getAttribute(l).split(x), K = /([.?@])?(.*)/.exec(m);
+          a.push({ type: 1, index: o, name: K[2], strings: w, ctor: K[1] === "." ? Wt : K[1] === "?" ? Zt : K[1] === "@" ? Gt : Y }), s.removeAttribute(l);
+        } else l.startsWith(x) && (a.push({ type: 6, index: o }), s.removeAttribute(l));
+        if (St.test(s.tagName)) {
+          const l = s.textContent.split(x), m = l.length - 1;
+          if (m > 0) {
+            s.textContent = X ? X.emptyScript : "";
+            for (let w = 0; w < m; w++) s.append(l[w], B()), N.nextNode(), a.push({ type: 2, index: ++o });
+            s.append(l[m], B());
           }
         }
-      } else if (r.nodeType === 8) if (r.data === $t) a.push({ type: 2, index: o });
+      } else if (s.nodeType === 8) if (s.data === Et) a.push({ type: 2, index: o });
       else {
         let l = -1;
-        for (; (l = r.data.indexOf(_, l + 1)) !== -1; ) a.push({ type: 7, index: o }), l += _.length - 1;
+        for (; (l = s.data.indexOf(x, l + 1)) !== -1; ) a.push({ type: 7, index: o }), l += x.length - 1;
       }
       o++;
     }
   }
   static createElement(t, e) {
-    const i = w.createElement("template");
-    return i.innerHTML = t, i;
+    const r = C.createElement("template");
+    return r.innerHTML = t, r;
   }
 }
-function N(s, t, e = s, i) {
-  if (t === S) return t;
-  let r = i !== void 0 ? e._$Co?.[i] : e._$Cl;
-  const o = T(t) ? void 0 : t._$litDirective$;
-  return r?.constructor !== o && (r?._$AO?.(!1), o === void 0 ? r = void 0 : (r = new o(s), r._$AT(s, e, i)), i !== void 0 ? (e._$Co ??= [])[i] = r : e._$Cl = r), r !== void 0 && (t = N(s, r._$AS(s, t.values), r, i)), t;
+function H(i, t, e = i, r) {
+  if (t === z) return t;
+  let s = r !== void 0 ? e._$Co?.[r] : e._$Cl;
+  const o = I(t) ? void 0 : t._$litDirective$;
+  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(i), s._$AT(i, e, r)), r !== void 0 ? (e._$Co ??= [])[r] = s : e._$Cl = s), s !== void 0 && (t = H(i, s._$AS(i, t.values), s, r)), t;
 }
-class Rt {
+class Kt {
   constructor(t, e) {
     this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = e;
   }
@@ -320,29 +320,29 @@ class Rt {
     return this._$AM._$AU;
   }
   u(t) {
-    const { el: { content: e }, parts: i } = this._$AD, r = (t?.creationScope ?? w).importNode(e, !0);
-    b.currentNode = r;
-    let o = b.nextNode(), n = 0, c = 0, a = i[0];
+    const { el: { content: e }, parts: r } = this._$AD, s = (t?.creationScope ?? C).importNode(e, !0);
+    N.currentNode = s;
+    let o = N.nextNode(), n = 0, c = 0, a = r[0];
     for (; a !== void 0; ) {
       if (n === a.index) {
-        let h;
-        a.type === 2 ? h = new k(o, o.nextSibling, this, t) : a.type === 1 ? h = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (h = new Bt(o, this, t)), this._$AV.push(h), a = i[++c];
+        let p;
+        a.type === 2 ? p = new V(o, o.nextSibling, this, t) : a.type === 1 ? p = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (p = new Xt(o, this, t)), this._$AV.push(p), a = r[++c];
       }
-      n !== a?.index && (o = b.nextNode(), n++);
+      n !== a?.index && (o = N.nextNode(), n++);
     }
-    return b.currentNode = w, r;
+    return N.currentNode = C, s;
   }
   p(t) {
     let e = 0;
-    for (const i of this._$AV) i !== void 0 && (i.strings !== void 0 ? (i._$AI(t, i, e), e += i.strings.length - 2) : i._$AI(t[e])), e++;
+    for (const r of this._$AV) r !== void 0 && (r.strings !== void 0 ? (r._$AI(t, r, e), e += r.strings.length - 2) : r._$AI(t[e])), e++;
   }
 }
-class k {
+class V {
   get _$AU() {
     return this._$AM?._$AU ?? this._$Cv;
   }
-  constructor(t, e, i, r) {
-    this.type = 2, this._$AH = p, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = i, this.options = r, this._$Cv = r?.isConnected ?? !0;
+  constructor(t, e, r, s) {
+    this.type = 2, this._$AH = u, this._$AN = void 0, this._$AA = t, this._$AB = e, this._$AM = r, this.options = s, this._$Cv = s?.isConnected ?? !0;
   }
   get parentNode() {
     let t = this._$AA.parentNode;
@@ -356,7 +356,7 @@ class k {
     return this._$AB;
   }
   _$AI(t, e = this) {
-    t = N(this, t, e), T(t) ? t === p || t == null || t === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : t !== this._$AH && t !== S && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : kt(t) ? this.k(t) : this._(t);
+    t = H(this, t, e), I(t) ? t === u || t == null || t === "" ? (this._$AH !== u && this._$AR(), this._$AH = u) : t !== this._$AH && t !== z && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : Vt(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -365,115 +365,115 @@ class k {
     this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
   }
   _(t) {
-    this._$AH !== p && T(this._$AH) ? this._$AA.nextSibling.data = t : this.T(w.createTextNode(t)), this._$AH = t;
+    this._$AH !== u && I(this._$AH) ? this._$AA.nextSibling.data = t : this.T(C.createTextNode(t)), this._$AH = t;
   }
   $(t) {
-    const { values: e, _$litType$: i } = t, r = typeof i == "number" ? this._$AC(t) : (i.el === void 0 && (i.el = M.createElement(_t(i.h, i.h[0]), this.options)), i);
-    if (this._$AH?._$AD === r) this._$AH.p(e);
+    const { values: e, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = F.createElement(Ct(r.h, r.h[0]), this.options)), r);
+    if (this._$AH?._$AD === s) this._$AH.p(e);
     else {
-      const o = new Rt(r, this), n = o.u(this.options);
+      const o = new Kt(s, this), n = o.u(this.options);
       o.p(e), this.T(n), this._$AH = o;
     }
   }
   _$AC(t) {
-    let e = pt.get(t.strings);
-    return e === void 0 && pt.set(t.strings, e = new M(t)), e;
+    let e = wt.get(t.strings);
+    return e === void 0 && wt.set(t.strings, e = new F(t)), e;
   }
   k(t) {
-    X(this._$AH) || (this._$AH = [], this._$AR());
+    at(this._$AH) || (this._$AH = [], this._$AR());
     const e = this._$AH;
-    let i, r = 0;
-    for (const o of t) r === e.length ? e.push(i = new k(this.O(O()), this.O(O()), this, this.options)) : i = e[r], i._$AI(o), r++;
-    r < e.length && (this._$AR(i && i._$AB.nextSibling, r), e.length = r);
+    let r, s = 0;
+    for (const o of t) s === e.length ? e.push(r = new V(this.O(B()), this.O(B()), this, this.options)) : r = e[s], r._$AI(o), s++;
+    s < e.length && (this._$AR(r && r._$AB.nextSibling, s), e.length = s);
   }
   _$AR(t = this._$AA.nextSibling, e) {
     for (this._$AP?.(!1, !0, e); t !== this._$AB; ) {
-      const i = nt(t).nextSibling;
-      nt(t).remove(), t = i;
+      const r = vt(t).nextSibling;
+      vt(t).remove(), t = r;
     }
   }
   setConnected(t) {
     this._$AM === void 0 && (this._$Cv = t, this._$AP?.(t));
   }
 }
-class F {
+class Y {
   get tagName() {
     return this.element.tagName;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
-  constructor(t, e, i, r, o) {
-    this.type = 1, this._$AH = p, this._$AN = void 0, this.element = t, this.name = e, this._$AM = r, this.options = o, i.length > 2 || i[0] !== "" || i[1] !== "" ? (this._$AH = Array(i.length - 1).fill(new String()), this.strings = i) : this._$AH = p;
+  constructor(t, e, r, s, o) {
+    this.type = 1, this._$AH = u, this._$AN = void 0, this.element = t, this.name = e, this._$AM = s, this.options = o, r.length > 2 || r[0] !== "" || r[1] !== "" ? (this._$AH = Array(r.length - 1).fill(new String()), this.strings = r) : this._$AH = u;
   }
-  _$AI(t, e = this, i, r) {
+  _$AI(t, e = this, r, s) {
     const o = this.strings;
     let n = !1;
-    if (o === void 0) t = N(this, t, e, 0), n = !T(t) || t !== this._$AH && t !== S, n && (this._$AH = t);
+    if (o === void 0) t = H(this, t, e, 0), n = !I(t) || t !== this._$AH && t !== z, n && (this._$AH = t);
     else {
       const c = t;
-      let a, h;
-      for (t = o[0], a = 0; a < o.length - 1; a++) h = N(this, c[i + a], e, a), h === S && (h = this._$AH[a]), n ||= !T(h) || h !== this._$AH[a], h === p ? t = p : t !== p && (t += (h ?? "") + o[a + 1]), this._$AH[a] = h;
+      let a, p;
+      for (t = o[0], a = 0; a < o.length - 1; a++) p = H(this, c[r + a], e, a), p === z && (p = this._$AH[a]), n ||= !I(p) || p !== this._$AH[a], p === u ? t = u : t !== u && (t += (p ?? "") + o[a + 1]), this._$AH[a] = p;
     }
-    n && !r && this.j(t);
+    n && !s && this.j(t);
   }
   j(t) {
-    t === p ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
+    t === u ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
 }
-class zt extends F {
+class Wt extends Y {
   constructor() {
     super(...arguments), this.type = 3;
   }
   j(t) {
-    this.element[this.name] = t === p ? void 0 : t;
+    this.element[this.name] = t === u ? void 0 : t;
   }
 }
-class Dt extends F {
+class Zt extends Y {
   constructor() {
     super(...arguments), this.type = 4;
   }
   j(t) {
-    this.element.toggleAttribute(this.name, !!t && t !== p);
+    this.element.toggleAttribute(this.name, !!t && t !== u);
   }
 }
-class jt extends F {
-  constructor(t, e, i, r, o) {
-    super(t, e, i, r, o), this.type = 5;
+class Gt extends Y {
+  constructor(t, e, r, s, o) {
+    super(t, e, r, s, o), this.type = 5;
   }
   _$AI(t, e = this) {
-    if ((t = N(this, t, e, 0) ?? p) === S) return;
-    const i = this._$AH, r = t === p && i !== p || t.capture !== i.capture || t.once !== i.once || t.passive !== i.passive, o = t !== p && (i === p || r);
-    r && this.element.removeEventListener(this.name, this, i), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
+    if ((t = H(this, t, e, 0) ?? u) === z) return;
+    const r = this._$AH, s = t === u && r !== u || t.capture !== r.capture || t.once !== r.once || t.passive !== r.passive, o = t !== u && (r === u || s);
+    s && this.element.removeEventListener(this.name, this, r), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
   handleEvent(t) {
     typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class Bt {
-  constructor(t, e, i) {
-    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = i;
+class Xt {
+  constructor(t, e, r) {
+    this.element = t, this.type = 6, this._$AN = void 0, this._$AM = e, this.options = r;
   }
   get _$AU() {
     return this._$AM._$AU;
   }
   _$AI(t) {
-    N(this, t);
+    H(this, t);
   }
 }
-const Lt = J.litHtmlPolyfillSupport;
-Lt?.(M, k), (J.litHtmlVersions ??= []).push("3.3.2");
-const It = (s, t, e) => {
-  const i = e?.renderBefore ?? t;
-  let r = i._$litPart$;
-  if (r === void 0) {
+const Jt = nt.litHtmlPolyfillSupport;
+Jt?.(F, V), (nt.litHtmlVersions ??= []).push("3.3.2");
+const Yt = (i, t, e) => {
+  const r = e?.renderBefore ?? t;
+  let s = r._$litPart$;
+  if (s === void 0) {
     const o = e?.renderBefore ?? null;
-    i._$litPart$ = r = new k(t.insertBefore(O(), o), o, void 0, e ?? {});
+    r._$litPart$ = s = new V(t.insertBefore(B(), o), o, void 0, e ?? {});
   }
-  return r._$AI(s), r;
+  return s._$AI(i), s;
 };
-const Y = globalThis;
-class A extends E {
+const ct = globalThis;
+class b extends T {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -483,7 +483,7 @@ class A extends E {
   }
   update(t) {
     const e = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = It(e, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = Yt(e, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     super.connectedCallback(), this._$Do?.setConnected(!0);
@@ -492,49 +492,58 @@ class A extends E {
     super.disconnectedCallback(), this._$Do?.setConnected(!1);
   }
   render() {
-    return S;
+    return z;
   }
 }
-A._$litElement$ = !0, A.finalized = !0, Y.litElementHydrateSupport?.({ LitElement: A });
-const Ft = Y.litElementPolyfillSupport;
-Ft?.({ LitElement: A });
-(Y.litElementVersions ??= []).push("4.2.2");
-const Q = (s) => (t, e) => {
+b._$litElement$ = !0, b.finalized = !0, ct.litElementHydrateSupport?.({ LitElement: b });
+const Qt = ct.litElementPolyfillSupport;
+Qt?.({ LitElement: b });
+(ct.litElementVersions ??= []).push("4.2.2");
+const M = (i) => (t, e) => {
   e !== void 0 ? e.addInitializer(() => {
-    customElements.define(s, t);
-  }) : customElements.define(s, t);
+    customElements.define(i, t);
+  }) : customElements.define(i, t);
 };
-const qt = { attribute: !0, type: String, converter: j, reflect: !1, hasChanged: G }, Vt = (s = qt, t, e) => {
-  const { kind: i, metadata: r } = e;
-  let o = globalThis.litPropertyMetadata.get(r);
-  if (o === void 0 && globalThis.litPropertyMetadata.set(r, o = /* @__PURE__ */ new Map()), i === "setter" && ((s = Object.create(s)).wrapped = !0), o.set(e.name, s), i === "accessor") {
+const te = { attribute: !0, type: String, converter: G, reflect: !1, hasChanged: ot }, ee = (i = te, t, e) => {
+  const { kind: r, metadata: s } = e;
+  let o = globalThis.litPropertyMetadata.get(s);
+  if (o === void 0 && globalThis.litPropertyMetadata.set(s, o = /* @__PURE__ */ new Map()), r === "setter" && ((i = Object.create(i)).wrapped = !0), o.set(e.name, i), r === "accessor") {
     const { name: n } = e;
     return { set(c) {
       const a = t.get.call(this);
-      t.set.call(this, c), this.requestUpdate(n, a, s, !0, c);
+      t.set.call(this, c), this.requestUpdate(n, a, i, !0, c);
     }, init(c) {
-      return c !== void 0 && this.C(n, void 0, s, c), c;
+      return c !== void 0 && this.C(n, void 0, i, c), c;
     } };
   }
-  if (i === "setter") {
+  if (r === "setter") {
     const { name: n } = e;
     return function(c) {
       const a = this[n];
-      t.call(this, c), this.requestUpdate(n, a, s, !0, c);
+      t.call(this, c), this.requestUpdate(n, a, i, !0, c);
     };
   }
-  throw Error("Unsupported decorator location: " + i);
+  throw Error("Unsupported decorator location: " + r);
 };
-function u(s) {
-  return (t, e) => typeof e == "object" ? Vt(s, t, e) : ((i, r, o) => {
-    const n = r.hasOwnProperty(o);
-    return r.constructor.createProperty(o, i), n ? Object.getOwnPropertyDescriptor(r, o) : void 0;
-  })(s, t, e);
+function h(i) {
+  return (t, e) => typeof e == "object" ? ee(i, t, e) : ((r, s, o) => {
+    const n = s.hasOwnProperty(o);
+    return s.constructor.createProperty(o, r), n ? Object.getOwnPropertyDescriptor(s, o) : void 0;
+  })(i, t, e);
 }
-function Wt(s) {
-  return u({ ...s, state: !0, attribute: !1 });
+function D(i) {
+  return h({ ...i, state: !0, attribute: !1 });
 }
-const tt = L`
+const ie = (i, t, e) => (e.configurable = !0, e.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(i, t, e), e);
+function lt(i, t) {
+  return (e, r, s) => {
+    const o = (n) => n.renderRoot?.querySelector(i) ?? null;
+    return ie(e, r, { get() {
+      return o(this);
+    } });
+  };
+}
+const U = O`
   :host {
     --cb-action-heating: var(--cb-color-heat, var(--state-climate-heat-color, #d9603f));
     --cb-action-cooling: var(--cb-color-cool, var(--state-climate-cool-color, #2f7fcc));
@@ -553,8 +562,8 @@ const tt = L`
     --cb-gap-lg: 16px;
   }
 `;
-function gt(s) {
-  switch (s) {
+function ht(i) {
+  switch (i) {
     case "heating":
       return "var(--cb-action-heating)";
     case "cooling":
@@ -565,40 +574,40 @@ function gt(s) {
       return "var(--cb-action-unknown)";
   }
 }
-function bt(s) {
-  return s === "heating" || s === "cooling" || s === "idle" ? s : "unknown";
+function dt(i) {
+  return i === "heating" || i === "cooling" || i === "idle" ? i : "unknown";
 }
-function Kt(s) {
-  return s.charAt(0).toUpperCase() + s.slice(1);
+function Pt(i) {
+  return i.charAt(0).toUpperCase() + i.slice(1);
 }
-var Zt = Object.defineProperty, Gt = Object.getOwnPropertyDescriptor, H = (s, t, e, i) => {
-  for (var r = i > 1 ? void 0 : i ? Gt(t, e) : t, o = s.length - 1, n; o >= 0; o--)
-    (n = s[o]) && (r = (i ? n(t, e, r) : n(r)) || r);
-  return i && r && Zt(t, e, r), r;
+var re = Object.defineProperty, se = Object.getOwnPropertyDescriptor, q = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? se(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && re(t, e, s), s;
 };
-const W = 15, yt = 28, Jt = yt - W;
-function V(s) {
-  return Number.isNaN(s) || !Number.isFinite(s) ? 0 : (Math.max(W, Math.min(yt, s)) - W) / Jt * 100;
+const it = 15, Ot = 28, oe = Ot - it;
+function et(i) {
+  return Number.isNaN(i) || !Number.isFinite(i) ? 0 : (Math.max(it, Math.min(Ot, i)) - it) / oe * 100;
 }
-let x = class extends A {
+let P = class extends b {
   constructor() {
     super(...arguments), this.low = NaN, this.high = NaN, this.room = NaN, this.action = "unknown";
   }
   render() {
-    const s = bt(this.action), t = gt(s), e = Number.isFinite(this.low), i = Number.isFinite(this.high), r = Number.isFinite(this.room), o = e ? V(this.low) : 0, n = i ? V(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), h = r ? V(this.room) : 50, d = (f) => Number.isFinite(f) ? `${f.toFixed(1)}°` : "—", l = `Comfort band gauge: low ${d(this.low)}, room ${d(this.room)}, high ${d(this.high)}, action ${s}`;
-    return y`
+    const i = dt(this.action), t = ht(i), e = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = e ? et(this.low) : 0, n = r ? et(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), p = s ? et(this.room) : 50, d = (m) => Number.isFinite(m) ? `${m.toFixed(1)}°` : "—", l = `Comfort band gauge: low ${d(this.low)}, room ${d(this.room)}, high ${d(this.high)}, action ${i}`;
+    return f`
       <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${l}>
-        ${z`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
-        ${e && i ? z`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
-        ${r ? z`<circle cx=${h} cy="12" r="4.5" fill=${t}></circle>` : null}
-        ${r ? z`<circle class="marker-ring" cx=${h} cy="12" r="3" stroke=${t}></circle>` : null}
+        ${W`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
+        ${e && r ? W`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
+        ${s ? W`<circle cx=${p} cy="12" r="4.5" fill=${t}></circle>` : null}
+        ${s ? W`<circle class="marker-ring" cx=${p} cy="12" r="3" stroke=${t}></circle>` : null}
       </svg>
     `;
   }
 };
-x.styles = [
-  tt,
-  L`
+P.styles = [
+  U,
+  O`
       :host {
         display: block;
         width: 100%;
@@ -626,51 +635,51 @@ x.styles = [
       }
     `
 ];
-H([
-  u({ type: Number })
-], x.prototype, "low", 2);
-H([
-  u({ type: Number })
-], x.prototype, "high", 2);
-H([
-  u({ type: Number })
-], x.prototype, "room", 2);
-H([
-  u({ type: String })
-], x.prototype, "action", 2);
-x = H([
-  Q("band-gauge")
-], x);
-var Xt = Object.defineProperty, Yt = Object.getOwnPropertyDescriptor, m = (s, t, e, i) => {
-  for (var r = i > 1 ? void 0 : i ? Yt(t, e) : t, o = s.length - 1, n; o >= 0; o--)
-    (n = s[o]) && (r = (i ? n(t, e, r) : n(r)) || r);
-  return i && r && Xt(t, e, r), r;
+q([
+  h({ type: Number })
+], P.prototype, "low", 2);
+q([
+  h({ type: Number })
+], P.prototype, "high", 2);
+q([
+  h({ type: Number })
+], P.prototype, "room", 2);
+q([
+  h({ type: String })
+], P.prototype, "action", 2);
+P = q([
+  M("band-gauge")
+], P);
+var ne = Object.defineProperty, ae = Object.getOwnPropertyDescriptor, $ = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? ae(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && ne(t, e, s), s;
 };
-let $ = class extends A {
+let v = class extends b {
   constructor() {
     super(...arguments), this.zoneName = "", this.roomTemp = NaN, this.low = NaN, this.high = NaN, this.action = "unknown", this.overrideActive = !1, this.overrideEnds = null, this.noExpand = !1;
   }
-  _onTap(s) {
-    this.noExpand || s instanceof KeyboardEvent && s.key !== "Enter" && s.key !== " " || (s.preventDefault(), this.dispatchEvent(new CustomEvent("comfort-band-tile-tap", { bubbles: !0, composed: !0 })));
+  _onTap(i) {
+    this.noExpand || i instanceof KeyboardEvent && i.key !== "Enter" && i.key !== " " || (i.preventDefault(), this.dispatchEvent(new CustomEvent("comfort-band-tile-tap", { bubbles: !0, composed: !0 })));
   }
   _renderRoomTemp() {
     return Number.isFinite(this.roomTemp) ? `${this.roomTemp.toFixed(1)}°` : "—";
   }
   _renderOverridePill() {
     if (!this.overrideActive) return null;
-    const s = Qt(this.overrideEnds);
-    return y`<div class="override-pill">Override${s ? ` · ${s}` : ""}</div>`;
+    const i = ce(this.overrideEnds);
+    return f`<div class="override-pill">Override${i ? ` · ${i}` : ""}</div>`;
   }
   _renderActionChip() {
-    const s = bt(this.action);
-    if (s === "idle" || s === "unknown") return null;
-    const t = gt(s);
-    return y`<span class="action-chip" style="background:${t}">
-      ${Kt(s)}
+    const i = dt(this.action);
+    if (i === "idle" || i === "unknown") return null;
+    const t = ht(i);
+    return f`<span class="action-chip" style="background:${t}">
+      ${Pt(i)}
     </span>`;
   }
   render() {
-    return y`
+    return f`
       <div
         class="tile ${this.noExpand ? "no-expand" : ""}"
         role="${this.noExpand ? "group" : "button"}"
@@ -698,9 +707,9 @@ let $ = class extends A {
     `;
   }
 };
-$.styles = [
-  tt,
-  L`
+v.styles = [
+  U,
+  O`
       :host {
         display: block;
       }
@@ -774,45 +783,662 @@ $.styles = [
       }
     `
 ];
-m([
-  u({ type: String })
-], $.prototype, "zoneName", 2);
-m([
-  u({ type: Number })
-], $.prototype, "roomTemp", 2);
-m([
-  u({ type: Number })
-], $.prototype, "low", 2);
-m([
-  u({ type: Number })
-], $.prototype, "high", 2);
-m([
-  u({ type: String })
-], $.prototype, "action", 2);
-m([
-  u({ type: Boolean })
-], $.prototype, "overrideActive", 2);
-m([
-  u({ type: String })
-], $.prototype, "overrideEnds", 2);
-m([
-  u({ type: Boolean })
-], $.prototype, "noExpand", 2);
-$ = m([
-  Q("comfort-band-tile")
-], $);
-function Qt(s) {
-  if (!s) return "";
-  const t = Date.parse(s);
+$([
+  h({ type: String })
+], v.prototype, "zoneName", 2);
+$([
+  h({ type: Number })
+], v.prototype, "roomTemp", 2);
+$([
+  h({ type: Number })
+], v.prototype, "low", 2);
+$([
+  h({ type: Number })
+], v.prototype, "high", 2);
+$([
+  h({ type: String })
+], v.prototype, "action", 2);
+$([
+  h({ type: Boolean })
+], v.prototype, "overrideActive", 2);
+$([
+  h({ type: String })
+], v.prototype, "overrideEnds", 2);
+$([
+  h({ type: Boolean })
+], v.prototype, "noExpand", 2);
+v = $([
+  M("comfort-band-tile")
+], v);
+function ce(i) {
+  if (!i) return "";
+  const t = Date.parse(i);
   if (Number.isNaN(t)) return "";
   const e = t - Date.now();
   if (e <= 0) return "";
-  const i = Math.round(e / 6e4);
-  if (i < 60) return `${i}m left`;
-  const r = Math.floor(i / 60), o = i % 60;
-  return o ? `${r}h ${o}m left` : `${r}h left`;
+  const r = Math.round(e / 6e4);
+  if (r < 60) return `${r}m left`;
+  const s = Math.floor(r / 60), o = r % 60;
+  return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-const At = "comfort_band", te = {
+var le = Object.defineProperty, he = Object.getOwnPropertyDescriptor, y = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? he(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && le(t, e, s), s;
+};
+let g = class extends b {
+  constructor() {
+    super(...arguments), this.min = 16, this.max = 26, this.step = 0.5, this.low = 19, this.high = 22, this.unit = "°", this._dragging = null, this._onThumbPointerDown = (i, t) => {
+      i.preventDefault();
+      const e = i.currentTarget;
+      e.setPointerCapture(i.pointerId), this._dragging = t;
+      const r = (o) => {
+        this._setHandle(t, this._xToValue(o.clientX)) && this._fire("input");
+      }, s = (o) => {
+        e.releasePointerCapture(o.pointerId), e.removeEventListener("pointermove", r), e.removeEventListener("pointerup", s), e.removeEventListener("pointercancel", s), this._dragging = null, this._fire("change");
+      };
+      e.addEventListener("pointermove", r), e.addEventListener("pointerup", s), e.addEventListener("pointercancel", s);
+    }, this._onTrackPointerDown = (i) => {
+      if (i.target.classList.contains("thumb")) return;
+      const t = this._xToValue(i.clientX), e = (this.low + this.high) / 2, r = t < e ? "low" : "high";
+      this._setHandle(r, t) && this._fire("change");
+    }, this._onKeyDown = (i, t) => {
+      let e = 0;
+      switch (i.key) {
+        case "ArrowLeft":
+        case "ArrowDown":
+          e = -this.step;
+          break;
+        case "ArrowRight":
+        case "ArrowUp":
+          e = this.step;
+          break;
+        case "Home":
+          i.preventDefault(), this._setHandle(t, this.min) && this._fire("change");
+          return;
+        case "End":
+          i.preventDefault(), this._setHandle(t, this.max) && this._fire("change");
+          return;
+        default:
+          return;
+      }
+      i.preventDefault();
+      const r = t === "low" ? this.low : this.high;
+      this._setHandle(t, r + e) && this._fire("change");
+    };
+  }
+  _pct(i) {
+    const t = this.max - this.min;
+    return t <= 0 ? 0 : (i - this.min) / t * 100;
+  }
+  _snap(i) {
+    const t = Math.round((i - this.min) / this.step) * this.step + this.min;
+    return Math.max(this.min, Math.min(this.max, t));
+  }
+  _setHandle(i, t) {
+    const e = this._snap(t);
+    if (i === "low") {
+      const r = Math.min(e, this.high - this.step);
+      if (r === this.low) return !1;
+      this.low = r;
+    } else {
+      const r = Math.max(e, this.low + this.step);
+      if (r === this.high) return !1;
+      this.high = r;
+    }
+    return !0;
+  }
+  _xToValue(i) {
+    const t = this._track?.getBoundingClientRect();
+    if (!t || t.width === 0) return this.min;
+    const e = Math.max(0, Math.min(1, (i - t.left) / t.width));
+    return this.min + e * (this.max - this.min);
+  }
+  _fire(i) {
+    this.dispatchEvent(
+      new CustomEvent(i, {
+        detail: { low: this.low, high: this.high },
+        bubbles: !0,
+        composed: !0
+      })
+    );
+  }
+  _fmt(i) {
+    return `${i.toFixed(1)}${this.unit}`;
+  }
+  render() {
+    const i = this._pct(this.low), t = this._pct(this.high);
+    return f`
+      <div class="track" @pointerdown=${this._onTrackPointerDown}>
+        <div class="fill" style="left:${i}%; width:${t - i}%"></div>
+        <div
+          class="thumb ${this._dragging === "low" ? "dragging" : ""}"
+          style="left:${i}%"
+          tabindex="0"
+          role="slider"
+          aria-label="Lower bound"
+          aria-valuemin=${this.min}
+          aria-valuemax=${this.high - this.step}
+          aria-valuenow=${this.low}
+          aria-valuetext=${this._fmt(this.low)}
+          @pointerdown=${(e) => this._onThumbPointerDown(e, "low")}
+          @keydown=${(e) => this._onKeyDown(e, "low")}
+        ></div>
+        <div
+          class="thumb ${this._dragging === "high" ? "dragging" : ""}"
+          style="left:${t}%"
+          tabindex="0"
+          role="slider"
+          aria-label="Upper bound"
+          aria-valuemin=${this.low + this.step}
+          aria-valuemax=${this.max}
+          aria-valuenow=${this.high}
+          aria-valuetext=${this._fmt(this.high)}
+          @pointerdown=${(e) => this._onThumbPointerDown(e, "high")}
+          @keydown=${(e) => this._onKeyDown(e, "high")}
+        ></div>
+      </div>
+      <div class="label-row">
+        <span class="value-low">${this._fmt(this.low)}</span>
+        <span class="value-high">${this._fmt(this.high)}</span>
+      </div>
+    `;
+  }
+};
+g.styles = [
+  U,
+  O`
+      :host {
+        display: block;
+        padding: 16px 12px;
+        --thumb-size: 20px;
+      }
+      .track {
+        position: relative;
+        height: 6px;
+        background: var(--cb-track-bg);
+        border-radius: 3px;
+        cursor: pointer;
+      }
+      .fill {
+        position: absolute;
+        top: 0;
+        height: 100%;
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        opacity: 0.6;
+        border-radius: 3px;
+        pointer-events: none;
+      }
+      .thumb {
+        position: absolute;
+        top: 50%;
+        width: var(--thumb-size);
+        height: var(--thumb-size);
+        margin-left: calc(var(--thumb-size) / -2);
+        margin-top: calc(var(--thumb-size) / -2);
+        background: var(--ha-card-background, #ffffff);
+        border: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        border-radius: 50%;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+        cursor: grab;
+        touch-action: none;
+        transition: transform 0.1s ease;
+      }
+      .thumb:focus-visible {
+        outline: 2px solid var(--cb-accent, var(--primary-color, #03a9f4));
+        outline-offset: 3px;
+      }
+      .thumb.dragging {
+        cursor: grabbing;
+        transform: scale(1.15);
+      }
+      .label-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+        margin-top: 14px;
+        font-variant-numeric: tabular-nums;
+      }
+      .value-low,
+      .value-high {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--cb-text-primary);
+      }
+    `
+];
+y([
+  h({ type: Number })
+], g.prototype, "min", 2);
+y([
+  h({ type: Number })
+], g.prototype, "max", 2);
+y([
+  h({ type: Number })
+], g.prototype, "step", 2);
+y([
+  h({ type: Number })
+], g.prototype, "low", 2);
+y([
+  h({ type: Number })
+], g.prototype, "high", 2);
+y([
+  h({ type: String })
+], g.prototype, "unit", 2);
+y([
+  D()
+], g.prototype, "_dragging", 2);
+y([
+  lt(".track")
+], g.prototype, "_track", 2);
+g = y([
+  M("dual-handle-slider")
+], g);
+const Tt = "comfort_band";
+function de(i, t) {
+  const e = { zone: t.zone };
+  return t.low !== void 0 && (e.low = t.low), t.high !== void 0 && (e.high = t.high), t.hours !== void 0 && (e.hours = t.hours), i.callService(Tt, "start_override", e);
+}
+function pe(i, t) {
+  return i.callService(Tt, "cancel_override", { ...t });
+}
+var ue = Object.defineProperty, fe = Object.getOwnPropertyDescriptor, R = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? fe(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && ue(t, e, s), s;
+};
+const me = [1, 3, 6];
+let A = class extends b {
+  constructor() {
+    super(...arguments), this.zone = "", this._pendingLow = null, this._pendingHigh = null, this._onSliderInput = (i) => {
+      this._pendingLow = i.detail.low, this._pendingHigh = i.detail.high;
+    }, this._onSliderChange = (i) => {
+      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, de(this.hass, {
+        zone: this.zone,
+        low: i.detail.low,
+        high: i.detail.high
+      }));
+    }, this._onCancel = () => {
+      !this.hass || !this.zone || pe(this.hass, { zone: this.zone });
+    }, this._onPickHours = (i) => {
+      !this.hass || !this.entities?.overrideHours || this.hass.callService("number", "set_value", {
+        entity_id: this.entities.overrideHours,
+        value: i
+      });
+    };
+  }
+  get _stateOf() {
+    const i = this.hass?.states ?? {};
+    return (t) => t !== null ? i[t] : void 0;
+  }
+  _numericState(i) {
+    const t = this._stateOf(i);
+    if (!t) return NaN;
+    const e = parseFloat(t.state);
+    return Number.isFinite(e) ? e : NaN;
+  }
+  render() {
+    if (!this.hass || !this.entities) return u;
+    const i = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), e = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", c = this._stateOf(this.entities.overrideActive)?.state === "on", a = this._pendingLow ?? (Number.isFinite(i) ? i : 19), p = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), d = dt(n), l = d !== "idle" && d !== "unknown";
+    return f`
+      <div class="header-row">
+        <div class="room-temp">${Number.isFinite(s) ? `${s.toFixed(1)}°` : "—"}</div>
+        ${l ? f`<span class="action-chip" style="background:${ht(d)}"
+              >${Pt(d)}</span
+            >` : u}
+      </div>
+      <div class="gauge-row">
+        <band-gauge .low=${e} .high=${r} .room=${s} .action=${n}></band-gauge>
+      </div>
+
+      <section>
+        <h3>Manual band</h3>
+        <dual-handle-slider
+          .min=${16}
+          .max=${26}
+          .step=${0.5}
+          .low=${a}
+          .high=${p}
+          @input=${this._onSliderInput}
+          @change=${this._onSliderChange}
+        ></dual-handle-slider>
+      </section>
+
+      ${this._renderOverrideSection(c)} ${this._renderHoursSection(o)}
+    `;
+  }
+  _renderOverrideSection(i) {
+    if (!i) return u;
+    const t = this._stateOf(this.entities.overrideEnds)?.state, e = ve(t ?? null);
+    return f`
+      <section>
+        <h3>Override</h3>
+        <div class="override-row">
+          <span>Active${e ? ` · ${e}` : ""}</span>
+          <button class="button secondary" @click=${this._onCancel}>Cancel</button>
+        </div>
+      </section>
+    `;
+  }
+  _renderHoursSection(i) {
+    return this.entities?.overrideHours ? f`
+      <section>
+        <h3>Override duration</h3>
+        <div class="preset-row">
+          ${me.map(
+      (t) => f`
+              <button
+                class="preset ${i === t ? "active" : ""}"
+                @click=${() => this._onPickHours(t)}
+              >
+                ${t} h
+              </button>
+            `
+    )}
+        </div>
+      </section>
+    ` : u;
+  }
+};
+A.styles = [
+  U,
+  O`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      .gauge-row {
+        margin-bottom: var(--cb-gap-md);
+      }
+      .header-row {
+        display: flex;
+        align-items: baseline;
+        gap: var(--cb-gap-sm);
+        margin-bottom: var(--cb-gap-sm);
+      }
+      .room-temp {
+        font-size: 36px;
+        font-weight: 300;
+        color: var(--cb-text-primary);
+        font-variant-numeric: tabular-nums;
+        line-height: 1;
+      }
+      .action-chip {
+        font-size: 11px;
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 2px 8px;
+        border-radius: var(--cb-radius-pill);
+        color: var(--cb-text-on-action, #ffffff);
+      }
+      section {
+        margin-top: var(--cb-gap-lg);
+      }
+      h3 {
+        margin: 0 0 var(--cb-gap-sm);
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--cb-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .override-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--cb-gap-sm);
+        padding: var(--cb-gap-sm) var(--cb-gap-md);
+        border-radius: var(--cb-radius-card);
+        background: var(--cb-track-bg);
+        font-size: 13px;
+        color: var(--cb-text-primary);
+      }
+      .button {
+        font: inherit;
+        padding: 6px 12px;
+        border-radius: var(--cb-radius-pill);
+        border: 1px solid transparent;
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        color: #ffffff;
+        cursor: pointer;
+      }
+      .button.secondary {
+        background: transparent;
+        border-color: var(--divider-color, #cccccc);
+        color: var(--cb-text-primary);
+      }
+      .preset-row {
+        display: flex;
+        gap: var(--cb-gap-sm);
+      }
+      .preset {
+        font: inherit;
+        padding: 4px 10px;
+        border-radius: var(--cb-radius-pill);
+        border: 1px solid var(--divider-color, #cccccc);
+        background: transparent;
+        color: var(--cb-text-primary);
+        cursor: pointer;
+      }
+      .preset.active {
+        background: var(--cb-accent, var(--primary-color, #03a9f4));
+        color: #ffffff;
+        border-color: transparent;
+      }
+    `
+];
+R([
+  h({ attribute: !1 })
+], A.prototype, "hass", 2);
+R([
+  h({ type: String })
+], A.prototype, "zone", 2);
+R([
+  h({ attribute: !1 })
+], A.prototype, "entities", 2);
+R([
+  D()
+], A.prototype, "_pendingLow", 2);
+R([
+  D()
+], A.prototype, "_pendingHigh", 2);
+A = R([
+  M("comfort-band-now-tab")
+], A);
+function ve(i) {
+  if (!i) return "";
+  const t = Date.parse(i);
+  if (Number.isNaN(t)) return "";
+  const e = t - Date.now();
+  if (e <= 0) return "";
+  const r = Math.round(e / 6e4);
+  if (r < 60) return `${r}m left`;
+  const s = Math.floor(r / 60), o = r % 60;
+  return o ? `${s}h ${o}m left` : `${s}h left`;
+}
+var ge = Object.defineProperty, be = Object.getOwnPropertyDescriptor, E = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? be(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && ge(t, e, s), s;
+};
+const _e = [
+  { id: "now", label: "Now" },
+  { id: "schedule", label: "Schedule" },
+  { id: "profiles", label: "Profiles" },
+  { id: "insights", label: "Insights" }
+];
+let _ = class extends b {
+  constructor() {
+    super(...arguments), this.zone = "", this.zoneName = "", this._activeTab = "now", this._isOpen = !1, this._onClose = () => {
+      this._isOpen = !1, this.dispatchEvent(
+        new CustomEvent("comfort-band-modal-close", { bubbles: !0, composed: !0 })
+      );
+    }, this._onSelectTab = (i) => {
+      this._activeTab = i;
+    };
+  }
+  open() {
+    this._isOpen = !0, this.updateComplete.then(() => this._dialog?.showModal());
+  }
+  close() {
+    this._dialog?.close();
+  }
+  selectTab(i) {
+    this._activeTab = i;
+  }
+  render() {
+    if (!this._isOpen) return u;
+    const i = this.zoneName || this.zone || "Comfort Band";
+    return f`
+      <dialog @close=${this._onClose}>
+        <div class="frame">
+          <header>
+            <h2>${i}</h2>
+            <button class="close" @click=${this.close} aria-label="Close">×</button>
+          </header>
+          <nav role="tablist">
+            ${_e.map(
+      (t) => f`
+                <button
+                  role="tab"
+                  aria-selected=${this._activeTab === t.id}
+                  @click=${() => this._onSelectTab(t.id)}
+                >
+                  ${t.label}
+                </button>
+              `
+    )}
+          </nav>
+          <div class="panel" role="tabpanel">${this._renderTab()}</div>
+        </div>
+      </dialog>
+    `;
+  }
+  _renderTab() {
+    switch (this._activeTab) {
+      case "now":
+        return f`<comfort-band-now-tab
+          .hass=${this.hass}
+          .zone=${this.zone}
+          .entities=${this.entities}
+        ></comfort-band-now-tab>`;
+      case "schedule":
+        return f`<div class="placeholder">Schedule editor — landing in commit 7.</div>`;
+      case "profiles":
+        return f`<div class="placeholder">Profiles — landing in commit 5.</div>`;
+      case "insights":
+        return f`<div class="placeholder">Insights — landing in commit 6.</div>`;
+    }
+  }
+};
+_.styles = [
+  U,
+  O`
+      :host {
+        --cb-modal-max-width: 480px;
+      }
+      dialog {
+        width: min(90vw, var(--cb-modal-max-width));
+        max-height: min(90vh, 720px);
+        padding: 0;
+        border: none;
+        border-radius: var(--cb-radius-card);
+        background: var(--ha-card-background, var(--card-background-color, #ffffff));
+        color: var(--cb-text-primary);
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+        overflow: hidden;
+      }
+      dialog::backdrop {
+        background: rgba(0, 0, 0, 0.4);
+      }
+      .frame {
+        display: flex;
+        flex-direction: column;
+        max-height: inherit;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--cb-gap-md);
+        border-bottom: 1px solid var(--divider-color, #e0e0e0);
+      }
+      header h2 {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 500;
+        color: var(--cb-text-primary);
+      }
+      .close {
+        font: inherit;
+        font-size: 22px;
+        line-height: 1;
+        background: transparent;
+        border: none;
+        color: var(--cb-text-secondary);
+        cursor: pointer;
+        padding: 4px 8px;
+      }
+      nav {
+        display: flex;
+        gap: 0;
+        border-bottom: 1px solid var(--divider-color, #e0e0e0);
+        overflow-x: auto;
+      }
+      nav button {
+        font: inherit;
+        font-size: 13px;
+        padding: 10px 14px;
+        background: transparent;
+        border: none;
+        border-bottom: 2px solid transparent;
+        color: var(--cb-text-secondary);
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      nav button[aria-selected='true'] {
+        color: var(--cb-accent, var(--primary-color, #03a9f4));
+        border-bottom-color: var(--cb-accent, var(--primary-color, #03a9f4));
+      }
+      .panel {
+        overflow-y: auto;
+        flex: 1;
+      }
+      .placeholder {
+        padding: var(--cb-gap-lg);
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+        text-align: center;
+      }
+    `
+];
+E([
+  h({ attribute: !1 })
+], _.prototype, "hass", 2);
+E([
+  h({ type: String })
+], _.prototype, "zone", 2);
+E([
+  h({ type: String })
+], _.prototype, "zoneName", 2);
+E([
+  h({ attribute: !1 })
+], _.prototype, "entities", 2);
+E([
+  D()
+], _.prototype, "_activeTab", 2);
+E([
+  D()
+], _.prototype, "_isOpen", 2);
+E([
+  lt("dialog")
+], _.prototype, "_dialog", 2);
+_ = E([
+  M("comfort-band-modal")
+], _);
+const zt = "comfort_band", $e = {
   effective_low: "effectiveLow",
   effective_high: "effectiveHigh",
   room_temperature: "roomTemperature",
@@ -828,7 +1454,7 @@ const At = "comfort_band", te = {
   cancel_override: "cancelOverride",
   enabled: "enabled"
 };
-function ee() {
+function ye() {
   return {
     effectiveLow: null,
     effectiveHigh: null,
@@ -848,94 +1474,100 @@ function ee() {
     deviceName: null
   };
 }
-function ie(s, t) {
-  for (const e of Object.values(s.devices))
-    for (const [i, r] of e.identifiers)
-      if (i === t[0] && r === t[1])
+function we(i, t) {
+  for (const e of Object.values(i.devices))
+    for (const [r, s] of e.identifiers)
+      if (r === t[0] && s === t[1])
         return e;
   return null;
 }
-function re(s, t) {
-  return Object.values(s.entities).filter(
-    (e) => e.device_id === t && e.platform === At
+function xe(i, t) {
+  return Object.values(i.entities).filter(
+    (e) => e.device_id === t && e.platform === zt
   );
 }
-function se(s, t) {
-  const e = ee(), i = ie(s, [At, `zone:${t}`]);
-  if (i === null) return e;
-  e.deviceId = i.id, e.deviceName = i.name_by_user ?? i.name;
-  const r = `${t}_`;
-  for (const o of re(s, i.id)) {
-    if (!o.unique_id.startsWith(r)) continue;
-    const n = o.unique_id.slice(r.length), c = te[n];
+function Ae(i, t) {
+  const e = ye(), r = we(i, [zt, `zone:${t}`]);
+  if (r === null) return e;
+  e.deviceId = r.id, e.deviceName = r.name_by_user ?? r.name;
+  const s = `${t}_`;
+  for (const o of xe(i, r.id)) {
+    if (!o.unique_id.startsWith(s)) continue;
+    const n = o.unique_id.slice(s.length), c = $e[n];
     c !== void 0 && (e[c] = o.entity_id);
   }
   return e;
 }
-var oe = Object.defineProperty, ne = Object.getOwnPropertyDescriptor, et = (s, t, e, i) => {
-  for (var r = i > 1 ? void 0 : i ? ne(t, e) : t, o = s.length - 1, n; o >= 0; o--)
-    (n = s[o]) && (r = (i ? n(t, e, r) : n(r)) || r);
-  return i && r && oe(t, e, r), r;
+var Ee = Object.defineProperty, Se = Object.getOwnPropertyDescriptor, Q = (i, t, e, r) => {
+  for (var s = r > 1 ? void 0 : r ? Se(t, e) : t, o = i.length - 1, n; o >= 0; o--)
+    (n = i[o]) && (s = (r ? n(t, e, s) : n(s)) || s);
+  return r && s && Ee(t, e, s), s;
 };
-let U = class extends A {
+let k = class extends b {
   constructor() {
     super(...arguments), this._onTileTap = () => {
-      console.debug("comfort-band-card: tile tap (modal lands in commit 4)");
+      this._modal?.open();
     };
   }
-  setConfig(s) {
-    if (!s?.zone)
+  setConfig(i) {
+    if (!i?.zone)
       throw new Error("comfort-band-card: `zone` is required");
-    this._config = s;
+    this._config = i;
   }
   /** HA's panel/grid uses this to size the card. ~1 row per ~50 px of content. */
   getCardSize() {
     return 2;
   }
   render() {
-    if (!this._config || !this.hass) return y``;
-    const s = this._config.zone, t = se(this.hass, s);
+    if (!this._config || !this.hass) return f``;
+    const i = this._config.zone, t = Ae(this.hass, i);
     if (t.deviceId === null)
-      return y`<div class="placeholder">
-        Comfort Band zone <code>${s}</code> not found. Add it via Settings → Devices &
+      return f`<div class="placeholder">
+        Comfort Band zone <code>${i}</code> not found. Add it via Settings → Devices &
         Services.
       </div>`;
-    const e = this._config.compact === !0, i = this._buildView(this.hass, t);
-    return y`
+    const e = this._config.compact === !0, r = this._buildView(this.hass, t);
+    return f`
       <comfort-band-tile
-        zoneName=${i.zoneName}
-        .roomTemp=${i.roomTemp}
-        .low=${i.low}
-        .high=${i.high}
-        .action=${i.action}
-        .overrideActive=${i.overrideActive}
-        .overrideEnds=${i.overrideEnds}
+        zoneName=${r.zoneName}
+        .roomTemp=${r.roomTemp}
+        .low=${r.low}
+        .high=${r.high}
+        .action=${r.action}
+        .overrideActive=${r.overrideActive}
+        .overrideEnds=${r.overrideEnds}
         .noExpand=${e}
         @comfort-band-tile-tap=${this._onTileTap}
       ></comfort-band-tile>
+      ${e ? null : f`<comfort-band-modal
+            .hass=${this.hass}
+            zone=${i}
+            zoneName=${r.zoneName}
+            .entities=${t}
+          ></comfort-band-modal>`}
     `;
   }
-  _buildView(s, t) {
-    const e = (r) => r !== null ? s.states[r] : void 0, i = (r) => {
-      const o = e(r);
+  _buildView(i, t) {
+    const e = (s) => s !== null ? i.states[s] : void 0, r = (s) => {
+      const o = e(s);
       if (!o) return NaN;
       const n = parseFloat(o.state);
       return Number.isFinite(n) ? n : NaN;
     };
     return {
       zoneName: t.deviceName ?? this._config.zone,
-      low: i(t.effectiveLow),
-      high: i(t.effectiveHigh),
-      roomTemp: i(t.roomTemperature),
+      low: r(t.effectiveLow),
+      high: r(t.effectiveHigh),
+      roomTemp: r(t.roomTemperature),
       action: e(t.currentAction)?.state ?? "unknown",
       overrideActive: e(t.overrideActive)?.state === "on",
       overrideEnds: e(t.overrideEnds)?.state ?? null
     };
   }
 };
-U.styles = [
-  tt,
-  L`
+k.styles = [
+  U,
+  O`
       :host {
         display: block;
       }
@@ -949,15 +1581,18 @@ U.styles = [
       }
     `
 ];
-et([
-  u({ attribute: !1 })
-], U.prototype, "hass", 2);
-et([
-  Wt()
-], U.prototype, "_config", 2);
-U = et([
-  Q("comfort-band-card")
-], U);
+Q([
+  h({ attribute: !1 })
+], k.prototype, "hass", 2);
+Q([
+  D()
+], k.prototype, "_config", 2);
+Q([
+  lt("comfort-band-modal")
+], k.prototype, "_modal", 2);
+k = Q([
+  M("comfort-band-card")
+], k);
 (window.customCards ??= []).push({
   type: "comfort-band-card",
   name: "Comfort Band",

--- a/dist/comfort-band-card.js
+++ b/dist/comfort-band-card.js
@@ -1,15 +1,15 @@
-const Q = globalThis, ft = Q.ShadowRoot && (Q.ShadyCSS === void 0 || Q.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, mt = Symbol(), xt = /* @__PURE__ */ new WeakMap();
-let Lt = class {
+const tt = globalThis, mt = tt.ShadowRoot && (tt.ShadyCSS === void 0 || tt.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, bt = Symbol(), Et = /* @__PURE__ */ new WeakMap();
+let jt = class {
   constructor(t, i, r) {
-    if (this._$cssResult$ = !0, r !== mt) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+    if (this._$cssResult$ = !0, r !== bt) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
     this.cssText = t, this.t = i;
   }
   get styleSheet() {
     let t = this.o;
     const i = this.t;
-    if (ft && t === void 0) {
+    if (mt && t === void 0) {
       const r = i !== void 0 && i.length === 1;
-      r && (t = xt.get(i)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && xt.set(i, t));
+      r && (t = Et.get(i)), t === void 0 && ((this.o = t = new CSSStyleSheet()).replaceSync(this.cssText), r && Et.set(i, t));
     }
     return t;
   }
@@ -17,28 +17,28 @@ let Lt = class {
     return this.cssText;
   }
 };
-const Zt = (e) => new Lt(typeof e == "string" ? e : e + "", void 0, mt), _ = (e, ...t) => {
+const Yt = (e) => new jt(typeof e == "string" ? e : e + "", void 0, bt), v = (e, ...t) => {
   const i = e.length === 1 ? e[0] : t.reduce((r, s, o) => r + ((n) => {
     if (n._$cssResult$ === !0) return n.cssText;
     if (typeof n == "number") return n;
     throw Error("Value passed to 'css' function must be a 'css' function result: " + n + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
   })(s) + e[o + 1], e[0]);
-  return new Lt(i, e, mt);
-}, Jt = (e, t) => {
-  if (ft) e.adoptedStyleSheets = t.map((i) => i instanceof CSSStyleSheet ? i : i.styleSheet);
+  return new jt(i, e, bt);
+}, Qt = (e, t) => {
+  if (mt) e.adoptedStyleSheets = t.map((i) => i instanceof CSSStyleSheet ? i : i.styleSheet);
   else for (const i of t) {
-    const r = document.createElement("style"), s = Q.litNonce;
+    const r = document.createElement("style"), s = tt.litNonce;
     s !== void 0 && r.setAttribute("nonce", s), r.textContent = i.cssText, e.appendChild(r);
   }
-}, At = ft ? (e) => e : (e) => e instanceof CSSStyleSheet ? ((t) => {
+}, St = mt ? (e) => e : (e) => e instanceof CSSStyleSheet ? ((t) => {
   let i = "";
   for (const r of t.cssRules) i += r.cssText;
-  return Zt(i);
+  return Yt(i);
 })(e) : e;
-const { is: Yt, defineProperty: Qt, getOwnPropertyDescriptor: te, getOwnPropertyNames: ee, getOwnPropertySymbols: ie, getPrototypeOf: re } = Object, st = globalThis, Et = st.trustedTypes, se = Et ? Et.emptyScript : "", oe = st.reactiveElementPolyfillSupport, V = (e, t) => e, tt = { toAttribute(e, t) {
+const { is: te, defineProperty: ee, getOwnPropertyDescriptor: ie, getOwnPropertyNames: re, getOwnPropertySymbols: se, getPrototypeOf: oe } = Object, ot = globalThis, Ct = ot.trustedTypes, ne = Ct ? Ct.emptyScript : "", ae = ot.reactiveElementPolyfillSupport, V = (e, t) => e, et = { toAttribute(e, t) {
   switch (t) {
     case Boolean:
-      e = e ? se : null;
+      e = e ? ne : null;
       break;
     case Object:
     case Array:
@@ -63,8 +63,8 @@ const { is: Yt, defineProperty: Qt, getOwnPropertyDescriptor: te, getOwnProperty
       }
   }
   return i;
-} }, vt = (e, t) => !Yt(e, t), St = { attribute: !0, type: String, converter: tt, reflect: !1, useDefault: !1, hasChanged: vt };
-Symbol.metadata ??= Symbol("metadata"), st.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
+} }, vt = (e, t) => !te(e, t), Pt = { attribute: !0, type: String, converter: et, reflect: !1, useDefault: !1, hasChanged: vt };
+Symbol.metadata ??= Symbol("metadata"), ot.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
 let U = class extends HTMLElement {
   static addInitializer(t) {
     this._$Ei(), (this.l ??= []).push(t);
@@ -72,35 +72,35 @@ let U = class extends HTMLElement {
   static get observedAttributes() {
     return this.finalize(), this._$Eh && [...this._$Eh.keys()];
   }
-  static createProperty(t, i = St) {
+  static createProperty(t, i = Pt) {
     if (i.state && (i.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(t) && ((i = Object.create(i)).wrapped = !0), this.elementProperties.set(t, i), !i.noAccessor) {
       const r = Symbol(), s = this.getPropertyDescriptor(t, r, i);
-      s !== void 0 && Qt(this.prototype, t, s);
+      s !== void 0 && ee(this.prototype, t, s);
     }
   }
   static getPropertyDescriptor(t, i, r) {
-    const { get: s, set: o } = te(this.prototype, t) ?? { get() {
+    const { get: s, set: o } = ie(this.prototype, t) ?? { get() {
       return this[i];
     }, set(n) {
       this[i] = n;
     } };
     return { get: s, set(n) {
-      const c = s?.call(this);
-      o?.call(this, n), this.requestUpdate(t, c, r);
+      const h = s?.call(this);
+      o?.call(this, n), this.requestUpdate(t, h, r);
     }, configurable: !0, enumerable: !0 };
   }
   static getPropertyOptions(t) {
-    return this.elementProperties.get(t) ?? St;
+    return this.elementProperties.get(t) ?? Pt;
   }
   static _$Ei() {
     if (this.hasOwnProperty(V("elementProperties"))) return;
-    const t = re(this);
+    const t = oe(this);
     t.finalize(), t.l !== void 0 && (this.l = [...t.l]), this.elementProperties = new Map(t.elementProperties);
   }
   static finalize() {
     if (this.hasOwnProperty(V("finalized"))) return;
     if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(V("properties"))) {
-      const i = this.properties, r = [...ee(i), ...ie(i)];
+      const i = this.properties, r = [...re(i), ...se(i)];
       for (const s of r) this.createProperty(s, i[s]);
     }
     const t = this[Symbol.metadata];
@@ -119,8 +119,8 @@ let U = class extends HTMLElement {
     const i = [];
     if (Array.isArray(t)) {
       const r = new Set(t.flat(1 / 0).reverse());
-      for (const s of r) i.unshift(At(s));
-    } else t !== void 0 && i.push(At(t));
+      for (const s of r) i.unshift(St(s));
+    } else t !== void 0 && i.push(St(t));
     return i;
   }
   static _$Eu(t, i) {
@@ -146,7 +146,7 @@ let U = class extends HTMLElement {
   }
   createRenderRoot() {
     const t = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-    return Jt(t, this.constructor.elementStyles), t;
+    return Qt(t, this.constructor.elementStyles), t;
   }
   connectedCallback() {
     this.renderRoot ??= this.createRenderRoot(), this.enableUpdating(!0), this._$EO?.forEach((t) => t.hostConnected?.());
@@ -162,17 +162,17 @@ let U = class extends HTMLElement {
   _$ET(t, i) {
     const r = this.constructor.elementProperties.get(t), s = this.constructor._$Eu(t, r);
     if (s !== void 0 && r.reflect === !0) {
-      const o = (r.converter?.toAttribute !== void 0 ? r.converter : tt).toAttribute(i, r.type);
+      const o = (r.converter?.toAttribute !== void 0 ? r.converter : et).toAttribute(i, r.type);
       this._$Em = t, o == null ? this.removeAttribute(s) : this.setAttribute(s, o), this._$Em = null;
     }
   }
   _$AK(t, i) {
     const r = this.constructor, s = r._$Eh.get(t);
     if (s !== void 0 && this._$Em !== s) {
-      const o = r.getPropertyOptions(s), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : tt;
+      const o = r.getPropertyOptions(s), n = typeof o.converter == "function" ? { fromAttribute: o.converter } : o.converter?.fromAttribute !== void 0 ? o.converter : et;
       this._$Em = s;
-      const c = n.fromAttribute(i, o.type);
-      this[s] = c ?? this._$Ej?.get(s) ?? c, this._$Em = null;
+      const h = n.fromAttribute(i, o.type);
+      this[s] = h ?? this._$Ej?.get(s) ?? h, this._$Em = null;
     }
   }
   requestUpdate(t, i, r, s = !1, o) {
@@ -208,8 +208,8 @@ let U = class extends HTMLElement {
       }
       const r = this.constructor.elementProperties;
       if (r.size > 0) for (const [s, o] of r) {
-        const { wrapped: n } = o, c = this[s];
-        n !== !0 || this._$AL.has(s) || c === void 0 || this.C(s, void 0, o, c);
+        const { wrapped: n } = o, h = this[s];
+        n !== !0 || this._$AL.has(s) || h === void 0 || this.C(s, void 0, o, h);
       }
     }
     let t = !1;
@@ -246,54 +246,54 @@ let U = class extends HTMLElement {
   firstUpdated(t) {
   }
 };
-U.elementStyles = [], U.shadowRootOptions = { mode: "open" }, U[V("elementProperties")] = /* @__PURE__ */ new Map(), U[V("finalized")] = /* @__PURE__ */ new Map(), oe?.({ ReactiveElement: U }), (st.reactiveElementVersions ??= []).push("2.1.2");
-const bt = globalThis, Pt = (e) => e, et = bt.trustedTypes, Ct = et ? et.createPolicy("lit-html", { createHTML: (e) => e }) : void 0, Ut = "$lit$", N = `lit$${Math.random().toFixed(9).slice(2)}$`, Rt = "?" + N, ne = `<${Rt}>`, H = document, K = () => H.createComment(""), W = (e) => e === null || typeof e != "object" && typeof e != "function", gt = Array.isArray, ae = (e) => gt(e) || typeof e?.[Symbol.iterator] == "function", ht = `[ 	
-\f\r]`, q = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, Tt = /-->/g, Nt = />/g, D = RegExp(`>|${ht}(?:([^\\s"'>=/]+)(${ht}*=${ht}*(?:[^ 	
-\f\r"'\`<>=]|("|')|))|$)`, "g"), Ot = /'/g, zt = /"/g, jt = /^(?:script|style|textarea|title)$/i, Bt = (e) => (t, ...i) => ({ _$litType$: e, strings: t, values: i }), l = Bt(1), Y = Bt(2), R = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), kt = /* @__PURE__ */ new WeakMap(), M = H.createTreeWalker(H, 129);
-function It(e, t) {
-  if (!gt(e) || !e.hasOwnProperty("raw")) throw Error("invalid template strings array");
-  return Ct !== void 0 ? Ct.createHTML(t) : t;
+U.elementStyles = [], U.shadowRootOptions = { mode: "open" }, U[V("elementProperties")] = /* @__PURE__ */ new Map(), U[V("finalized")] = /* @__PURE__ */ new Map(), ae?.({ ReactiveElement: U }), (ot.reactiveElementVersions ??= []).push("2.1.2");
+const gt = globalThis, Ot = (e) => e, it = gt.trustedTypes, Tt = it ? it.createPolicy("lit-html", { createHTML: (e) => e }) : void 0, Rt = "$lit$", T = `lit$${Math.random().toFixed(9).slice(2)}$`, Bt = "?" + T, ce = `<${Bt}>`, H = document, W = () => H.createComment(""), K = (e) => e === null || typeof e != "object" && typeof e != "function", _t = Array.isArray, le = (e) => _t(e) || typeof e?.[Symbol.iterator] == "function", dt = `[ 	
+\f\r]`, q = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, Nt = /-->/g, zt = />/g, D = RegExp(`>|${dt}(?:([^\\s"'>=/]+)(${dt}*=${dt}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`, "g"), kt = /'/g, Dt = /"/g, It = /^(?:script|style|textarea|title)$/i, Ft = (e) => (t, ...i) => ({ _$litType$: e, strings: t, values: i }), a = Ft(1), Q = Ft(2), j = Symbol.for("lit-noChange"), p = Symbol.for("lit-nothing"), Mt = /* @__PURE__ */ new WeakMap(), M = H.createTreeWalker(H, 129);
+function qt(e, t) {
+  if (!_t(e) || !e.hasOwnProperty("raw")) throw Error("invalid template strings array");
+  return Tt !== void 0 ? Tt.createHTML(t) : t;
 }
-const le = (e, t) => {
+const he = (e, t) => {
   const i = e.length - 1, r = [];
   let s, o = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", n = q;
-  for (let c = 0; c < i; c++) {
-    const a = e[c];
-    let f, u, d = -1, b = 0;
-    for (; b < a.length && (n.lastIndex = b, u = n.exec(a), u !== null); ) b = n.lastIndex, n === q ? u[1] === "!--" ? n = Tt : u[1] !== void 0 ? n = Nt : u[2] !== void 0 ? (jt.test(u[2]) && (s = RegExp("</" + u[2], "g")), n = D) : u[3] !== void 0 && (n = D) : n === D ? u[0] === ">" ? (n = s ?? q, d = -1) : u[1] === void 0 ? d = -2 : (d = n.lastIndex - u[2].length, f = u[1], n = u[3] === void 0 ? D : u[3] === '"' ? zt : Ot) : n === zt || n === Ot ? n = D : n === Tt || n === Nt ? n = q : (n = D, s = void 0);
-    const T = n === D && e[c + 1].startsWith("/>") ? " " : "";
-    o += n === q ? a + ne : d >= 0 ? (r.push(f), a.slice(0, d) + Ut + a.slice(d) + N + T) : a + N + (d === -2 ? c : T);
+  for (let h = 0; h < i; h++) {
+    const c = e[h];
+    let f, u, d = -1, g = 0;
+    for (; g < c.length && (n.lastIndex = g, u = n.exec(c), u !== null); ) g = n.lastIndex, n === q ? u[1] === "!--" ? n = Nt : u[1] !== void 0 ? n = zt : u[2] !== void 0 ? (It.test(u[2]) && (s = RegExp("</" + u[2], "g")), n = D) : u[3] !== void 0 && (n = D) : n === D ? u[0] === ">" ? (n = s ?? q, d = -1) : u[1] === void 0 ? d = -2 : (d = n.lastIndex - u[2].length, f = u[1], n = u[3] === void 0 ? D : u[3] === '"' ? Dt : kt) : n === Dt || n === kt ? n = D : n === Nt || n === zt ? n = q : (n = D, s = void 0);
+    const O = n === D && e[h + 1].startsWith("/>") ? " " : "";
+    o += n === q ? c + ce : d >= 0 ? (r.push(f), c.slice(0, d) + Rt + c.slice(d) + T + O) : c + T + (d === -2 ? h : O);
   }
-  return [It(e, o + (e[i] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
+  return [qt(e, o + (e[i] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
 };
-class X {
+class Z {
   constructor({ strings: t, _$litType$: i }, r) {
     let s;
     this.parts = [];
     let o = 0, n = 0;
-    const c = t.length - 1, a = this.parts, [f, u] = le(t, i);
-    if (this.el = X.createElement(f, r), M.currentNode = this.el.content, i === 2 || i === 3) {
+    const h = t.length - 1, c = this.parts, [f, u] = he(t, i);
+    if (this.el = Z.createElement(f, r), M.currentNode = this.el.content, i === 2 || i === 3) {
       const d = this.el.content.firstChild;
       d.replaceWith(...d.childNodes);
     }
-    for (; (s = M.nextNode()) !== null && a.length < c; ) {
+    for (; (s = M.nextNode()) !== null && c.length < h; ) {
       if (s.nodeType === 1) {
-        if (s.hasAttributes()) for (const d of s.getAttributeNames()) if (d.endsWith(Ut)) {
-          const b = u[n++], T = s.getAttribute(d).split(N), J = /([.?@])?(.*)/.exec(b);
-          a.push({ type: 1, index: o, name: J[2], strings: T, ctor: J[1] === "." ? he : J[1] === "?" ? de : J[1] === "@" ? pe : ot }), s.removeAttribute(d);
-        } else d.startsWith(N) && (a.push({ type: 6, index: o }), s.removeAttribute(d));
-        if (jt.test(s.tagName)) {
-          const d = s.textContent.split(N), b = d.length - 1;
-          if (b > 0) {
-            s.textContent = et ? et.emptyScript : "";
-            for (let T = 0; T < b; T++) s.append(d[T], K()), M.nextNode(), a.push({ type: 2, index: ++o });
-            s.append(d[b], K());
+        if (s.hasAttributes()) for (const d of s.getAttributeNames()) if (d.endsWith(Rt)) {
+          const g = u[n++], O = s.getAttribute(d).split(T), Y = /([.?@])?(.*)/.exec(g);
+          c.push({ type: 1, index: o, name: Y[2], strings: O, ctor: Y[1] === "." ? pe : Y[1] === "?" ? ue : Y[1] === "@" ? fe : nt }), s.removeAttribute(d);
+        } else d.startsWith(T) && (c.push({ type: 6, index: o }), s.removeAttribute(d));
+        if (It.test(s.tagName)) {
+          const d = s.textContent.split(T), g = d.length - 1;
+          if (g > 0) {
+            s.textContent = it ? it.emptyScript : "";
+            for (let O = 0; O < g; O++) s.append(d[O], W()), M.nextNode(), c.push({ type: 2, index: ++o });
+            s.append(d[g], W());
           }
         }
-      } else if (s.nodeType === 8) if (s.data === Rt) a.push({ type: 2, index: o });
+      } else if (s.nodeType === 8) if (s.data === Bt) c.push({ type: 2, index: o });
       else {
         let d = -1;
-        for (; (d = s.data.indexOf(N, d + 1)) !== -1; ) a.push({ type: 7, index: o }), d += N.length - 1;
+        for (; (d = s.data.indexOf(T, d + 1)) !== -1; ) c.push({ type: 7, index: o }), d += T.length - 1;
       }
       o++;
     }
@@ -303,13 +303,13 @@ class X {
     return r.innerHTML = t, r;
   }
 }
-function j(e, t, i = e, r) {
-  if (t === R) return t;
+function R(e, t, i = e, r) {
+  if (t === j) return t;
   let s = r !== void 0 ? i._$Co?.[r] : i._$Cl;
-  const o = W(t) ? void 0 : t._$litDirective$;
-  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(e), s._$AT(e, i, r)), r !== void 0 ? (i._$Co ??= [])[r] = s : i._$Cl = s), s !== void 0 && (t = j(e, s._$AS(e, t.values), s, r)), t;
+  const o = K(t) ? void 0 : t._$litDirective$;
+  return s?.constructor !== o && (s?._$AO?.(!1), o === void 0 ? s = void 0 : (s = new o(e), s._$AT(e, i, r)), r !== void 0 ? (i._$Co ??= [])[r] = s : i._$Cl = s), s !== void 0 && (t = R(e, s._$AS(e, t.values), s, r)), t;
 }
-class ce {
+class de {
   constructor(t, i) {
     this._$AV = [], this._$AN = void 0, this._$AD = t, this._$AM = i;
   }
@@ -322,13 +322,13 @@ class ce {
   u(t) {
     const { el: { content: i }, parts: r } = this._$AD, s = (t?.creationScope ?? H).importNode(i, !0);
     M.currentNode = s;
-    let o = M.nextNode(), n = 0, c = 0, a = r[0];
-    for (; a !== void 0; ) {
-      if (n === a.index) {
+    let o = M.nextNode(), n = 0, h = 0, c = r[0];
+    for (; c !== void 0; ) {
+      if (n === c.index) {
         let f;
-        a.type === 2 ? f = new G(o, o.nextSibling, this, t) : a.type === 1 ? f = new a.ctor(o, a.name, a.strings, this, t) : a.type === 6 && (f = new ue(o, this, t)), this._$AV.push(f), a = r[++c];
+        c.type === 2 ? f = new G(o, o.nextSibling, this, t) : c.type === 1 ? f = new c.ctor(o, c.name, c.strings, this, t) : c.type === 6 && (f = new me(o, this, t)), this._$AV.push(f), c = r[++h];
       }
-      n !== a?.index && (o = M.nextNode(), n++);
+      n !== c?.index && (o = M.nextNode(), n++);
     }
     return M.currentNode = H, s;
   }
@@ -356,7 +356,7 @@ class G {
     return this._$AB;
   }
   _$AI(t, i = this) {
-    t = j(this, t, i), W(t) ? t === p || t == null || t === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : t !== this._$AH && t !== R && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : ae(t) ? this.k(t) : this._(t);
+    t = R(this, t, i), K(t) ? t === p || t == null || t === "" ? (this._$AH !== p && this._$AR(), this._$AH = p) : t !== this._$AH && t !== j && this._(t) : t._$litType$ !== void 0 ? this.$(t) : t.nodeType !== void 0 ? this.T(t) : le(t) ? this.k(t) : this._(t);
   }
   O(t) {
     return this._$AA.parentNode.insertBefore(t, this._$AB);
@@ -365,38 +365,38 @@ class G {
     this._$AH !== t && (this._$AR(), this._$AH = this.O(t));
   }
   _(t) {
-    this._$AH !== p && W(this._$AH) ? this._$AA.nextSibling.data = t : this.T(H.createTextNode(t)), this._$AH = t;
+    this._$AH !== p && K(this._$AH) ? this._$AA.nextSibling.data = t : this.T(H.createTextNode(t)), this._$AH = t;
   }
   $(t) {
-    const { values: i, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = X.createElement(It(r.h, r.h[0]), this.options)), r);
+    const { values: i, _$litType$: r } = t, s = typeof r == "number" ? this._$AC(t) : (r.el === void 0 && (r.el = Z.createElement(qt(r.h, r.h[0]), this.options)), r);
     if (this._$AH?._$AD === s) this._$AH.p(i);
     else {
-      const o = new ce(s, this), n = o.u(this.options);
+      const o = new de(s, this), n = o.u(this.options);
       o.p(i), this.T(n), this._$AH = o;
     }
   }
   _$AC(t) {
-    let i = kt.get(t.strings);
-    return i === void 0 && kt.set(t.strings, i = new X(t)), i;
+    let i = Mt.get(t.strings);
+    return i === void 0 && Mt.set(t.strings, i = new Z(t)), i;
   }
   k(t) {
-    gt(this._$AH) || (this._$AH = [], this._$AR());
+    _t(this._$AH) || (this._$AH = [], this._$AR());
     const i = this._$AH;
     let r, s = 0;
-    for (const o of t) s === i.length ? i.push(r = new G(this.O(K()), this.O(K()), this, this.options)) : r = i[s], r._$AI(o), s++;
+    for (const o of t) s === i.length ? i.push(r = new G(this.O(W()), this.O(W()), this, this.options)) : r = i[s], r._$AI(o), s++;
     s < i.length && (this._$AR(r && r._$AB.nextSibling, s), i.length = s);
   }
   _$AR(t = this._$AA.nextSibling, i) {
     for (this._$AP?.(!1, !0, i); t !== this._$AB; ) {
-      const r = Pt(t).nextSibling;
-      Pt(t).remove(), t = r;
+      const r = Ot(t).nextSibling;
+      Ot(t).remove(), t = r;
     }
   }
   setConnected(t) {
     this._$AM === void 0 && (this._$Cv = t, this._$AP?.(t));
   }
 }
-class ot {
+class nt {
   get tagName() {
     return this.element.tagName;
   }
@@ -409,11 +409,11 @@ class ot {
   _$AI(t, i = this, r, s) {
     const o = this.strings;
     let n = !1;
-    if (o === void 0) t = j(this, t, i, 0), n = !W(t) || t !== this._$AH && t !== R, n && (this._$AH = t);
+    if (o === void 0) t = R(this, t, i, 0), n = !K(t) || t !== this._$AH && t !== j, n && (this._$AH = t);
     else {
-      const c = t;
-      let a, f;
-      for (t = o[0], a = 0; a < o.length - 1; a++) f = j(this, c[r + a], i, a), f === R && (f = this._$AH[a]), n ||= !W(f) || f !== this._$AH[a], f === p ? t = p : t !== p && (t += (f ?? "") + o[a + 1]), this._$AH[a] = f;
+      const h = t;
+      let c, f;
+      for (t = o[0], c = 0; c < o.length - 1; c++) f = R(this, h[r + c], i, c), f === j && (f = this._$AH[c]), n ||= !K(f) || f !== this._$AH[c], f === p ? t = p : t !== p && (t += (f ?? "") + o[c + 1]), this._$AH[c] = f;
     }
     n && !s && this.j(t);
   }
@@ -421,7 +421,7 @@ class ot {
     t === p ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, t ?? "");
   }
 }
-class he extends ot {
+class pe extends nt {
   constructor() {
     super(...arguments), this.type = 3;
   }
@@ -429,7 +429,7 @@ class he extends ot {
     this.element[this.name] = t === p ? void 0 : t;
   }
 }
-class de extends ot {
+class ue extends nt {
   constructor() {
     super(...arguments), this.type = 4;
   }
@@ -437,12 +437,12 @@ class de extends ot {
     this.element.toggleAttribute(this.name, !!t && t !== p);
   }
 }
-class pe extends ot {
+class fe extends nt {
   constructor(t, i, r, s, o) {
     super(t, i, r, s, o), this.type = 5;
   }
   _$AI(t, i = this) {
-    if ((t = j(this, t, i, 0) ?? p) === R) return;
+    if ((t = R(this, t, i, 0) ?? p) === j) return;
     const r = this._$AH, s = t === p && r !== p || t.capture !== r.capture || t.once !== r.once || t.passive !== r.passive, o = t !== p && (r === p || s);
     s && this.element.removeEventListener(this.name, this, r), o && this.element.addEventListener(this.name, this, t), this._$AH = t;
   }
@@ -450,7 +450,7 @@ class pe extends ot {
     typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, t) : this._$AH.handleEvent(t);
   }
 }
-class ue {
+class me {
   constructor(t, i, r) {
     this.element = t, this.type = 6, this._$AN = void 0, this._$AM = i, this.options = r;
   }
@@ -458,22 +458,22 @@ class ue {
     return this._$AM._$AU;
   }
   _$AI(t) {
-    j(this, t);
+    R(this, t);
   }
 }
-const fe = bt.litHtmlPolyfillSupport;
-fe?.(X, G), (bt.litHtmlVersions ??= []).push("3.3.2");
-const me = (e, t, i) => {
+const be = gt.litHtmlPolyfillSupport;
+be?.(Z, G), (gt.litHtmlVersions ??= []).push("3.3.2");
+const ve = (e, t, i) => {
   const r = i?.renderBefore ?? t;
   let s = r._$litPart$;
   if (s === void 0) {
     const o = i?.renderBefore ?? null;
-    r._$litPart$ = s = new G(t.insertBefore(K(), o), o, void 0, i ?? {});
+    r._$litPart$ = s = new G(t.insertBefore(W(), o), o, void 0, i ?? {});
   }
   return s._$AI(e), s;
 };
-const _t = globalThis;
-class v extends U {
+const $t = globalThis;
+class b extends U {
   constructor() {
     super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
   }
@@ -483,7 +483,7 @@ class v extends U {
   }
   update(t) {
     const i = this.render();
-    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = me(i, this.renderRoot, this.renderOptions);
+    this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(t), this._$Do = ve(i, this.renderRoot, this.renderOptions);
   }
   connectedCallback() {
     super.connectedCallback(), this._$Do?.setConnected(!0);
@@ -492,58 +492,58 @@ class v extends U {
     super.disconnectedCallback(), this._$Do?.setConnected(!1);
   }
   render() {
-    return R;
+    return j;
   }
 }
-v._$litElement$ = !0, v.finalized = !0, _t.litElementHydrateSupport?.({ LitElement: v });
-const ve = _t.litElementPolyfillSupport;
-ve?.({ LitElement: v });
-(_t.litElementVersions ??= []).push("4.2.2");
-const w = (e) => (t, i) => {
+b._$litElement$ = !0, b.finalized = !0, $t.litElementHydrateSupport?.({ LitElement: b });
+const ge = $t.litElementPolyfillSupport;
+ge?.({ LitElement: b });
+($t.litElementVersions ??= []).push("4.2.2");
+const $ = (e) => (t, i) => {
   i !== void 0 ? i.addInitializer(() => {
     customElements.define(e, t);
   }) : customElements.define(e, t);
 };
-const be = { attribute: !0, type: String, converter: tt, reflect: !1, hasChanged: vt }, ge = (e = be, t, i) => {
+const _e = { attribute: !0, type: String, converter: et, reflect: !1, hasChanged: vt }, $e = (e = _e, t, i) => {
   const { kind: r, metadata: s } = i;
   let o = globalThis.litPropertyMetadata.get(s);
   if (o === void 0 && globalThis.litPropertyMetadata.set(s, o = /* @__PURE__ */ new Map()), r === "setter" && ((e = Object.create(e)).wrapped = !0), o.set(i.name, e), r === "accessor") {
     const { name: n } = i;
-    return { set(c) {
-      const a = t.get.call(this);
-      t.set.call(this, c), this.requestUpdate(n, a, e, !0, c);
-    }, init(c) {
-      return c !== void 0 && this.C(n, void 0, e, c), c;
+    return { set(h) {
+      const c = t.get.call(this);
+      t.set.call(this, h), this.requestUpdate(n, c, e, !0, h);
+    }, init(h) {
+      return h !== void 0 && this.C(n, void 0, e, h), h;
     } };
   }
   if (r === "setter") {
     const { name: n } = i;
-    return function(c) {
-      const a = this[n];
-      t.call(this, c), this.requestUpdate(n, a, e, !0, c);
+    return function(h) {
+      const c = this[n];
+      t.call(this, h), this.requestUpdate(n, c, e, !0, h);
     };
   }
   throw Error("Unsupported decorator location: " + r);
 };
-function h(e) {
-  return (t, i) => typeof i == "object" ? ge(e, t, i) : ((r, s, o) => {
+function l(e) {
+  return (t, i) => typeof i == "object" ? $e(e, t, i) : ((r, s, o) => {
     const n = s.hasOwnProperty(o);
     return s.constructor.createProperty(o, r), n ? Object.getOwnPropertyDescriptor(s, o) : void 0;
   })(e, t, i);
 }
 function m(e) {
-  return h({ ...e, state: !0, attribute: !1 });
+  return l({ ...e, state: !0, attribute: !1 });
 }
-const _e = (e, t, i) => (i.configurable = !0, i.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(e, t, i), i);
-function nt(e, t) {
+const ye = (e, t, i) => (i.configurable = !0, i.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(e, t, i), i);
+function at(e, t) {
   return (i, r, s) => {
     const o = (n) => n.renderRoot?.querySelector(e) ?? null;
-    return _e(i, r, { get() {
+    return ye(i, r, { get() {
       return o(this);
     } });
   };
 }
-const x = _`
+const y = v`
   :host {
     --cb-action-heating: var(--cb-color-heat, var(--state-climate-heat-color, #d9603f));
     --cb-action-cooling: var(--cb-color-cool, var(--state-climate-cool-color, #2f7fcc));
@@ -562,7 +562,7 @@ const x = _`
     --cb-gap-lg: 16px;
   }
 `;
-function $t(e) {
+function yt(e) {
   switch (e) {
     case "heating":
       return "var(--cb-action-heating)";
@@ -574,40 +574,40 @@ function $t(e) {
       return "var(--cb-action-unknown)";
   }
 }
-function yt(e) {
+function wt(e) {
   return e === "heating" || e === "cooling" || e === "idle" ? e : "unknown";
 }
-function Ft(e) {
+function Vt(e) {
   return e.charAt(0).toUpperCase() + e.slice(1);
 }
-var $e = Object.defineProperty, ye = Object.getOwnPropertyDescriptor, Z = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? ye(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+var we = Object.defineProperty, xe = Object.getOwnPropertyDescriptor, J = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? xe(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && $e(t, i, s), s;
+  return r && s && we(t, i, s), s;
 };
-const ut = 15, qt = 28, we = qt - ut;
-function dt(e) {
-  return Number.isNaN(e) || !Number.isFinite(e) ? 0 : (Math.max(ut, Math.min(qt, e)) - ut) / we * 100;
+const ft = 15, Wt = 28, Ae = Wt - ft;
+function pt(e) {
+  return Number.isNaN(e) || !Number.isFinite(e) ? 0 : (Math.max(ft, Math.min(Wt, e)) - ft) / Ae * 100;
 }
-let L = class extends v {
+let L = class extends b {
   constructor() {
     super(...arguments), this.low = NaN, this.high = NaN, this.room = NaN, this.action = "unknown";
   }
   render() {
-    const e = yt(this.action), t = $t(e), i = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = i ? dt(this.low) : 0, n = r ? dt(this.high) : 100, c = Math.min(o, n), a = Math.max(0, Math.abs(n - o)), f = s ? dt(this.room) : 50, u = (b) => Number.isFinite(b) ? `${b.toFixed(1)}°` : "—", d = `Comfort band gauge: low ${u(this.low)}, room ${u(this.room)}, high ${u(this.high)}, action ${e}`;
-    return l`
+    const e = wt(this.action), t = yt(e), i = Number.isFinite(this.low), r = Number.isFinite(this.high), s = Number.isFinite(this.room), o = i ? pt(this.low) : 0, n = r ? pt(this.high) : 100, h = Math.min(o, n), c = Math.max(0, Math.abs(n - o)), f = s ? pt(this.room) : 50, u = (g) => Number.isFinite(g) ? `${g.toFixed(1)}°` : "—", d = `Comfort band gauge: low ${u(this.low)}, room ${u(this.room)}, high ${u(this.high)}, action ${e}`;
+    return a`
       <svg viewBox="0 0 100 24" preserveAspectRatio="none" role="img" aria-label=${d}>
-        ${Y`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
-        ${i && r ? Y`<rect class="band" x=${c} y="9" width=${a} height="6" rx="3" fill=${t}></rect>` : null}
-        ${s ? Y`<circle cx=${f} cy="12" r="4.5" fill=${t}></circle>` : null}
-        ${s ? Y`<circle class="marker-ring" cx=${f} cy="12" r="3" stroke=${t}></circle>` : null}
+        ${Q`<rect class="track" x="0" y="10" width="100" height="4" rx="2"></rect>`}
+        ${i && r ? Q`<rect class="band" x=${h} y="9" width=${c} height="6" rx="3" fill=${t}></rect>` : null}
+        ${s ? Q`<circle cx=${f} cy="12" r="4.5" fill=${t}></circle>` : null}
+        ${s ? Q`<circle class="marker-ring" cx=${f} cy="12" r="3" stroke=${t}></circle>` : null}
       </svg>
     `;
   }
 };
 L.styles = [
-  x,
-  _`
+  y,
+  v`
       :host {
         display: block;
         width: 100%;
@@ -635,27 +635,27 @@ L.styles = [
       }
     `
 ];
-Z([
-  h({ type: Number })
+J([
+  l({ type: Number })
 ], L.prototype, "low", 2);
-Z([
-  h({ type: Number })
+J([
+  l({ type: Number })
 ], L.prototype, "high", 2);
-Z([
-  h({ type: Number })
+J([
+  l({ type: Number })
 ], L.prototype, "room", 2);
-Z([
-  h({ type: String })
+J([
+  l({ type: String })
 ], L.prototype, "action", 2);
-L = Z([
-  w("band-gauge")
+L = J([
+  $("band-gauge")
 ], L);
-var xe = Object.defineProperty, Ae = Object.getOwnPropertyDescriptor, P = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? Ae(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+var Ee = Object.defineProperty, Se = Object.getOwnPropertyDescriptor, C = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Se(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && xe(t, i, s), s;
+  return r && s && Ee(t, i, s), s;
 };
-let $ = class extends v {
+let w = class extends b {
   constructor() {
     super(...arguments), this.zoneName = "", this.roomTemp = NaN, this.low = NaN, this.high = NaN, this.action = "unknown", this.overrideActive = !1, this.overrideEnds = null, this.noExpand = !1;
   }
@@ -667,19 +667,19 @@ let $ = class extends v {
   }
   _renderOverridePill() {
     if (!this.overrideActive) return null;
-    const e = Ee(this.overrideEnds);
-    return l`<div class="override-pill">Override${e ? ` · ${e}` : ""}</div>`;
+    const e = Ce(this.overrideEnds);
+    return a`<div class="override-pill">Override${e ? ` · ${e}` : ""}</div>`;
   }
   _renderActionChip() {
-    const e = yt(this.action);
+    const e = wt(this.action);
     if (e === "idle" || e === "unknown") return null;
-    const t = $t(e);
-    return l`<span class="action-chip" style="background:${t}">
-      ${Ft(e)}
+    const t = yt(e);
+    return a`<span class="action-chip" style="background:${t}">
+      ${Vt(e)}
     </span>`;
   }
   render() {
-    return l`
+    return a`
       <div
         class="tile ${this.noExpand ? "no-expand" : ""}"
         role="${this.noExpand ? "group" : "button"}"
@@ -707,9 +707,9 @@ let $ = class extends v {
     `;
   }
 };
-$.styles = [
-  x,
-  _`
+w.styles = [
+  y,
+  v`
       :host {
         display: block;
       }
@@ -783,34 +783,34 @@ $.styles = [
       }
     `
 ];
-P([
-  h({ type: String })
-], $.prototype, "zoneName", 2);
-P([
-  h({ type: Number })
-], $.prototype, "roomTemp", 2);
-P([
-  h({ type: Number })
-], $.prototype, "low", 2);
-P([
-  h({ type: Number })
-], $.prototype, "high", 2);
-P([
-  h({ type: String })
-], $.prototype, "action", 2);
-P([
-  h({ type: Boolean })
-], $.prototype, "overrideActive", 2);
-P([
-  h({ type: String })
-], $.prototype, "overrideEnds", 2);
-P([
-  h({ type: Boolean })
-], $.prototype, "noExpand", 2);
-$ = P([
-  w("comfort-band-tile")
-], $);
-function Ee(e) {
+C([
+  l({ type: String })
+], w.prototype, "zoneName", 2);
+C([
+  l({ type: Number })
+], w.prototype, "roomTemp", 2);
+C([
+  l({ type: Number })
+], w.prototype, "low", 2);
+C([
+  l({ type: Number })
+], w.prototype, "high", 2);
+C([
+  l({ type: String })
+], w.prototype, "action", 2);
+C([
+  l({ type: Boolean })
+], w.prototype, "overrideActive", 2);
+C([
+  l({ type: String })
+], w.prototype, "overrideEnds", 2);
+C([
+  l({ type: Boolean })
+], w.prototype, "noExpand", 2);
+w = C([
+  $("comfort-band-tile")
+], w);
+function Ce(e) {
   if (!e) return "";
   const t = Date.parse(e);
   if (Number.isNaN(t)) return "";
@@ -821,12 +821,12 @@ function Ee(e) {
   const s = Math.floor(r / 60), o = r % 60;
   return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-var Se = Object.defineProperty, Pe = Object.getOwnPropertyDescriptor, C = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? Pe(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+var Pe = Object.defineProperty, Oe = Object.getOwnPropertyDescriptor, P = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Oe(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && Se(t, i, s), s;
+  return r && s && Pe(t, i, s), s;
 };
-let y = class extends v {
+let x = class extends b {
   constructor() {
     super(...arguments), this.min = 16, this.max = 26, this.step = 0.5, this.low = 19, this.high = 22, this.unit = "°", this._dragging = null, this._onThumbPointerDown = (e, t) => {
       e.preventDefault();
@@ -908,7 +908,7 @@ let y = class extends v {
   }
   render() {
     const e = this._pct(this.low), t = this._pct(this.high);
-    return l`
+    return a`
       <div class="track" @pointerdown=${this._onTrackPointerDown}>
         <div class="fill" style="left:${e}%; width:${t - e}%"></div>
         <div
@@ -945,9 +945,9 @@ let y = class extends v {
     `;
   }
 };
-y.styles = [
-  x,
-  _`
+x.styles = [
+  y,
+  v`
       :host {
         display: block;
         padding: 16px 12px;
@@ -1008,71 +1008,71 @@ y.styles = [
       }
     `
 ];
-C([
-  h({ type: Number })
-], y.prototype, "min", 2);
-C([
-  h({ type: Number })
-], y.prototype, "max", 2);
-C([
-  h({ type: Number })
-], y.prototype, "step", 2);
-C([
-  h({ type: Number })
-], y.prototype, "low", 2);
-C([
-  h({ type: Number })
-], y.prototype, "high", 2);
-C([
-  h({ type: String })
-], y.prototype, "unit", 2);
-C([
+P([
+  l({ type: Number })
+], x.prototype, "min", 2);
+P([
+  l({ type: Number })
+], x.prototype, "max", 2);
+P([
+  l({ type: Number })
+], x.prototype, "step", 2);
+P([
+  l({ type: Number })
+], x.prototype, "low", 2);
+P([
+  l({ type: Number })
+], x.prototype, "high", 2);
+P([
+  l({ type: String })
+], x.prototype, "unit", 2);
+P([
   m()
-], y.prototype, "_dragging", 2);
-C([
-  nt(".track")
-], y.prototype, "_track", 2);
-y = C([
-  w("dual-handle-slider")
-], y);
-const at = "comfort_band";
-function Ce(e, t) {
+], x.prototype, "_dragging", 2);
+P([
+  at(".track")
+], x.prototype, "_track", 2);
+x = P([
+  $("dual-handle-slider")
+], x);
+const ct = "comfort_band";
+function Te(e, t) {
   return e.callWS({
     type: "comfort_band/get_schedule",
     ...t
   });
 }
-function Te(e, t) {
-  return e.callService(at, "set_schedule", { ...t });
-}
 function Ne(e, t) {
-  const i = { zone: t.zone };
-  return t.low !== void 0 && (i.low = t.low), t.high !== void 0 && (i.high = t.high), t.hours !== void 0 && (i.hours = t.hours), e.callService(at, "start_override", i);
-}
-function Oe(e, t) {
-  return e.callService(at, "cancel_override", { ...t });
+  return e.callService(ct, "set_schedule", { ...t });
 }
 function ze(e, t) {
-  return e.callService(at, "set_profile", { ...t });
+  const i = { zone: t.zone };
+  return t.low !== void 0 && (i.low = t.low), t.high !== void 0 && (i.high = t.high), t.hours !== void 0 && (i.hours = t.hours), e.callService(ct, "start_override", i);
 }
-var ke = Object.defineProperty, De = Object.getOwnPropertyDescriptor, F = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? De(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+function ke(e, t) {
+  return e.callService(ct, "cancel_override", { ...t });
+}
+function De(e, t) {
+  return e.callService(ct, "set_profile", { ...t });
+}
+var Me = Object.defineProperty, He = Object.getOwnPropertyDescriptor, F = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? He(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && ke(t, i, s), s;
+  return r && s && Me(t, i, s), s;
 };
-const Me = [1, 3, 6];
-let O = class extends v {
+const Le = [1, 3, 6];
+let N = class extends b {
   constructor() {
     super(...arguments), this.zone = "", this._pendingLow = null, this._pendingHigh = null, this._onSliderInput = (e) => {
       this._pendingLow = e.detail.low, this._pendingHigh = e.detail.high;
     }, this._onSliderChange = (e) => {
-      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, Ne(this.hass, {
+      !this.hass || !this.zone || (this._pendingLow = null, this._pendingHigh = null, ze(this.hass, {
         zone: this.zone,
         low: e.detail.low,
         high: e.detail.high
       }));
     }, this._onCancel = () => {
-      !this.hass || !this.zone || Oe(this.hass, { zone: this.zone });
+      !this.hass || !this.zone || ke(this.hass, { zone: this.zone });
     }, this._onPickHours = (e) => {
       !this.hass || !this.entities?.overrideHours || this.hass.callService("number", "set_value", {
         entity_id: this.entities.overrideHours,
@@ -1092,12 +1092,12 @@ let O = class extends v {
   }
   render() {
     if (!this.hass || !this.entities) return p;
-    const e = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), i = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", c = this._stateOf(this.entities.overrideActive)?.state === "on", a = this._pendingLow ?? (Number.isFinite(e) ? e : 19), f = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), u = yt(n), d = u !== "idle" && u !== "unknown";
-    return l`
+    const e = this._numericState(this.entities.manualLow), t = this._numericState(this.entities.manualHigh), i = this._numericState(this.entities.effectiveLow), r = this._numericState(this.entities.effectiveHigh), s = this._numericState(this.entities.roomTemperature), o = this._numericState(this.entities.overrideHours), n = this._stateOf(this.entities.currentAction)?.state ?? "unknown", h = this._stateOf(this.entities.overrideActive)?.state === "on", c = this._pendingLow ?? (Number.isFinite(e) ? e : 19), f = this._pendingHigh ?? (Number.isFinite(t) ? t : 22), u = wt(n), d = u !== "idle" && u !== "unknown";
+    return a`
       <div class="header-row">
         <div class="room-temp">${Number.isFinite(s) ? `${s.toFixed(1)}°` : "—"}</div>
-        ${d ? l`<span class="action-chip" style="background:${$t(u)}"
-              >${Ft(u)}</span
+        ${d ? a`<span class="action-chip" style="background:${yt(u)}"
+              >${Vt(u)}</span
             >` : p}
       </div>
       <div class="gauge-row">
@@ -1110,20 +1110,20 @@ let O = class extends v {
           .min=${16}
           .max=${26}
           .step=${0.5}
-          .low=${a}
+          .low=${c}
           .high=${f}
           @input=${this._onSliderInput}
           @change=${this._onSliderChange}
         ></dual-handle-slider>
       </section>
 
-      ${this._renderOverrideSection(c)} ${this._renderHoursSection(o)}
+      ${this._renderOverrideSection(h)} ${this._renderHoursSection(o)}
     `;
   }
   _renderOverrideSection(e) {
     if (!e) return p;
-    const t = this._stateOf(this.entities.overrideEnds)?.state, i = He(t ?? null);
-    return l`
+    const t = this._stateOf(this.entities.overrideEnds)?.state, i = Ue(t ?? null);
+    return a`
       <section>
         <h3>Override</h3>
         <div class="override-row">
@@ -1134,12 +1134,12 @@ let O = class extends v {
     `;
   }
   _renderHoursSection(e) {
-    return this.entities?.overrideHours ? l`
+    return this.entities?.overrideHours ? a`
       <section>
         <h3>Override duration</h3>
         <div class="preset-row">
-          ${Me.map(
-      (t) => l`
+          ${Le.map(
+      (t) => a`
               <button
                 class="preset ${e === t ? "active" : ""}"
                 @click=${() => this._onPickHours(t)}
@@ -1153,9 +1153,9 @@ let O = class extends v {
     ` : p;
   }
 };
-O.styles = [
-  x,
-  _`
+N.styles = [
+  y,
+  v`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1242,24 +1242,24 @@ O.styles = [
     `
 ];
 F([
-  h({ attribute: !1 })
-], O.prototype, "hass", 2);
+  l({ attribute: !1 })
+], N.prototype, "hass", 2);
 F([
-  h({ type: String })
-], O.prototype, "zone", 2);
+  l({ type: String })
+], N.prototype, "zone", 2);
 F([
-  h({ attribute: !1 })
-], O.prototype, "entities", 2);
-F([
-  m()
-], O.prototype, "_pendingLow", 2);
+  l({ attribute: !1 })
+], N.prototype, "entities", 2);
 F([
   m()
-], O.prototype, "_pendingHigh", 2);
-O = F([
-  w("comfort-band-now-tab")
-], O);
-function He(e) {
+], N.prototype, "_pendingLow", 2);
+F([
+  m()
+], N.prototype, "_pendingHigh", 2);
+N = F([
+  $("comfort-band-now-tab")
+], N);
+function Ue(e) {
   if (!e) return "";
   const t = Date.parse(e);
   if (Number.isNaN(t)) return "";
@@ -1270,7 +1270,7 @@ function He(e) {
   const s = Math.floor(r / 60), o = r % 60;
   return o ? `${s}h ${o}m left` : `${s}h left`;
 }
-const wt = "comfort_band", Le = {
+const xt = "comfort_band", je = {
   effective_low: "effectiveLow",
   effective_high: "effectiveHigh",
   room_temperature: "roomTemperature",
@@ -1286,7 +1286,7 @@ const wt = "comfort_band", Le = {
   cancel_override: "cancelOverride",
   enabled: "enabled"
 };
-function Ue() {
+function Re() {
   return {
     effectiveLow: null,
     effectiveHigh: null,
@@ -1306,57 +1306,57 @@ function Ue() {
     deviceName: null
   };
 }
-function Vt(e, t) {
+function Kt(e, t) {
   for (const i of Object.values(e.devices))
     for (const [r, s] of i.identifiers)
       if (r === t[0] && s === t[1])
         return i;
   return null;
 }
-function Kt(e, t) {
+function Zt(e, t) {
   return Object.values(e.entities).filter(
-    (i) => i.device_id === t && i.platform === wt
+    (i) => i.device_id === t && i.platform === xt
   );
 }
-function Re(e, t) {
-  const i = Ue(), r = Vt(e, [wt, `zone:${t}`]);
+function Be(e, t) {
+  const i = Re(), r = Kt(e, [xt, `zone:${t}`]);
   if (r === null) return i;
   i.deviceId = r.id, i.deviceName = r.name_by_user ?? r.name;
   const s = `${t}_`;
-  for (const o of Kt(e, r.id)) {
+  for (const o of Zt(e, r.id)) {
     if (!o.unique_id.startsWith(s)) continue;
-    const n = o.unique_id.slice(s.length), c = Le[n];
-    c !== void 0 && (i[c] = o.entity_id);
+    const n = o.unique_id.slice(s.length), h = je[n];
+    h !== void 0 && (i[h] = o.entity_id);
   }
   return i;
 }
-function Wt(e) {
-  const t = Vt(e, [wt, "profile_manager"]);
+function Xt(e) {
+  const t = Kt(e, [xt, "profile_manager"]);
   if (t === null) return null;
-  for (const i of Kt(e, t.id))
+  for (const i of Zt(e, t.id))
     if (i.unique_id === "profile_manager_active_profile")
       return i.entity_id;
   return null;
 }
-var je = Object.defineProperty, Be = Object.getOwnPropertyDescriptor, Xt = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? Be(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+var Ie = Object.defineProperty, Fe = Object.getOwnPropertyDescriptor, Gt = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Fe(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && je(t, i, s), s;
+  return r && s && Ie(t, i, s), s;
 };
-let it = class extends v {
+let rt = class extends b {
   _onSelect(e) {
-    this.hass && ze(this.hass, { profile: e });
+    this.hass && De(this.hass, { profile: e });
   }
   render() {
     if (!this.hass) return p;
-    const e = Wt(this.hass);
+    const e = Xt(this.hass);
     if (e === null)
-      return l`<div class="empty">Profile manager not registered yet.</div>`;
+      return a`<div class="empty">Profile manager not registered yet.</div>`;
     const t = this.hass.states[e], i = t?.attributes.options, r = Array.isArray(i) ? i.filter((o) => typeof o == "string") : [], s = t?.state ?? "";
-    return r.length === 0 ? l`<div class="empty">No profiles configured.</div>` : l`
+    return r.length === 0 ? a`<div class="empty">No profiles configured.</div>` : a`
       <ul role="listbox" aria-label="Profiles">
         ${r.map(
-      (o) => l`
+      (o) => a`
             <li
               role="option"
               tabindex="0"
@@ -1368,7 +1368,7 @@ let it = class extends v {
       }}
             >
               <span class="name">${o}</span>
-              ${o === s ? l`<span class="badge">Active</span>` : p}
+              ${o === s ? a`<span class="badge">Active</span>` : p}
             </li>
           `
     )}
@@ -1377,9 +1377,9 @@ let it = class extends v {
     `;
   }
 };
-it.styles = [
-  x,
-  _`
+rt.styles = [
+  y,
+  v`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1435,18 +1435,18 @@ it.styles = [
       }
     `
 ];
-Xt([
-  h({ attribute: !1 })
-], it.prototype, "hass", 2);
-it = Xt([
-  w("comfort-band-profiles-tab")
-], it);
-var Ie = Object.defineProperty, Fe = Object.getOwnPropertyDescriptor, lt = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? Fe(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+Gt([
+  l({ attribute: !1 })
+], rt.prototype, "hass", 2);
+rt = Gt([
+  $("comfort-band-profiles-tab")
+], rt);
+var qe = Object.defineProperty, Ve = Object.getOwnPropertyDescriptor, lt = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Ve(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && Ie(t, i, s), s;
+  return r && s && qe(t, i, s), s;
 };
-let B = class extends v {
+let B = class extends b {
   constructor() {
     super(...arguments), this._graphAvailable = null, this._graphCard = null;
   }
@@ -1483,20 +1483,20 @@ let B = class extends v {
   }
   render() {
     const e = this.entities?.roomTemperature;
-    return e ? l`
+    return e ? a`
       <div class="graph-container"></div>
-      ${this._graphAvailable === !1 ? l`<div class="fallback">
+      ${this._graphAvailable === !1 ? a`<div class="fallback">
             Inline graph unavailable.
             <a href="/history?entity_id=${e}" target="_blank" rel="noopener"
               >Open in HA history →</a
             >
           </div>` : p}
-    ` : l`<div class="empty">No room temperature sensor for this zone.</div>`;
+    ` : a`<div class="empty">No room temperature sensor for this zone.</div>`;
   }
 };
 B.styles = [
-  x,
-  _`
+  y,
+  v`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1522,38 +1522,38 @@ B.styles = [
     `
 ];
 lt([
-  h({ attribute: !1 })
+  l({ attribute: !1 })
 ], B.prototype, "hass", 2);
 lt([
-  h({ attribute: !1 })
+  l({ attribute: !1 })
 ], B.prototype, "entities", 2);
 lt([
   m()
 ], B.prototype, "_graphAvailable", 2);
 B = lt([
-  w("comfort-band-insights-tab")
+  $("comfort-band-insights-tab")
 ], B);
-var qe = Object.defineProperty, Ve = Object.getOwnPropertyDescriptor, Gt = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? Ve(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+var We = Object.defineProperty, Ke = Object.getOwnPropertyDescriptor, Jt = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? Ke(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && qe(t, i, s), s;
+  return r && s && We(t, i, s), s;
 };
-const Ke = 500, We = 1.5, Xe = 15, Dt = [0, 6, 12, 18, 24];
-function Mt(e) {
+const Ze = 500, Xe = 1.5, Ge = 15, Ht = [0, 6, 12, 18, 24];
+function Lt(e) {
   const t = /^(\d{1,2}):(\d{2})$/.exec(e);
   return t ? parseInt(t[1], 10) * 60 + parseInt(t[2], 10) : 0;
 }
-function Ge(e) {
+function Je(e) {
   const t = Math.max(0, Math.min(1439, e)), i = Math.floor(t / 60), r = t % 60;
   return `${i.toString().padStart(2, "0")}:${r.toString().padStart(2, "0")}`;
 }
-function pt(e) {
+function ut(e) {
   return e / (24 * 60) * 100;
 }
-function Ze(e, t) {
+function Ye(e, t) {
   return Math.round(e / t) * t;
 }
-let rt = class extends v {
+let st = class extends b {
   constructor() {
     super(...arguments), this.transitions = [], this._longPressTimer = null, this._onTrackTap = (e) => {
       if (e.target.classList.contains("point")) return;
@@ -1561,12 +1561,12 @@ let rt = class extends v {
       if (!t) return;
       const i = t.getBoundingClientRect(), r = this._xToMinutes(e.clientX, i);
       for (const s of this.transitions) {
-        const o = Mt(s.at);
-        if (Math.abs(pt(o) - pt(r)) < We) return;
+        const o = Lt(s.at);
+        if (Math.abs(ut(o) - ut(r)) < Xe) return;
       }
       this.dispatchEvent(
         new CustomEvent("transition-add", {
-          detail: { at: Ge(r) },
+          detail: { at: Je(r) },
           bubbles: !0,
           composed: !0
         })
@@ -1591,7 +1591,7 @@ let rt = class extends v {
             composed: !0
           })
         );
-      }, Ke);
+      }, Ze);
       const s = () => {
         i.removeEventListener("pointerup", s), i.removeEventListener("pointercancel", s), i.removeEventListener("pointerleave", s), this._longPressTimer !== null && (window.clearTimeout(this._longPressTimer), this._longPressTimer = null, r || this._onPointTap(t));
       };
@@ -1609,19 +1609,19 @@ let rt = class extends v {
   _xToMinutes(e, t) {
     if (t.width === 0) return 0;
     const i = Math.max(0, Math.min(1, (e - t.left) / t.width));
-    return Ze(i * 24 * 60, Xe);
+    return Ye(i * 24 * 60, Ge);
   }
   render() {
-    return l`
+    return a`
       <div class="ruler">
         <div class="track" @click=${this._onTrackTap}></div>
-        ${Dt.map((e, t) => {
-      const i = t === 0 ? "hour-tick start" : t === Dt.length - 1 ? "hour-tick terminal" : "hour-tick";
-      return l`<div class=${i} style="left:${e / 24 * 100}%">${e}h</div>`;
+        ${Ht.map((e, t) => {
+      const i = t === 0 ? "hour-tick start" : t === Ht.length - 1 ? "hour-tick terminal" : "hour-tick";
+      return a`<div class=${i} style="left:${e / 24 * 100}%">${e}h</div>`;
     })}
         ${this.transitions.map((e) => {
-      const t = Mt(e.at), i = pt(t), r = `Transition at ${e.at}, low ${e.low.toFixed(1)} degrees, high ${e.high.toFixed(1)} degrees. Tap to edit, long-press or Delete to remove.`;
-      return l`
+      const t = Lt(e.at), i = ut(t), r = `Transition at ${e.at}, low ${e.low.toFixed(1)} degrees, high ${e.high.toFixed(1)} degrees. Tap to edit, long-press or Delete to remove.`;
+      return a`
             <button
               class="point"
               role="button"
@@ -1638,13 +1638,13 @@ let rt = class extends v {
           `;
     })}
       </div>
-      ${this.transitions.length === 0 ? l`<div class="empty-hint">Tap the timeline to add a transition.</div>` : null}
+      ${this.transitions.length === 0 ? a`<div class="empty-hint">Tap the timeline to add a transition.</div>` : null}
     `;
   }
 };
-rt.styles = [
-  x,
-  _`
+st.styles = [
+  y,
+  v`
       :host {
         display: block;
       }
@@ -1712,18 +1712,18 @@ rt.styles = [
       }
     `
 ];
-Gt([
-  h({ type: Array })
-], rt.prototype, "transitions", 2);
-rt = Gt([
-  w("timeline-editor")
-], rt);
-var Je = Object.defineProperty, Ye = Object.getOwnPropertyDescriptor, z = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? Ye(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+Jt([
+  l({ type: Array })
+], st.prototype, "transitions", 2);
+st = Jt([
+  $("timeline-editor")
+], st);
+var Qe = Object.defineProperty, ti = Object.getOwnPropertyDescriptor, z = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? ti(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && Je(t, i, s), s;
+  return r && s && Qe(t, i, s), s;
 };
-let A = class extends v {
+let A = class extends b {
   constructor() {
     super(...arguments), this.transition = null, this.isNew = !1, this._at = "06:00", this._low = 19, this._high = 22, this._error = null, this._onSave = () => {
       this._validate() && this.dispatchEvent(
@@ -1755,7 +1755,7 @@ let A = class extends v {
     return /^([01]\d|2[0-3]):[0-5]\d$/.test(this._at) ? Number.isNaN(this._low) || Number.isNaN(this._high) ? (this._error = "Low and high must be numbers.", !1) : this._low >= this._high ? (this._error = "Low must be less than high.", !1) : this._low < 10 || this._high > 35 ? (this._error = "Temperatures must be between 10 °C and 35 °C.", !1) : (this._error = null, !0) : (this._error = "Time must be HH:MM (24h, e.g. 06:00).", !1);
   }
   render() {
-    return l`
+    return a`
       <h3>${this.isNew ? "Add transition" : "Edit transition"}</h3>
       <label>
         Time (HH:MM)
@@ -1791,9 +1791,9 @@ let A = class extends v {
           @input=${(e) => this._high = parseFloat(e.target.value)}
         />
       </label>
-      ${this._error ? l`<div class="error">${this._error}</div>` : null}
+      ${this._error ? a`<div class="error">${this._error}</div>` : null}
       <div class="actions">
-        ${this.isNew ? null : l`<button class="button danger" @click=${this._onDelete}>Delete</button>`}
+        ${this.isNew ? null : a`<button class="button danger" @click=${this._onDelete}>Delete</button>`}
         <div class="spacer"></div>
         <button class="button secondary" @click=${this._onCancel}>Cancel</button>
         <button class="button primary" @click=${this._onSave}>Save</button>
@@ -1802,8 +1802,8 @@ let A = class extends v {
   }
 };
 A.styles = [
-  x,
-  _`
+  y,
+  v`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -1874,10 +1874,10 @@ A.styles = [
     `
 ];
 z([
-  h({ type: Object })
+  l({ type: Object })
 ], A.prototype, "transition", 2);
 z([
-  h({ type: Boolean })
+  l({ type: Boolean })
 ], A.prototype, "isNew", 2);
 z([
   m()
@@ -1892,17 +1892,17 @@ z([
   m()
 ], A.prototype, "_error", 2);
 z([
-  nt('input[name="at"]')
+  at('input[name="at"]')
 ], A.prototype, "_atInput", 2);
 A = z([
-  w("transition-edit-dialog")
+  $("transition-edit-dialog")
 ], A);
-var Qe = Object.defineProperty, ti = Object.getOwnPropertyDescriptor, S = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? ti(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+var ei = Object.defineProperty, ii = Object.getOwnPropertyDescriptor, S = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? ii(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && Qe(t, i, s), s;
+  return r && s && ei(t, i, s), s;
 };
-let g = class extends v {
+let _ = class extends b {
   constructor() {
     super(...arguments), this.zone = "", this._profile = "", this._transitions = [], this._loading = !0, this._error = null, this._mode = "list", this._editing = null, this._newAt = "06:00", this._onAdd = (e) => {
       this._newAt = e.detail.at, this._editing = null, this._mode = "add";
@@ -1933,11 +1933,11 @@ let g = class extends v {
     };
   }
   willUpdate(e) {
-    e.has("hass") && this.hass && this._profile === "" && (this._profile = Ht(this.hass) ?? "home", this._refresh());
+    e.has("hass") && this.hass && this._profile === "" && (this._profile = Ut(this.hass) ?? "home", this._refresh());
   }
   updated(e) {
     if (e.has("hass") && this.hass) {
-      const t = Ht(this.hass);
+      const t = Ut(this.hass);
       t && t !== this._profile && (this._profile = t, this._refresh());
     }
   }
@@ -1945,7 +1945,7 @@ let g = class extends v {
     if (!(!this.hass || !this.zone || !this._profile)) {
       this._loading = !0, this._error = null;
       try {
-        const e = await Ce(this.hass, {
+        const e = await Te(this.hass, {
           zone: this.zone,
           profile: this._profile
         });
@@ -1960,7 +1960,7 @@ let g = class extends v {
   async _writeSchedule(e) {
     if (this.hass)
       try {
-        await Te(this.hass, {
+        await Ne(this.hass, {
           zone: this.zone,
           profile: this._profile,
           transitions: e
@@ -1974,10 +1974,10 @@ let g = class extends v {
     if (this._mode === "add" || this._mode === "edit") {
       const e = this._mode === "edit" ? this._editing : {
         at: this._newAt,
-        low: ei(this._transitions),
-        high: ii(this._transitions)
+        low: ri(this._transitions),
+        high: si(this._transitions)
       };
-      return l`
+      return a`
         <transition-edit-dialog
           .transition=${e}
           .isNew=${this._mode === "add"}
@@ -1987,12 +1987,12 @@ let g = class extends v {
         ></transition-edit-dialog>
       `;
     }
-    return l`
+    return a`
       <div class="header">
         <span class="profile-label">Active profile</span>
         <span class="profile-value">${this._profile || "—"}</span>
       </div>
-      ${this._loading ? l`<div class="loading">Loading schedule…</div>` : this._error ? l`<div class="error">${this._error}</div>` : l`
+      ${this._loading ? a`<div class="loading">Loading schedule…</div>` : this._error ? a`<div class="error">${this._error}</div>` : a`
               <timeline-editor
                 .transitions=${this._transitions}
                 @transition-add=${this._onAdd}
@@ -2004,10 +2004,10 @@ let g = class extends v {
     `;
   }
   _renderList() {
-    return this._transitions.length === 0 ? p : l`
+    return this._transitions.length === 0 ? p : a`
       <ul class="list">
         ${this._transitions.map(
-      (e) => l`
+      (e) => a`
             <li
               @click=${() => this._onEdit(new CustomEvent("transition-edit", { detail: { transition: e } }))}
             >
@@ -2020,9 +2020,9 @@ let g = class extends v {
     `;
   }
 };
-g.styles = [
-  x,
-  _`
+_.styles = [
+  y,
+  v`
       :host {
         display: block;
         padding: var(--cb-gap-md);
@@ -2081,57 +2081,57 @@ g.styles = [
     `
 ];
 S([
-  h({ attribute: !1 })
-], g.prototype, "hass", 2);
+  l({ attribute: !1 })
+], _.prototype, "hass", 2);
 S([
-  h({ type: String })
-], g.prototype, "zone", 2);
-S([
-  m()
-], g.prototype, "_profile", 2);
+  l({ type: String })
+], _.prototype, "zone", 2);
 S([
   m()
-], g.prototype, "_transitions", 2);
+], _.prototype, "_profile", 2);
 S([
   m()
-], g.prototype, "_loading", 2);
+], _.prototype, "_transitions", 2);
 S([
   m()
-], g.prototype, "_error", 2);
+], _.prototype, "_loading", 2);
 S([
   m()
-], g.prototype, "_mode", 2);
+], _.prototype, "_error", 2);
 S([
   m()
-], g.prototype, "_editing", 2);
+], _.prototype, "_mode", 2);
 S([
   m()
-], g.prototype, "_newAt", 2);
-g = S([
-  w("comfort-band-schedule-tab")
-], g);
-function Ht(e) {
-  const t = Wt(e);
+], _.prototype, "_editing", 2);
+S([
+  m()
+], _.prototype, "_newAt", 2);
+_ = S([
+  $("comfort-band-schedule-tab")
+], _);
+function Ut(e) {
+  const t = Xt(e);
   return t ? e.states[t]?.state ?? null : null;
 }
-function ei(e) {
+function ri(e) {
   return e.length === 0 ? 19 : e[e.length - 1].low;
 }
-function ii(e) {
+function si(e) {
   return e.length === 0 ? 22 : e[e.length - 1].high;
 }
-var ri = Object.defineProperty, si = Object.getOwnPropertyDescriptor, k = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? si(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+var oi = Object.defineProperty, ni = Object.getOwnPropertyDescriptor, k = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? ni(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && ri(t, i, s), s;
+  return r && s && oi(t, i, s), s;
 };
-const oi = [
+const ai = [
   { id: "now", label: "Now" },
   { id: "schedule", label: "Schedule" },
   { id: "profiles", label: "Profiles" },
   { id: "insights", label: "Insights" }
 ];
-let E = class extends v {
+let E = class extends b {
   constructor() {
     super(...arguments), this.zone = "", this.zoneName = "", this._activeTab = "now", this._isOpen = !1, this._onClose = () => {
       this._isOpen = !1, this.dispatchEvent(
@@ -2153,7 +2153,7 @@ let E = class extends v {
   render() {
     if (!this._isOpen) return p;
     const e = this.zoneName || this.zone || "Comfort Band";
-    return l`
+    return a`
       <dialog @close=${this._onClose}>
         <div class="frame">
           <header>
@@ -2161,8 +2161,8 @@ let E = class extends v {
             <button class="close" @click=${this.close} aria-label="Close">×</button>
           </header>
           <nav role="tablist">
-            ${oi.map(
-      (t) => l`
+            ${ai.map(
+      (t) => a`
                 <button
                   role="tab"
                   aria-selected=${this._activeTab === t.id}
@@ -2181,20 +2181,20 @@ let E = class extends v {
   _renderTab() {
     switch (this._activeTab) {
       case "now":
-        return l`<comfort-band-now-tab
+        return a`<comfort-band-now-tab
           .hass=${this.hass}
           .zone=${this.zone}
           .entities=${this.entities}
         ></comfort-band-now-tab>`;
       case "schedule":
-        return l`<comfort-band-schedule-tab
+        return a`<comfort-band-schedule-tab
           .hass=${this.hass}
           .zone=${this.zone}
         ></comfort-band-schedule-tab>`;
       case "profiles":
-        return l`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
+        return a`<comfort-band-profiles-tab .hass=${this.hass}></comfort-band-profiles-tab>`;
       case "insights":
-        return l`<comfort-band-insights-tab
+        return a`<comfort-band-insights-tab
           .hass=${this.hass}
           .entities=${this.entities}
         ></comfort-band-insights-tab>`;
@@ -2202,8 +2202,8 @@ let E = class extends v {
   }
 };
 E.styles = [
-  x,
-  _`
+  y,
+  v`
       :host {
         --cb-modal-max-width: 480px;
       }
@@ -2283,16 +2283,16 @@ E.styles = [
     `
 ];
 k([
-  h({ attribute: !1 })
+  l({ attribute: !1 })
 ], E.prototype, "hass", 2);
 k([
-  h({ type: String })
+  l({ type: String })
 ], E.prototype, "zone", 2);
 k([
-  h({ type: String })
+  l({ type: String })
 ], E.prototype, "zoneName", 2);
 k([
-  h({ attribute: !1 })
+  l({ attribute: !1 })
 ], E.prototype, "entities", 2);
 k([
   m()
@@ -2301,17 +2301,133 @@ k([
   m()
 ], E.prototype, "_isOpen", 2);
 k([
-  nt("dialog")
+  at("dialog")
 ], E.prototype, "_dialog", 2);
 E = k([
-  w("comfort-band-modal")
+  $("comfort-band-modal")
 ], E);
-var ni = Object.defineProperty, ai = Object.getOwnPropertyDescriptor, ct = (e, t, i, r) => {
-  for (var s = r > 1 ? void 0 : r ? ai(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+var ci = Object.defineProperty, li = Object.getOwnPropertyDescriptor, At = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? li(t, i) : t, o = e.length - 1, n; o >= 0; o--)
     (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
-  return r && s && ni(t, i, s), s;
+  return r && s && ci(t, i, s), s;
 };
-let I = class extends v {
+let X = class extends b {
+  constructor() {
+    super(...arguments), this.config = {
+      type: "custom:comfort-band-card",
+      zone: ""
+    }, this._onZoneChange = (e) => {
+      const t = e.target.value;
+      this._fireConfig({ ...this.config, zone: t });
+    }, this._onCompactChange = (e) => {
+      const t = e.target.checked, i = { ...this.config };
+      t ? i.compact = !0 : delete i.compact, this._fireConfig(i);
+    };
+  }
+  setConfig(e) {
+    this.config = {
+      type: e.type ?? "custom:comfort-band-card",
+      zone: e.zone ?? "",
+      ...e.compact !== void 0 ? { compact: e.compact } : {}
+    };
+  }
+  _availableZones() {
+    if (!this.hass) return [];
+    const e = [];
+    for (const t of Object.values(this.hass.devices))
+      for (const [i, r] of t.identifiers)
+        i === "comfort_band" && r.startsWith("zone:") && e.push(r.slice(5));
+    return e.sort();
+  }
+  _fireConfig(e) {
+    this.config = e, this.dispatchEvent(
+      new CustomEvent("config-changed", {
+        detail: { config: e },
+        bubbles: !0,
+        composed: !0
+      })
+    );
+  }
+  render() {
+    const e = this._availableZones();
+    return e.length === 0 ? a`<div class="empty">
+        No Comfort Band zones found. Add one via Settings → Devices & Services first.
+      </div>` : a`
+      <label>
+        Zone
+        <select @change=${this._onZoneChange} .value=${this.config.zone || ""}>
+          ${this.config.zone === "" ? a`<option value="" disabled selected>Select a zone…</option>` : null}
+          ${e.map(
+      (t) => a` <option value=${t} ?selected=${t === this.config.zone}>${t}</option> `
+    )}
+        </select>
+      </label>
+      <label class="checkbox-row">
+        <input
+          type="checkbox"
+          .checked=${this.config.compact === !0}
+          @change=${this._onCompactChange}
+        />
+        Compact mode (tile only, no expand on tap)
+      </label>
+    `;
+  }
+};
+X.styles = [
+  y,
+  v`
+      :host {
+        display: block;
+        padding: var(--cb-gap-md);
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: var(--cb-gap-md);
+        font-size: 12px;
+        color: var(--cb-text-secondary);
+      }
+      select,
+      input[type='checkbox'] {
+        font: inherit;
+      }
+      select {
+        font-size: 14px;
+        padding: 8px;
+        border: 1px solid var(--divider-color, #cccccc);
+        border-radius: 6px;
+        color: var(--cb-text-primary);
+        background: var(--ha-card-background, #ffffff);
+      }
+      .checkbox-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 14px;
+        color: var(--cb-text-primary);
+      }
+      .empty {
+        color: var(--cb-text-secondary);
+        font-size: 13px;
+      }
+    `
+];
+At([
+  l({ attribute: !1 })
+], X.prototype, "hass", 2);
+At([
+  l({ attribute: !1 })
+], X.prototype, "config", 2);
+X = At([
+  $("comfort-band-card-editor")
+], X);
+var hi = Object.defineProperty, di = Object.getOwnPropertyDescriptor, ht = (e, t, i, r) => {
+  for (var s = r > 1 ? void 0 : r ? di(t, i) : t, o = e.length - 1, n; o >= 0; o--)
+    (n = e[o]) && (s = (r ? n(t, i, s) : n(s)) || s);
+  return r && s && hi(t, i, s), s;
+};
+let I = class extends b {
   constructor() {
     super(...arguments), this._onTileTap = () => {
       this._modal?.open();
@@ -2326,16 +2442,37 @@ let I = class extends v {
   getCardSize() {
     return 2;
   }
+  /** HA dashboard editor: tells HA which custom element to render as the
+   *  visual config UI. Returning the element directly (not a string) is
+   *  the modern API. */
+  static getConfigElement() {
+    return document.createElement("comfort-band-card-editor");
+  }
+  /** Default config seed when the user adds the card via "Add card" in the
+   *  dashboard editor. Picks the first registered Comfort Band zone, if any. */
+  static getStubConfig(e) {
+    let t = "";
+    if (e)
+      for (const i of Object.values(e.devices)) {
+        for (const [r, s] of i.identifiers)
+          if (r === "comfort_band" && s.startsWith("zone:")) {
+            t = s.slice(5);
+            break;
+          }
+        if (t) break;
+      }
+    return { type: "custom:comfort-band-card", zone: t };
+  }
   render() {
-    if (!this._config || !this.hass) return l``;
-    const e = this._config.zone, t = Re(this.hass, e);
+    if (!this._config || !this.hass) return a``;
+    const e = this._config.zone, t = Be(this.hass, e);
     if (t.deviceId === null)
-      return l`<div class="placeholder">
+      return a`<div class="placeholder">
         Comfort Band zone <code>${e}</code> not found. Add it via Settings → Devices &
         Services.
       </div>`;
     const i = this._config.compact === !0, r = this._buildView(this.hass, t);
-    return l`
+    return a`
       <comfort-band-tile
         zoneName=${r.zoneName}
         .roomTemp=${r.roomTemp}
@@ -2347,7 +2484,7 @@ let I = class extends v {
         .noExpand=${i}
         @comfort-band-tile-tap=${this._onTileTap}
       ></comfort-band-tile>
-      ${i ? null : l`<comfort-band-modal
+      ${i ? null : a`<comfort-band-modal
             .hass=${this.hass}
             zone=${e}
             zoneName=${r.zoneName}
@@ -2374,8 +2511,8 @@ let I = class extends v {
   }
 };
 I.styles = [
-  x,
-  _`
+  y,
+  v`
       :host {
         display: block;
       }
@@ -2389,17 +2526,17 @@ I.styles = [
       }
     `
 ];
-ct([
-  h({ attribute: !1 })
+ht([
+  l({ attribute: !1 })
 ], I.prototype, "hass", 2);
-ct([
+ht([
   m()
 ], I.prototype, "_config", 2);
-ct([
-  nt("comfort-band-modal")
+ht([
+  at("comfort-band-modal")
 ], I.prototype, "_modal", 2);
-I = ct([
-  w("comfort-band-card")
+I = ht([
+  $("comfort-band-card")
 ], I);
 (window.customCards ??= []).push({
   type: "comfort-band-card",
@@ -2408,7 +2545,7 @@ I = ct([
   preview: !1
 });
 console.info(
-  "%c COMFORT-BAND-CARD %c v0.1.0-dev ",
+  "%c COMFORT-BAND-CARD %c v0.1.0 ",
   "color:white;background:#2196F3;padding:2px 4px;border-radius:3px",
   "color:#000;background:#fff;padding:2px 4px;border-radius:3px"
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,29 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default [
+  { ignores: ['dist/**', 'node_modules/**', 'coverage/**'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['card/**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+        customElements: 'readonly',
+        HTMLElement: 'readonly',
+        console: 'readonly',
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/consistent-type-imports': 'error',
+    },
+  },
+];

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Comfort Band",
   "render_readme": true,
-  "homeassistant": "2024.12.0"
+  "homeassistant": "2024.12.0",
+  "filename": "comfort-band-card.js"
 }

--- a/info.md
+++ b/info.md
@@ -2,4 +2,8 @@
 
 Per-room HVAC band-control for Home Assistant. Heats below a low threshold, cools above a high threshold, idles in between — giving heat pumps and mini-splits margin instead of fighting to hold a single setpoint.
 
-**v0.0.2** ships the full logic core: per-zone entities, asymmetric-deadband hysteresis, profile-driven schedules, and an `import_legacy` service for migrating from hand-rolled YAML. Defaults to **shadow mode** per zone (`switch.{zone}_enabled = off`) so you can verify decisions side-by-side with your existing setup before cutting over. No Lovelace card yet.
+**v0.1.0** is the first end-to-end release: integration + Lovelace card. The integration provides per-zone entities, asymmetric-deadband hysteresis, profile-driven schedules, and an `import_legacy` service for migrating from hand-rolled YAML. The card adds a compact tile + expanded modal with Now / Schedule / Profiles / Insights tabs (drag the dual-handle slider to override; tap the timeline to edit transitions; switch profiles with one tap).
+
+This repo publishes **both** an Integration and a Dashboard plugin from one source. Add the URL twice in HACS as a Custom Repository — once under Integrations, once under Frontend.
+
+Defaults to **shadow mode** per zone (`switch.{zone}_enabled = off`) so you can verify decisions side-by-side with your existing setup before cutting over.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2982 @@
+{
+  "name": "comfort-band-card",
+  "version": "0.1.0-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "comfort-band-card",
+      "version": "0.1.0-dev",
+      "dependencies": {
+        "lit": "^3.2.1"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.14.0",
+        "eslint": "^9.14.0",
+        "happy-dom": "^15.11.0",
+        "prettier": "^3.3.3",
+        "typescript": "^5.6.3",
+        "typescript-eslint": "^8.13.0",
+        "vite": "^5.4.11",
+        "vitest": "^2.1.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/type-utils": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "15.11.7",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
+      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.1",
+        "@typescript-eslint/parser": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,143 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.14.0",
+        "@open-wc/testing-helpers": "^3.0.1",
         "eslint": "^9.14.0",
-        "happy-dom": "^15.11.0",
+        "jsdom": "^25.0.1",
         "prettier": "^3.3.3",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.13.0",
         "vite": "^5.4.11",
         "vitest": "^2.1.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -642,6 +772,36 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-2.0.1.tgz",
+      "integrity": "sha512-+R4VxvceUxHAUJXJQipkkoV9fy10vNo+OnUnGKZnVmcwxMl460KLzytnUM4S35SI073R0yZQp9ra0MbPUwVcEA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-wc/scoped-elements": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-3.0.6.tgz",
+      "integrity": "sha512-w1ayJaUUmBw8tALtqQ6cBueld+op+bufujzbrOdH0uCTXnSQkONYZzOH+9jyQ8auVgKLqcxZ8oU6SzfqQhQkPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^2.0.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@open-wc/testing-helpers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-3.0.1.tgz",
+      "integrity": "sha512-hyNysSatbgT2FNxHJsS3rGKcLEo6+HwDFu1UQL6jcSQUabp/tj3PyX7UnXL3H5YGv0lJArdYLSnvjLnjn3O2fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-wc/scoped-elements": "^3.0.2",
+        "lit": "^2.0.0 || ^3.0.0",
+        "lit-html": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1432,6 +1592,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1482,6 +1652,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1508,6 +1685,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1584,6 +1775,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1606,6 +1810,51 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1624,6 +1873,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1641,17 +1897,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1660,6 +1963,35 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1977,6 +2309,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1990,6 +2339,55 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2018,12 +2416,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/happy-dom": {
       "version": "15.11.7",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
       "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -2041,6 +2454,102 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -2103,6 +2612,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2121,6 +2637,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/json-buffer": {
@@ -2229,6 +2796,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2237,6 +2811,39 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2282,6 +2889,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2346,6 +2960,32 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -2525,6 +3165,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2618,6 +3285,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2677,6 +3351,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2902,6 +3622,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -2912,14 +3645,44 @@
         "node": ">=12"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -2964,6 +3727,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "comfort-band-card",
+  "version": "0.1.0-dev",
+  "private": true,
+  "description": "Lovelace card for the Comfort Band Home Assistant integration",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "test": "vitest run --passWithNoTests",
+    "test:watch": "vitest",
+    "lint": "eslint card",
+    "lint:fix": "eslint card --fix",
+    "format": "prettier --write 'card/**/*.{ts,js,json}' '*.json'",
+    "format:check": "prettier --check 'card/**/*.{ts,js,json}' '*.json'",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "lit": "^3.2.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.14.0",
+    "eslint": "^9.14.0",
+    "happy-dom": "^15.11.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.6.3",
+    "typescript-eslint": "^8.13.0",
+    "vite": "^5.4.11",
+    "vitest": "^2.1.4"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
+    "@open-wc/testing-helpers": "^3.0.1",
     "eslint": "^9.14.0",
-    "happy-dom": "^15.11.0",
+    "jsdom": "^25.0.1",
     "prettier": "^3.3.3",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfort-band-card",
-  "version": "0.1.0-dev",
+  "version": "0.1.0",
   "private": true,
   "description": "Lovelace card for the Comfort Band Home Assistant integration",
   "type": "module",

--- a/scripts/check-banned-words.sh
+++ b/scripts/check-banned-words.sh
@@ -33,8 +33,10 @@ fi
 # Combine patterns into a single ERE alternation.
 COMBINED="$(echo "$PATTERNS" | paste -sd '|' -)"
 
-# Files to scan: everything tracked except this script and the pattern files.
-EXCLUDE_RE='^(scripts/check-banned-words\.sh|\.banned-words(\.local)?)$'
+# Files to scan: everything tracked except this script, the pattern files, and
+# generated lockfiles (`10.0.0` semver versions and registry URLs trigger false
+# positives, and the file is regenerated wholesale by npm/yarn anyway).
+EXCLUDE_RE='^(scripts/check-banned-words\.sh|\.banned-words(\.local)?|package-lock\.json)$'
 FILES="$(git ls-files | grep -vE "$EXCLUDE_RE" || true)"
 
 if [[ -z "$FILES" ]]; then

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -23,7 +23,7 @@ def test_manifest_shape() -> None:
     assert manifest["integration_type"] == "helper"
     assert manifest["iot_class"] == "local_push"
     assert manifest["codeowners"] == ["@dpretty"]
-    assert manifest["version"] == "0.0.2"
+    assert manifest["version"] == "0.1.0"
     assert manifest["documentation"].startswith("https://")
     assert manifest["issue_tracker"].startswith("https://")
     assert manifest["requirements"] == []

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1,0 +1,107 @@
+"""Tests for the `comfort_band/*` websocket commands.
+
+We invoke the handler directly with a fake `ActiveConnection` instead of
+spinning up the full websocket server — that path triggers a teardown
+timing flake in `pytest_homeassistant_custom_component` on macOS, and
+adds nothing testable beyond what the framework already guarantees
+(schema validation + dispatch). The handler itself is plain Python.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.comfort_band.ws import ws_get_schedule
+
+
+class _FakeConnection:
+    """Minimal stand-in for `websocket_api.ActiveConnection`."""
+
+    def __init__(self) -> None:
+        self.results: list[tuple[int, Any]] = []
+        self.errors: list[tuple[int, str, str]] = []
+
+    def send_result(self, msg_id: int, data: Any) -> None:
+        self.results.append((msg_id, data))
+
+    def send_error(self, msg_id: int, code: str, message: str) -> None:
+        self.errors.append((msg_id, code, message))
+
+
+@pytest.fixture
+async def setup_zone(
+    hass: HomeAssistant, hass_storage: dict[str, Any], make_zone_entry: Any
+) -> None:
+    entry = make_zone_entry(temp_sensor="sensor.office_temp")
+    entry.add_to_hass(hass)
+    hass.states.async_set("sensor.office_temp", "21.0", {})
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_get_schedule_returns_null_for_unset_profile(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """Newly created zones have no schedules — read returns None (=> null)."""
+    conn = _FakeConnection()
+    ws_get_schedule(
+        hass,
+        conn,  # type: ignore[arg-type]
+        {"id": 1, "type": "comfort_band/get_schedule", "zone": "office", "profile": "home"},
+    )
+    assert conn.errors == []
+    assert conn.results == [(1, None)]
+
+
+async def test_get_schedule_returns_baseline_and_current_after_set(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """After comfort_band.set_schedule, the WS read sees the persisted data."""
+    transitions = [
+        {"at": "06:00", "low": 20.0, "high": 23.0},
+        {"at": "22:00", "low": 18.0, "high": 21.0},
+    ]
+    await hass.services.async_call(
+        "comfort_band",
+        "set_schedule",
+        {"zone": "office", "profile": "home", "transitions": transitions},
+        blocking=True,
+    )
+
+    conn = _FakeConnection()
+    ws_get_schedule(
+        hass,
+        conn,  # type: ignore[arg-type]
+        {"id": 7, "type": "comfort_band/get_schedule", "zone": "office", "profile": "home"},
+    )
+    assert conn.errors == []
+    msg_id, schedule = conn.results[0]
+    assert msg_id == 7
+    assert schedule is not None
+    assert schedule["baseline"] == transitions
+    assert schedule["current"] == transitions
+
+
+async def test_get_schedule_errors_for_unknown_zone(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """An unknown zone surfaces a typed error rather than a result."""
+    conn = _FakeConnection()
+    ws_get_schedule(
+        hass,
+        conn,  # type: ignore[arg-type]
+        {"id": 3, "type": "comfort_band/get_schedule", "zone": "ghost", "profile": "home"},
+    )
+    assert conn.results == []
+    assert conn.errors == [(3, "zone_not_found", "Zone 'ghost' does not exist")]
+
+
+async def test_command_is_registered_at_setup(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """Sanity: async_register_ws_commands() runs and the command is wired."""
+    handlers = hass.data.get("websocket_api", {})
+    assert "comfort_band/get_schedule" in handlers

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "types": ["vitest/globals", "vite/client"]
+  },
+  "include": ["card/src/**/*.ts", "card/test/**/*.ts", "vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  build: {
+    target: 'es2022',
+    lib: {
+      entry: 'card/src/index.ts',
+      formats: ['es'],
+      fileName: () => 'comfort-band-card.js',
+    },
+    outDir: 'dist',
+    emptyOutDir: true,
+    minify: 'esbuild',
+    sourcemap: false,
+    rollupOptions: {
+      output: { inlineDynamicImports: true },
+    },
+  },
+  esbuild: {
+    legalComments: 'none',
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    include: ['card/test/**/*.test.ts'],
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     legalComments: 'none',
   },
   test: {
-    environment: 'happy-dom',
+    environment: 'jsdom',
     globals: true,
     include: ['card/test/**/*.test.ts'],
   },


### PR DESCRIPTION
## Summary

First end-to-end release of `comfort-band-card` and v0.1.0 of the integration. Eight commits, each green on its own:

| # | Commit | Highlights |
|---|---|---|
| 1 | Bootstrap | Vite + TS + Lit 3, ESLint/Prettier, Vitest + jsdom, new `Card` workflow with a `dist/` drift check, HACS plugin metadata, `validate.yml` now runs HACS for both `integration` and `plugin` categories. |
| 2 | Types + services + `findZoneEntities` | Card resolves entities by `(comfort_band, zone:{slug})` device identifier so post-cutover entity-id chaos (`*.gym_hvac_new_*` and `*_2` collision suffixes) doesn't break it. |
| 3 | Tile + band gauge | First visible render. Compact tile with prominent room temp, action-coloured band gauge, override pill. Test runtime moved happy-dom → jsdom (Lit's nested `svg` template namespace handling). |
| 4 | Modal + Now tab + dual-handle slider | Native `<dialog>` + `showModal()`, no `browser_mod`. Custom dual-handle slider with full keyboard support. Slider release fires `start_override`. |
| 5 | Profiles tab | Lists profiles from the singleton select; tap fires `set_profile`. |
| 6 | Insights tab | Wraps HA's built-in `history-graph` via `loadCardHelpers()`; falls back to a deep link if the helper isn't available. v0.2 will replace with a uPlot chart shaded by `current_action`. |
| 7 | Schedule tab + timeline editor + ws/get_schedule | Adds `comfort_band/get_schedule` websocket command to the integration (it was write-only). Timeline ribbon with tap-to-add / tap-to-edit / long-press-to-delete. All edits persist via atomic `set_schedule`. |
| 8 | Card editor + v0.1.0 polish | Visual config UI (zone dropdown + compact toggle), `getStubConfig`, manifest bump, README rewritten (including the dual-content HACS install footnote). |

**Test counts:** 94 card tests, 105 python tests, all green. mypy `--strict` clean, ruff clean, ESLint/Prettier clean, banned-words clean. Bundle: 81.51 kB / 19.63 kB gzip (under the 100 kB v0.1.0 budget).

## HACS install (after this lands)

Add the repo URL **twice** as a Custom Repository — once under Integrations, once under Frontend. HACS doesn't auto-detect dual-content repos.

## Test plan

- [ ] CI green on this PR (Card lint/typecheck/test/build, validate hassfest + HACS×2, Python lint/test).
- [ ] Merge to `main`, tag `v0.1.0`, create GitHub Release.
- [ ] On HA Yellow: install the card via HACS Frontend, drop `type: custom:comfort-band-card, zone: gym` into the dashboard, verify tile renders + modal opens.
- [ ] Now tab — drag slider, verify `binary_sensor.gym_override_active = on` and `sensor.gym_override_ends ≈ now() + override_hours`.
- [ ] Schedule tab — verify imported transitions render, tap empty space adds, long-press deletes, edit dialog round-trips.
- [ ] Profiles tab — switch to `away`, verify `select.comfort_band_profiles_active_profile.state == 'away'`.
- [ ] Insights tab — 24h temp graph renders.
- [ ] Replace remaining 4 sections (main, mbr, nate, zach) with the card.
- [ ] Mobile sanity check.

## Deferred to v0.2 (flagged in commit messages)

- Drag-to-move-time on schedule transitions (current path: edit dialog).
- Custom uPlot chart with `current_action`-shaded bands replacing the `history-graph` wrapper.
- Profile create / clone / rename / delete UI (needs new `comfort_band` services).
- Live-update WebSocket subscription for schedules (currently re-fetches after every write).
- Mobile-specific layout if the responsive single-layout proves cramped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)