### PR TITLE
Add SIGNAL_ZONE_SCHEDULE_CHANGED + ws_subscribe_schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Each zone gets its own band, override, and per-profile schedule. A **profile** (
 
 ## Status
 
-**v0.1.1.** The integration logic is the same as v0.0.2 / v0.1.0 — full coordinator, per-zone entities, profile schedules, override timers, legacy importer. v0.1.0 added a `comfort_band/get_schedule` websocket command for the companion Lovelace card. v0.1.1 is just a repo cleanup release (the card moves to its own repo — see below).
+**v0.2.0.** Adds a `comfort_band/subscribe_schedule` websocket command so the card can receive live schedule updates from any source (a second card on another dashboard, an automation, Developer Tools → Services) without polling. The store fires a new `SIGNAL_ZONE_SCHEDULE_CHANGED` dispatcher signal on every persisted schedule write. The older `comfort_band/get_schedule` request/response command remains for back-compat. The integration logic itself is unchanged from v0.1 — full coordinator, per-zone entities, profile schedules, override timers, legacy importer.
 
 Every zone still defaults to **shadow mode** (`switch.{zone}_enabled = off`): the integration computes the heat/cool/idle decision and updates the `current_action` sensor, but does **not** call `climate.set_hvac_mode`. Flip the switch on per zone when you're ready to cut over.
 

--- a/custom_components/comfort_band/const.py
+++ b/custom_components/comfort_band/const.py
@@ -69,3 +69,4 @@ PLATFORMS_PROFILE_MANAGER: Final = (Platform.SELECT,)
 
 # Signals (async_dispatcher).
 SIGNAL_ACTIVE_PROFILE_CHANGED: Final = f"{DOMAIN}_active_profile_changed"
+SIGNAL_ZONE_SCHEDULE_CHANGED: Final = f"{DOMAIN}_zone_schedule_changed"

--- a/custom_components/comfort_band/manifest.json
+++ b/custom_components/comfort_band/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/dpretty/ha-comfort-band/issues",
   "requirements": [],
-  "version": "0.1.1"
+  "version": "0.2.0"
 }

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -19,6 +19,7 @@ import copy
 from typing import Any, TypedDict, cast
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import Store
 
 __all__ = [
@@ -37,6 +38,7 @@ from .const import (
     DEFAULT_MIN_CYCLE_MINUTES,
     DEFAULT_OVERRIDE_HOURS,
     DEFAULT_PROFILE,
+    SIGNAL_ZONE_SCHEDULE_CHANGED,
     STORAGE_KEY,
     STORAGE_VERSION,
     TEMP_MAX,
@@ -121,6 +123,7 @@ class ComfortBandStore:
     """Wraps `Store[StoredData]` with typed accessors and copy-on-read isolation."""
 
     def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
         self._store: Store[StoredData] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
         self._data: StoredData = _default_data()
         self._loaded = False
@@ -204,6 +207,13 @@ class ComfortBandStore:
             "current": copy.deepcopy(current) if current is not None else copy.deepcopy(baseline),
         }
         await self.async_save()
+        async_dispatcher_send(
+            self._hass,
+            SIGNAL_ZONE_SCHEDULE_CHANGED,
+            zone_name,
+            profile_name,
+            self.get_zone_schedule(zone_name, profile_name),
+        )
 
     # ----- profiles -----
 

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -202,17 +202,24 @@ class ComfortBandStore:
         if profile_name not in self._data["profiles"]:
             raise ValueError(f"Profile {profile_name!r} does not exist")
         # Independent baseline/current lists so caller mutation doesn't alias.
-        self._data["zones"][zone_name]["schedules"][profile_name] = {
+        persisted: StoredProfileSchedule = {
             "baseline": copy.deepcopy(baseline),
             "current": copy.deepcopy(current) if current is not None else copy.deepcopy(baseline),
         }
+        self._data["zones"][zone_name]["schedules"][profile_name] = persisted
         await self.async_save()
+        # The sibling SIGNAL_ACTIVE_PROFILE_CHANGED is fired from ProfileRegistry
+        # (a wrapper) to keep the store notification-unaware. There is no
+        # analogous wrapper for schedule writes — services.py mutates the store
+        # directly — so firing here covers every call site without adding an
+        # empty pass-through layer. Separate deep-copy keeps listener mutations
+        # from aliasing in-memory state.
         async_dispatcher_send(
             self._hass,
             SIGNAL_ZONE_SCHEDULE_CHANGED,
             zone_name,
             profile_name,
-            self.get_zone_schedule(zone_name, profile_name),
+            copy.deepcopy(persisted),
         )
 
     # ----- profiles -----

--- a/custom_components/comfort_band/ws.py
+++ b/custom_components/comfort_band/ws.py
@@ -57,11 +57,14 @@ def ws_get_schedule(
     connection.send_result(msg["id"], schedule)
 
 
+_NAME_FIELD = vol.All(str, vol.Length(min=1, max=255))
+
+
 @websocket_command(
     {
         vol.Required("type"): "comfort_band/subscribe_schedule",
-        vol.Required("zone"): str,
-        vol.Required("profile"): str,
+        vol.Required("zone"): _NAME_FIELD,
+        vol.Required("profile"): _NAME_FIELD,
     }
 )
 @async_response
@@ -80,17 +83,16 @@ async def ws_subscribe_schedule(
     zone = msg["zone"]
     profile = msg["profile"]
 
-    try:
-        initial = data.store.get_zone_schedule(zone, profile)
-    except KeyError:
+    if not data.store.has_zone(zone):
         connection.send_error(msg["id"], "zone_not_found", f"Zone {zone!r} does not exist")
         return
-    # get_zone_schedule returns None for unknown profiles on a valid zone —
-    # surface that as an error so the client doesn't sit in a "loading"
-    # state on a subscription that will never fire.
+    # An unknown profile is a typo, not an empty schedule: get_zone_schedule
+    # would return None for both, which would leave the client on a
+    # subscription that never fires. Reject up front.
     if profile not in data.store.list_profiles():
         connection.send_error(msg["id"], "profile_not_found", f"Profile {profile!r} does not exist")
         return
+    initial = data.store.get_zone_schedule(zone, profile)
 
     @callback
     def _forward(

--- a/custom_components/comfort_band/ws.py
+++ b/custom_components/comfort_band/ws.py
@@ -14,7 +14,6 @@ import voluptuous as vol
 from homeassistant.components.websocket_api import async_register_command
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.components.websocket_api.decorators import async_response, websocket_command
-from homeassistant.components.websocket_api.messages import event_message
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -23,6 +22,9 @@ from .const import DOMAIN, SIGNAL_ZONE_SCHEDULE_CHANGED
 if TYPE_CHECKING:
     from . import ComfortBandData
     from .storage import StoredProfileSchedule
+
+
+_NAME_FIELD = vol.All(str, vol.Length(min=1, max=255))
 
 
 @callback
@@ -35,8 +37,8 @@ def async_register_ws_commands(hass: HomeAssistant) -> None:
 @websocket_command(
     {
         vol.Required("type"): "comfort_band/get_schedule",
-        vol.Required("zone"): str,
-        vol.Required("profile"): str,
+        vol.Required("zone"): _NAME_FIELD,
+        vol.Required("profile"): _NAME_FIELD,
     }
 )
 @callback
@@ -55,9 +57,6 @@ def ws_get_schedule(
         connection.send_error(msg["id"], "zone_not_found", f"Zone {zone!r} does not exist")
         return
     connection.send_result(msg["id"], schedule)
-
-
-_NAME_FIELD = vol.All(str, vol.Length(min=1, max=255))
 
 
 @websocket_command(
@@ -92,20 +91,23 @@ async def ws_subscribe_schedule(
     if profile not in data.store.list_profiles():
         connection.send_error(msg["id"], "profile_not_found", f"Profile {profile!r} does not exist")
         return
+    # No awaits between this snapshot and the dispatcher_connect below —
+    # a future refactor that introduces one would risk missing an update
+    # written in the gap.
     initial = data.store.get_zone_schedule(zone, profile)
 
     @callback
     def _forward(
         changed_zone: str,
         changed_profile: str,
-        schedule: StoredProfileSchedule | None,
+        schedule: StoredProfileSchedule,
     ) -> None:
         if changed_zone != zone or changed_profile != profile:
             return
-        connection.send_message(event_message(msg["id"], {"schedule": schedule}))
+        connection.send_event(msg["id"], {"schedule": schedule})
 
     connection.subscriptions[msg["id"]] = async_dispatcher_connect(
         hass, SIGNAL_ZONE_SCHEDULE_CHANGED, _forward
     )
     connection.send_result(msg["id"])
-    connection.send_message(event_message(msg["id"], {"schedule": initial}))
+    connection.send_event(msg["id"], {"schedule": initial})

--- a/custom_components/comfort_band/ws.py
+++ b/custom_components/comfort_band/ws.py
@@ -85,6 +85,12 @@ async def ws_subscribe_schedule(
     except KeyError:
         connection.send_error(msg["id"], "zone_not_found", f"Zone {zone!r} does not exist")
         return
+    # get_zone_schedule returns None for unknown profiles on a valid zone —
+    # surface that as an error so the client doesn't sit in a "loading"
+    # state on a subscription that will never fire.
+    if profile not in data.store.list_profiles():
+        connection.send_error(msg["id"], "profile_not_found", f"Profile {profile!r} does not exist")
+        return
 
     @callback
     def _forward(

--- a/custom_components/comfort_band/ws.py
+++ b/custom_components/comfort_band/ws.py
@@ -47,7 +47,13 @@ def ws_get_schedule(
     connection: ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Return `{baseline, current}` for the (zone, profile), or `null` if unset."""
+    """Return `{baseline, current}` for the (zone, profile), or `null` if unset.
+
+    Returns `null` for both "profile has no schedule yet" and "profile
+    does not exist" — the request/response shape can't distinguish them.
+    The push command `subscribe_schedule` errors on unknown profiles so
+    the card doesn't sit on a subscription that will never fire.
+    """
     data: ComfortBandData = hass.data[DOMAIN]
     zone = msg["zone"]
     profile = msg["profile"]

--- a/custom_components/comfort_band/ws.py
+++ b/custom_components/comfort_band/ws.py
@@ -1,9 +1,9 @@
 """Websocket commands for the Comfort Band frontend card.
 
 The integration's services in `services.py` are write-only; the card needs
-a read API to render the schedule editor. This module owns the read API
-plus a push subscription so multiple card instances stay in sync without
-polling.
+read APIs to render the schedule editor. This module owns both: the
+request/response `get_schedule` and the push `subscribe_schedule` that
+keeps multiple card instances in sync without polling.
 """
 
 from __future__ import annotations
@@ -51,12 +51,10 @@ def ws_get_schedule(
     data: ComfortBandData = hass.data[DOMAIN]
     zone = msg["zone"]
     profile = msg["profile"]
-    try:
-        schedule = data.store.get_zone_schedule(zone, profile)
-    except KeyError:
+    if not data.store.has_zone(zone):
         connection.send_error(msg["id"], "zone_not_found", f"Zone {zone!r} does not exist")
         return
-    connection.send_result(msg["id"], schedule)
+    connection.send_result(msg["id"], data.store.get_zone_schedule(zone, profile))
 
 
 @websocket_command(
@@ -109,5 +107,8 @@ async def ws_subscribe_schedule(
     connection.subscriptions[msg["id"]] = async_dispatcher_connect(
         hass, SIGNAL_ZONE_SCHEDULE_CHANGED, _forward
     )
+    # `send_result` must precede `send_event`: the HA WS protocol expects
+    # the subscription ack before any events, and the JS client only
+    # resolves its `subscribeMessage` promise on the result frame.
     connection.send_result(msg["id"])
     connection.send_event(msg["id"], {"schedule": initial})

--- a/custom_components/comfort_band/ws.py
+++ b/custom_components/comfort_band/ws.py
@@ -1,8 +1,9 @@
 """Websocket commands for the Comfort Band frontend card.
 
 The integration's services in `services.py` are write-only; the card needs
-a read API to render the schedule editor. This module owns the read API.
-Add live-update subscriptions here when the card grows in v0.2.
+a read API to render the schedule editor. This module owns the read API
+plus a push subscription so multiple card instances stay in sync without
+polling.
 """
 
 from __future__ import annotations
@@ -12,19 +13,23 @@ from typing import TYPE_CHECKING, Any
 import voluptuous as vol
 from homeassistant.components.websocket_api import async_register_command
 from homeassistant.components.websocket_api.connection import ActiveConnection
-from homeassistant.components.websocket_api.decorators import websocket_command
+from homeassistant.components.websocket_api.decorators import async_response, websocket_command
+from homeassistant.components.websocket_api.messages import event_message
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN
+from .const import DOMAIN, SIGNAL_ZONE_SCHEDULE_CHANGED
 
 if TYPE_CHECKING:
     from . import ComfortBandData
+    from .storage import StoredProfileSchedule
 
 
 @callback
 def async_register_ws_commands(hass: HomeAssistant) -> None:
     """Register every websocket command in this module."""
     async_register_command(hass, ws_get_schedule)
+    async_register_command(hass, ws_subscribe_schedule)
 
 
 @websocket_command(
@@ -50,3 +55,49 @@ def ws_get_schedule(
         connection.send_error(msg["id"], "zone_not_found", f"Zone {zone!r} does not exist")
         return
     connection.send_result(msg["id"], schedule)
+
+
+@websocket_command(
+    {
+        vol.Required("type"): "comfort_band/subscribe_schedule",
+        vol.Required("zone"): str,
+        vol.Required("profile"): str,
+    }
+)
+@async_response
+async def ws_subscribe_schedule(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Subscribe to (zone, profile) schedule changes.
+
+    Sends one initial `{schedule}` event with the current value, then one
+    event per `SIGNAL_ZONE_SCHEDULE_CHANGED` dispatch matching the
+    requested (zone, profile). Cleanup is automatic on WS disconnect.
+    """
+    data: ComfortBandData = hass.data[DOMAIN]
+    zone = msg["zone"]
+    profile = msg["profile"]
+
+    try:
+        initial = data.store.get_zone_schedule(zone, profile)
+    except KeyError:
+        connection.send_error(msg["id"], "zone_not_found", f"Zone {zone!r} does not exist")
+        return
+
+    @callback
+    def _forward(
+        changed_zone: str,
+        changed_profile: str,
+        schedule: StoredProfileSchedule | None,
+    ) -> None:
+        if changed_zone != zone or changed_profile != profile:
+            return
+        connection.send_message(event_message(msg["id"], {"schedule": schedule}))
+
+    connection.subscriptions[msg["id"]] = async_dispatcher_connect(
+        hass, SIGNAL_ZONE_SCHEDULE_CHANGED, _forward
+    )
+    connection.send_result(msg["id"])
+    connection.send_message(event_message(msg["id"], {"schedule": initial}))

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -23,7 +23,7 @@ def test_manifest_shape() -> None:
     assert manifest["integration_type"] == "helper"
     assert manifest["iot_class"] == "local_push"
     assert manifest["codeowners"] == ["@dpretty"]
-    assert manifest["version"] == "0.1.1"
+    assert manifest["version"] == "0.2.0"
     assert manifest["documentation"].startswith("https://")
     assert manifest["issue_tracker"].startswith("https://")
     assert manifest["requirements"] == []

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,7 +6,9 @@ from typing import Any
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
+from custom_components.comfort_band.const import SIGNAL_ZONE_SCHEDULE_CHANGED
 from custom_components.comfort_band.storage import ComfortBandStore
 
 # ----- defaults -----
@@ -193,3 +195,33 @@ async def test_set_zone_schedule_independent_lists(
     schedule = store.get_zone_schedule("office", "home")
     assert schedule is not None
     assert schedule["baseline"][0]["low"] == 20.0
+
+
+async def test_set_zone_schedule_fires_signal(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Every persisted schedule write must dispatch SIGNAL_ZONE_SCHEDULE_CHANGED."""
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_add_zone("office")
+
+    received: list[tuple[str, str, Any]] = []
+    unsub = async_dispatcher_connect(
+        hass,
+        SIGNAL_ZONE_SCHEDULE_CHANGED,
+        lambda zone, profile, schedule: received.append((zone, profile, schedule)),
+    )
+    try:
+        baseline = [{"at": "06:00", "low": 20.0, "high": 23.0}]
+        await store.async_set_zone_schedule("office", "home", baseline)
+        await hass.async_block_till_done()
+    finally:
+        unsub()
+
+    assert len(received) == 1
+    zone, profile, schedule = received[0]
+    assert zone == "office"
+    assert profile == "home"
+    assert schedule is not None
+    assert schedule["baseline"] == baseline
+    assert schedule["current"] == baseline

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -9,26 +9,41 @@ adds nothing testable beyond what the framework already guarantees
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import pytest
 from homeassistant.core import HomeAssistant
 
-from custom_components.comfort_band.ws import ws_get_schedule
+from custom_components.comfort_band.ws import ws_get_schedule, ws_subscribe_schedule
 
 
 class _FakeConnection:
-    """Minimal stand-in for `websocket_api.ActiveConnection`."""
+    """Minimal stand-in for `websocket_api.ActiveConnection`.
+
+    Captures every send_* and tracks the `subscriptions` dict used by
+    HA's WS framework for cleanup on disconnect.
+    """
 
     def __init__(self) -> None:
         self.results: list[tuple[int, Any]] = []
         self.errors: list[tuple[int, str, str]] = []
+        self.messages: list[dict[str, Any]] = []
+        self.subscriptions: dict[int, Callable[[], None]] = {}
 
-    def send_result(self, msg_id: int, data: Any) -> None:
+    def send_result(self, msg_id: int, data: Any = None) -> None:
         self.results.append((msg_id, data))
 
     def send_error(self, msg_id: int, code: str, message: str) -> None:
         self.errors.append((msg_id, code, message))
+
+    def send_message(self, message: dict[str, Any]) -> None:
+        self.messages.append(message)
+
+    def async_handle_exception(self, msg: dict[str, Any], err: Exception) -> None:
+        # Mirrors the real ActiveConnection contract: surface bugs as errors
+        # rather than swallowing them so the test sees a failure.
+        self.errors.append((msg["id"], "unhandled_exception", repr(err)))
 
 
 @pytest.fixture
@@ -102,6 +117,137 @@ async def test_get_schedule_errors_for_unknown_zone(
 async def test_command_is_registered_at_setup(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:
-    """Sanity: async_register_ws_commands() runs and the command is wired."""
+    """Sanity: async_register_ws_commands() runs and the commands are wired."""
     handlers = hass.data.get("websocket_api", {})
     assert "comfort_band/get_schedule" in handlers
+    assert "comfort_band/subscribe_schedule" in handlers
+
+
+# ----- subscribe_schedule -----
+
+
+def _events_from(conn: _FakeConnection) -> list[Any]:
+    """Extract the `event` payload from each event_message captured."""
+    return [m["event"] for m in conn.messages if m.get("type") == "event"]
+
+
+async def test_subscribe_sends_initial_value_then_updates(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """Subscribe pushes the current schedule, then echoes every later write."""
+    initial = [{"at": "06:00", "low": 20.0, "high": 23.0}]
+    await hass.services.async_call(
+        "comfort_band",
+        "set_schedule",
+        {"zone": "office", "profile": "home", "transitions": initial},
+        blocking=True,
+    )
+
+    conn = _FakeConnection()
+    ws_subscribe_schedule(
+        hass,
+        conn,  # type: ignore[arg-type]
+        {"id": 11, "type": "comfort_band/subscribe_schedule", "zone": "office", "profile": "home"},
+    )
+    await hass.async_block_till_done()
+
+    assert conn.errors == []
+    assert conn.results == [(11, None)]
+    events = _events_from(conn)
+    assert len(events) == 1
+    assert events[0]["schedule"]["baseline"] == initial
+    assert 11 in conn.subscriptions
+
+    updated = [
+        {"at": "06:00", "low": 20.0, "high": 23.0},
+        {"at": "22:00", "low": 18.0, "high": 21.0},
+    ]
+    await hass.services.async_call(
+        "comfort_band",
+        "set_schedule",
+        {"zone": "office", "profile": "home", "transitions": updated},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    events = _events_from(conn)
+    assert len(events) == 2
+    assert events[1]["schedule"]["baseline"] == updated
+
+
+async def test_subscribe_filters_to_matching_zone_profile(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """Updates for an unrelated (zone, profile) must not reach the subscriber."""
+    conn = _FakeConnection()
+    ws_subscribe_schedule(
+        hass,
+        conn,  # type: ignore[arg-type]
+        {"id": 12, "type": "comfort_band/subscribe_schedule", "zone": "office", "profile": "home"},
+    )
+    await hass.async_block_till_done()
+    baseline_count = len(_events_from(conn))
+
+    # Write to a different profile on the same zone — must not echo through.
+    await hass.services.async_call(
+        "comfort_band",
+        "set_schedule",
+        {
+            "zone": "office",
+            "profile": "away",
+            "transitions": [{"at": "06:00", "low": 17.0, "high": 20.0}],
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert len(_events_from(conn)) == baseline_count
+
+
+async def test_subscribe_unknown_zone_errors(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """An unknown zone surfaces a typed error and does not open a subscription."""
+    conn = _FakeConnection()
+    ws_subscribe_schedule(
+        hass,
+        conn,  # type: ignore[arg-type]
+        {"id": 13, "type": "comfort_band/subscribe_schedule", "zone": "ghost", "profile": "home"},
+    )
+    await hass.async_block_till_done()
+
+    assert conn.results == []
+    assert conn.messages == []
+    assert conn.subscriptions == {}
+    assert conn.errors == [(13, "zone_not_found", "Zone 'ghost' does not exist")]
+
+
+async def test_subscribe_unsubscribe_stops_updates(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """Calling the stored unsubscribe handle detaches the dispatcher listener."""
+    conn = _FakeConnection()
+    ws_subscribe_schedule(
+        hass,
+        conn,  # type: ignore[arg-type]
+        {"id": 14, "type": "comfort_band/subscribe_schedule", "zone": "office", "profile": "home"},
+    )
+    await hass.async_block_till_done()
+
+    unsub = conn.subscriptions[14]
+    unsub()
+
+    await hass.services.async_call(
+        "comfort_band",
+        "set_schedule",
+        {
+            "zone": "office",
+            "profile": "home",
+            "transitions": [{"at": "06:00", "low": 20.0, "high": 23.0}],
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Only the initial event from subscribe — nothing after unsub.
+    assert len(_events_from(conn)) == 1

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -28,7 +28,7 @@ class _FakeConnection:
     def __init__(self) -> None:
         self.results: list[tuple[int, Any]] = []
         self.errors: list[tuple[int, str, str]] = []
-        self.messages: list[dict[str, Any]] = []
+        self.events: list[tuple[int, Any]] = []
         self.subscriptions: dict[int, Callable[[], None]] = {}
 
     def send_result(self, msg_id: int, data: Any = None) -> None:
@@ -37,8 +37,10 @@ class _FakeConnection:
     def send_error(self, msg_id: int, code: str, message: str) -> None:
         self.errors.append((msg_id, code, message))
 
-    def send_message(self, message: dict[str, Any]) -> None:
-        self.messages.append(message)
+    def send_event(self, msg_id: int, event: Any | None = None) -> None:
+        # Real ActiveConnection serialises via event_message() →
+        # message_to_json_bytes(); the test only cares about the payload.
+        self.events.append((msg_id, event))
 
     def async_handle_exception(self, msg: dict[str, Any], err: Exception) -> None:
         # Mirrors the real ActiveConnection contract: surface bugs as errors
@@ -127,8 +129,8 @@ async def test_command_is_registered_at_setup(
 
 
 def _events_from(conn: _FakeConnection) -> list[Any]:
-    """Extract the `event` payload from each event_message captured."""
-    return [m["event"] for m in conn.messages if m.get("type") == "event"]
+    """Extract the event payload from each send_event call."""
+    return [event for _msg_id, event in conn.events]
 
 
 async def test_subscribe_sends_initial_value_then_updates(
@@ -176,9 +178,23 @@ async def test_subscribe_sends_initial_value_then_updates(
 
 
 async def test_subscribe_filters_to_matching_zone_profile(
-    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    setup_zone: None,
+    make_zone_entry: Any,
 ) -> None:
     """Updates for an unrelated (zone, profile) must not reach the subscriber."""
+    # Second zone so we can probe both filter axes.
+    kitchen_entry = make_zone_entry(
+        zone_name="kitchen",
+        climate_entity="climate.kitchen_hvac",
+        temp_sensor="sensor.kitchen_temp",
+    )
+    kitchen_entry.add_to_hass(hass)
+    hass.states.async_set("sensor.kitchen_temp", "20.0", {})
+    assert await hass.config_entries.async_setup(kitchen_entry.entry_id)
+    await hass.async_block_till_done()
+
     conn = _FakeConnection()
     ws_subscribe_schedule(
         hass,
@@ -200,7 +216,20 @@ async def test_subscribe_filters_to_matching_zone_profile(
         blocking=True,
     )
     await hass.async_block_till_done()
+    assert len(_events_from(conn)) == baseline_count
 
+    # Write to the matching profile on a different zone — must not echo through.
+    await hass.services.async_call(
+        "comfort_band",
+        "set_schedule",
+        {
+            "zone": "kitchen",
+            "profile": "home",
+            "transitions": [{"at": "07:00", "low": 19.0, "high": 22.0}],
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
     assert len(_events_from(conn)) == baseline_count
 
 
@@ -217,7 +246,7 @@ async def test_subscribe_unknown_zone_errors(
     await hass.async_block_till_done()
 
     assert conn.results == []
-    assert conn.messages == []
+    assert conn.events == []
     assert conn.subscriptions == {}
     assert conn.errors == [(13, "zone_not_found", "Zone 'ghost' does not exist")]
 
@@ -240,7 +269,7 @@ async def test_subscribe_unknown_profile_errors(
     await hass.async_block_till_done()
 
     assert conn.results == []
-    assert conn.messages == []
+    assert conn.events == []
     assert conn.subscriptions == {}
     assert conn.errors == [(15, "profile_not_found", "Profile 'ghost' does not exist")]
 

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -222,6 +222,29 @@ async def test_subscribe_unknown_zone_errors(
     assert conn.errors == [(13, "zone_not_found", "Zone 'ghost' does not exist")]
 
 
+async def test_subscribe_unknown_profile_errors(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """An unknown profile on a valid zone also errors — never leaves a dangling sub."""
+    conn = _FakeConnection()
+    ws_subscribe_schedule(
+        hass,
+        conn,  # type: ignore[arg-type]
+        {
+            "id": 15,
+            "type": "comfort_band/subscribe_schedule",
+            "zone": "office",
+            "profile": "ghost",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert conn.results == []
+    assert conn.messages == []
+    assert conn.subscriptions == {}
+    assert conn.errors == [(15, "profile_not_found", "Profile 'ghost' does not exist")]
+
+
 async def test_subscribe_unsubscribe_stops_updates(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:


### PR DESCRIPTION
## Summary

Backend half of #5. The store now fires `SIGNAL_ZONE_SCHEDULE_CHANGED` whenever a (zone, profile) schedule is persisted, and a new `comfort_band/subscribe_schedule` WS command pushes the current schedule on connect plus every later change. Card-side PR: dpretty/ha-comfort-band-card#TBD.

- `const.py`: new dispatcher signal (mirrors `SIGNAL_ACTIVE_PROFILE_CHANGED` pattern).
- `storage.py`: `ComfortBandStore` keeps a hass reference and dispatches at the end of `async_set_zone_schedule` — single chokepoint covers every mutation path (services, internal callers, future writers).
- `ws.py`: `ws_subscribe_schedule` validates the zone up-front, registers a dispatcher listener via `connection.subscriptions[msg_id]` for automatic cleanup on disconnect, and sends the current value as the initial event. Filters dispatches by (zone, profile).
- Test coverage: initial-value + live-update, filtering on mismatched (zone, profile), unknown-zone error path, unsubscribe stops updates, signal-fires-once at the storage layer.

## Test plan

- [x] `pytest` — 110/110 pass
- [x] `mypy --strict` — clean
- [x] `ruff check` + `ruff format` + `pre-commit run --all-files` — clean
- [ ] Live HA: pair with card PR, open two card instances on different dashboards, confirm edit in one reflects live in the other; confirm Developer Tools → `comfort_band.set_schedule` updates open cards