### PR TITLE
Profile management UI: create / clone / rename / delete (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ A Home Assistant custom integration for per-room HVAC band-control.
 
 Most thermostats hold a single setpoint, which makes heat pumps and mini-splits short-cycle as the room temperature drifts above and below the target. Comfort Band lets you define a **low/high band per room**: the system heats when the room falls below the low, cools when it climbs above the high, and stays idle (`fan_only`) in between.
 
-Each zone gets its own band, override, and per-profile schedule. A **profile** (e.g. `home`, `away`, `sleep`) lets you swap every zone's schedule with a single tap or service call.
+Each zone gets its own band, override, and per-profile schedule. A **profile** (e.g. `home`, `away`) lets you swap every zone's schedule with a single tap or service call.
 
 ## Status
 
-**v0.2.0.** Adds a `comfort_band/subscribe_schedule` websocket command so the card can receive live schedule updates from any source (a second card on another dashboard, an automation, Developer Tools → Services) without polling. The store fires a new `SIGNAL_ZONE_SCHEDULE_CHANGED` dispatcher signal on every persisted schedule write. The older `comfort_band/get_schedule` request/response command remains for back-compat. The integration logic itself is unchanged from v0.1 — full coordinator, per-zone entities, profile schedules, override timers, legacy importer.
+**v0.3.0.** Adds full profile CRUD: four new services (`create_profile`, `clone_profile`, `rename_profile`, `delete_profile`) and a new `SIGNAL_PROFILE_LIST_CHANGED` dispatcher signal so the singleton select entity (and any subscribed cards) re-render on every profile mutation. The `default_profile` is now tracked per-store and survives renames — whatever profile holds that role cannot be deleted. Built-in profiles narrowed from `home / away / sleep` to **`home` + `away`**; existing installs keep any `sleep` profile they had as a normal user profile that can now be renamed or deleted.
+
+**v0.2.0** added a `comfort_band/subscribe_schedule` websocket command so the card receives live schedule updates from any source without polling.
 
 Every zone still defaults to **shadow mode** (`switch.{zone}_enabled = off`): the integration computes the heat/cool/idle decision and updates the `current_action` sensor, but does **not** call `climate.set_hvac_mode`. Flip the switch on per zone when you're ready to cut over.
 
@@ -27,7 +29,7 @@ A Lovelace card lives in a separate repo: **[dpretty/ha-comfort-band-card](https
 
 ## Setup walkthrough
 
-1. **Add the profile manager** (one-time): Add Integration → Comfort Band → *Set up profile manager*. This creates `select.comfort_band_profiles_active_profile` with the built-in profiles `home` / `away` / `sleep`.
+1. **Add the profile manager** (one-time): Add Integration → Comfort Band → *Set up profile manager*. This creates `select.comfort_band_profiles_active_profile` with the built-in profiles `home` + `away`. Use the card's Profiles tab (or the `create_profile` / `clone_profile` services) to add your own.
 2. **Add a zone**: Add Integration → Comfort Band → *Add a zone*. You'll be asked for:
    - **Zone name (slug)**: lowercase letters / digits / underscores, e.g. `office`. Becomes part of every entity_id.
    - **Climate entity**: the `climate.*` entity Comfort Band will eventually drive (e.g. a Mitsubishi mini-split).
@@ -67,7 +69,7 @@ Adjacent identical hours collapse into a single transition, so a flat 24-hour ba
 
 ## Other services
 
-`set_schedule`, `add_transition`, `update_transition`, `remove_transition` (per-zone, per-profile schedule mutations); `start_override` / `cancel_override` (per-zone); `set_profile` (global). All take the bare zone slug, not an entity_id. See `services.yaml` or **Developer Tools → Services** for the full schemas.
+Per-zone schedule mutations: `set_schedule`, `add_transition`, `update_transition`, `remove_transition`. Per-zone override control: `start_override` / `cancel_override`. Profile management: `set_profile` (switch active), `create_profile`, `clone_profile`, `rename_profile`, `delete_profile`. All zone-scoped services take the bare zone slug, not an entity_id. See `services.yaml` or **Developer Tools → Services** for the full schemas.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Plus one global entity: `select.comfort_band_profiles_active_profile`.
 
 ### Profile manager entity attributes
 
-`select.comfort_band_profiles_active_profile` carries three attributes the card (or any consumer) can read alongside the standard `options` / `state`:
+`select.comfort_band_profiles_active_profile` carries two extra attributes the card (or any consumer) can read alongside the standard `options` / `state`:
 
 - `default_profile` — the rename-aware fallback target. Initially `"home"`; tracks renames. The profile pointed to by this attribute cannot be deleted.
 - `descriptions` — a `{profile_name: description}` map; each profile's optional description as set via `create_profile` / `clone_profile`.
@@ -63,7 +63,7 @@ The card uses presence of `default_profile` as a feature flag — if it's missin
 
 ## Importing a legacy schedule
 
-If you're migrating from a hand-rolled YAML system that stored each zone's schedule as 48 `input_number` helpers (one each for low and high, per hour 00..23), the `comfort_band.import_legacy` service will collapse them into a transition list and seed the zone's `home` profile.
+If you're migrating from a hand-rolled YAML system that stored each zone's schedule as 48 `input_number` helpers (one each for low and high, per hour 00..23), the `comfort_band.import_legacy` service will collapse them into a transition list and seed the zone's **default profile** (initially `home`; tracks renames).
 
 In **Developer Tools → Services**:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ A Lovelace card lives in a separate repo: **[dpretty/ha-comfort-band-card](https
 
 Plus one global entity: `select.comfort_band_profiles_active_profile`.
 
+### Profile manager entity attributes
+
+`select.comfort_band_profiles_active_profile` carries three attributes the card (or any consumer) can read alongside the standard `options` / `state`:
+
+- `default_profile` — the rename-aware fallback target. Initially `"home"`; tracks renames. The profile pointed to by this attribute cannot be deleted.
+- `descriptions` — a `{profile_name: description}` map; each profile's optional description as set via `create_profile` / `clone_profile`.
+
+The card uses presence of `default_profile` as a feature flag — if it's missing, the card knows it's talking to a pre-v0.3.0 install and hides the CRUD affordances.
+
 ## Importing a legacy schedule
 
 If you're migrating from a hand-rolled YAML system that stored each zone's schedule as 48 `input_number` helpers (one each for low and high, per hour 00..23), the `comfort_band.import_legacy` service will collapse them into a transition list and seed the zone's `home` profile.

--- a/custom_components/comfort_band/const.py
+++ b/custom_components/comfort_band/const.py
@@ -37,8 +37,11 @@ TEMP_MAX: Final = 26.0
 TEMP_STEP: Final = 0.5
 
 # Profiles.
+# DEFAULT_PROFILE is the *seed* default for fresh installs. After install the
+# live default is tracked per-store as `default_profile`, which moves with
+# renames — see `ComfortBandStore.default_profile`.
 DEFAULT_PROFILE: Final = "home"
-BUILTIN_PROFILES: Final = ("home", "away", "sleep")
+BUILTIN_PROFILES: Final = ("home", "away")
 
 # Action labels (returned by hysteresis.decide; surfaced via the current_action sensor).
 ACTION_HEAT: Final = "heating"
@@ -69,4 +72,5 @@ PLATFORMS_PROFILE_MANAGER: Final = (Platform.SELECT,)
 
 # Signals (async_dispatcher).
 SIGNAL_ACTIVE_PROFILE_CHANGED: Final = f"{DOMAIN}_active_profile_changed"
+SIGNAL_PROFILE_LIST_CHANGED: Final = f"{DOMAIN}_profile_list_changed"
 SIGNAL_ZONE_SCHEDULE_CHANGED: Final = f"{DOMAIN}_zone_schedule_changed"

--- a/custom_components/comfort_band/const.py
+++ b/custom_components/comfort_band/const.py
@@ -42,6 +42,10 @@ TEMP_STEP: Final = 0.5
 # renames — see `ComfortBandStore.default_profile`.
 DEFAULT_PROFILE: Final = "home"
 BUILTIN_PROFILES: Final = ("home", "away")
+# Hard cap on user-defined profiles. Generous (50 is far beyond any
+# realistic household), but prevents an unbounded-create loop from bloating
+# the .storage file.
+MAX_PROFILES: Final = 50
 
 # Action labels (returned by hysteresis.decide; surfaced via the current_action sensor).
 ACTION_HEAT: Final = "heating"

--- a/custom_components/comfort_band/coordinator.py
+++ b/custom_components/comfort_band/coordinator.py
@@ -34,7 +34,6 @@ from homeassistant.util import dt as dt_util
 from . import hysteresis, schedule
 from .const import (
     ACTION_UNKNOWN,
-    DEFAULT_PROFILE,
     LOGGER,
     SIGNAL_ACTIVE_PROFILE_CHANGED,
 )
@@ -229,9 +228,13 @@ class ZoneCoordinator(DataUpdateCoordinator[ZoneState]):
             zone = self._store.get_zone(self.zone_name)
             override_until = None
 
-        # Resolve scheduled band (falls back to manual band if no schedule).
+        # Resolve scheduled band (falls back to default profile's schedule,
+        # then to manual band). `default_profile` tracks the renamed-home
+        # name, so this still works after the user renames the original
+        # "home" profile.
+        default_profile = self._store.default_profile
         schedule_data = zone["schedules"].get(active_profile) or zone["schedules"].get(
-            DEFAULT_PROFILE
+            default_profile
         )
         sched_low, sched_high = self._resolve_schedule(
             schedule_data, fallback=(zone["manual_low"], zone["manual_high"])

--- a/custom_components/comfort_band/entity.py
+++ b/custom_components/comfort_band/entity.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, SIGNAL_ACTIVE_PROFILE_CHANGED
+from .const import DOMAIN, SIGNAL_ACTIVE_PROFILE_CHANGED, SIGNAL_PROFILE_LIST_CHANGED
 from .coordinator import ZoneCoordinator
 
 
@@ -58,7 +58,7 @@ class ComfortBandProfileEntity(Entity):
         )
 
     async def async_added_to_hass(self) -> None:
-        """Re-render when the active profile changes."""
+        """Re-render when the active profile or the profile list changes."""
         await super().async_added_to_hass()
         self.async_on_remove(
             async_dispatcher_connect(
@@ -67,7 +67,18 @@ class ComfortBandProfileEntity(Entity):
                 self._handle_active_changed,
             )
         )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_PROFILE_LIST_CHANGED,
+                self._handle_list_changed,
+            )
+        )
 
     @callback
     def _handle_active_changed(self, _new_active: str) -> None:
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_list_changed(self) -> None:
         self.async_write_ha_state()

--- a/custom_components/comfort_band/manifest.json
+++ b/custom_components/comfort_band/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/dpretty/ha-comfort-band/issues",
   "requirements": [],
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/custom_components/comfort_band/profiles.py
+++ b/custom_components/comfort_band/profiles.py
@@ -1,6 +1,12 @@
-"""Profile registry — thin wrapper around the store that fires a dispatcher
-signal whenever the active profile changes, so every zone coordinator can
-react in lockstep without polling.
+"""Profile registry — thin wrapper around the store that fires dispatcher
+signals on profile mutations so every zone coordinator and the singleton
+select entity can react without polling.
+
+Two signals:
+- `SIGNAL_ACTIVE_PROFILE_CHANGED(name)` — fires when the active profile
+  changes (including indirectly, e.g. when the active is deleted or renamed).
+- `SIGNAL_PROFILE_LIST_CHANGED` — fires on every list mutation (create,
+  clone, rename, delete) so the select entity re-pushes its `options`.
 """
 
 from __future__ import annotations
@@ -8,7 +14,7 @@ from __future__ import annotations
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DEFAULT_PROFILE, SIGNAL_ACTIVE_PROFILE_CHANGED
+from .const import SIGNAL_ACTIVE_PROFILE_CHANGED, SIGNAL_PROFILE_LIST_CHANGED
 from .storage import ComfortBandStore
 
 
@@ -27,6 +33,13 @@ class ProfileRegistry:
     def active(self) -> str:
         return self._store.active_profile
 
+    @property
+    def default(self) -> str:
+        return self._store.default_profile
+
+    def description(self, name: str) -> str:
+        return self._store.get_profile(name)["description"]
+
     async def async_set_active(self, name: str) -> None:
         if name == self.active:
             return
@@ -35,11 +48,26 @@ class ProfileRegistry:
 
     async def async_create(self, name: str, description: str = "") -> None:
         await self._store.async_add_profile(name, description)
+        async_dispatcher_send(self._hass, SIGNAL_PROFILE_LIST_CHANGED)
+
+    async def async_clone(self, source: str, target: str, description: str = "") -> None:
+        await self._store.async_clone_profile(source, target, description)
+        async_dispatcher_send(self._hass, SIGNAL_PROFILE_LIST_CHANGED)
+
+    async def async_rename(self, old: str, new: str) -> None:
+        if old == new:
+            return
+        was_active = self.active == old
+        await self._store.async_rename_profile(old, new)
+        async_dispatcher_send(self._hass, SIGNAL_PROFILE_LIST_CHANGED)
+        if was_active:
+            async_dispatcher_send(self._hass, SIGNAL_ACTIVE_PROFILE_CHANGED, new)
 
     async def async_delete(self, name: str) -> None:
-        if name == DEFAULT_PROFILE:
-            raise ValueError(f"Cannot delete the default profile {DEFAULT_PROFILE!r}")
+        if name == self.default:
+            raise ValueError(f"Cannot delete the default profile {name!r}")
         was_active = self.active == name
         await self._store.async_remove_profile(name)
+        async_dispatcher_send(self._hass, SIGNAL_PROFILE_LIST_CHANGED)
         if was_active:
-            async_dispatcher_send(self._hass, SIGNAL_ACTIVE_PROFILE_CHANGED, DEFAULT_PROFILE)
+            async_dispatcher_send(self._hass, SIGNAL_ACTIVE_PROFILE_CHANGED, self.default)

--- a/custom_components/comfort_band/profiles.py
+++ b/custom_components/comfort_band/profiles.py
@@ -66,6 +66,8 @@ class ProfileRegistry:
     async def async_delete(self, name: str) -> None:
         if name == self.default:
             raise ValueError(f"Cannot delete the default profile {name!r}")
+        if name not in self.names:
+            raise KeyError(f"Profile {name!r} does not exist")
         was_active = self.active == name
         await self._store.async_remove_profile(name)
         async_dispatcher_send(self._hass, SIGNAL_PROFILE_LIST_CHANGED)

--- a/custom_components/comfort_band/profiles.py
+++ b/custom_components/comfort_band/profiles.py
@@ -64,10 +64,9 @@ class ProfileRegistry:
             async_dispatcher_send(self._hass, SIGNAL_ACTIVE_PROFILE_CHANGED, new)
 
     async def async_delete(self, name: str) -> None:
-        if name == self.default:
-            raise ValueError(f"Cannot delete the default profile {name!r}")
-        if name not in self.names:
-            raise KeyError(f"Profile {name!r} does not exist")
+        # The store raises KeyError for unknown names and ValueError for the
+        # default. We capture `was_active` first; if the store raises, the
+        # dispatcher is never called (the await propagates the exception).
         was_active = self.active == name
         await self._store.async_remove_profile(name)
         async_dispatcher_send(self._hass, SIGNAL_PROFILE_LIST_CHANGED)

--- a/custom_components/comfort_band/select.py
+++ b/custom_components/comfort_band/select.py
@@ -8,7 +8,7 @@ zone coordinator listens on.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -33,6 +33,17 @@ class ActiveProfileSelect(ComfortBandProfileEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         return self._registry().active
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        # Surface the rename-aware default and per-profile descriptions so the
+        # card can render them without a second WS round-trip. Pushed
+        # alongside `options` and `state` every time the entity writes state.
+        registry = self._registry()
+        return {
+            "default_profile": registry.default,
+            "descriptions": {name: registry.description(name) for name in registry.names},
+        }
 
     async def async_select_option(self, option: str) -> None:
         await self._registry().async_set_active(option)

--- a/custom_components/comfort_band/services.py
+++ b/custom_components/comfort_band/services.py
@@ -322,8 +322,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
             raise ServiceValidationError(str(err)) from err
 
     async def _delete_profile(call: ServiceCall) -> None:
+        name = call.data["name"].strip()
+        if not name:
+            raise ServiceValidationError("Profile name cannot be empty")
         try:
-            await _data(hass).profile_registry.async_delete(call.data["name"].strip())
+            await _data(hass).profile_registry.async_delete(name)
         except (KeyError, ValueError) as err:
             raise ServiceValidationError(str(err)) from err
 

--- a/custom_components/comfort_band/services.py
+++ b/custom_components/comfort_band/services.py
@@ -303,9 +303,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
         if not target:
             raise ServiceValidationError("Target profile name cannot be empty")
         try:
-            await _data(hass).profile_registry.async_clone(
-                source, target, call.data["description"]
-            )
+            await _data(hass).profile_registry.async_clone(source, target, call.data["description"])
         except (KeyError, ValueError) as err:
             raise ServiceValidationError(str(err)) from err
 

--- a/custom_components/comfort_band/services.py
+++ b/custom_components/comfort_band/services.py
@@ -42,6 +42,10 @@ SERVICE_START_OVERRIDE = "start_override"
 SERVICE_CANCEL_OVERRIDE = "cancel_override"
 SERVICE_SET_PROFILE = "set_profile"
 SERVICE_IMPORT_LEGACY = "import_legacy"
+SERVICE_CREATE_PROFILE = "create_profile"
+SERVICE_CLONE_PROFILE = "clone_profile"
+SERVICE_RENAME_PROFILE = "rename_profile"
+SERVICE_DELETE_PROFILE = "delete_profile"
 
 _TIME_RE = r"^[0-2]\d:[0-5]\d$"
 
@@ -98,6 +102,30 @@ _IMPORT_LEGACY_SCHEMA = vol.Schema(
         vol.Required("source_zone_name"): cv.string,
     }
 )
+
+_CREATE_PROFILE_SCHEMA = vol.Schema(
+    {
+        vol.Required("name"): cv.string,
+        vol.Optional("description", default=""): cv.string,
+    }
+)
+
+_CLONE_PROFILE_SCHEMA = vol.Schema(
+    {
+        vol.Required("source"): cv.string,
+        vol.Required("target"): cv.string,
+        vol.Optional("description", default=""): cv.string,
+    }
+)
+
+_RENAME_PROFILE_SCHEMA = vol.Schema(
+    {
+        vol.Required("old"): cv.string,
+        vol.Required("new"): cv.string,
+    }
+)
+
+_DELETE_PROFILE_SCHEMA = vol.Schema({vol.Required("name"): cv.string})
 
 
 def _data(hass: HomeAssistant) -> ComfortBandData:
@@ -244,6 +272,43 @@ async def async_register_services(hass: HomeAssistant) -> None:
     async def _set_profile(call: ServiceCall) -> None:
         await _data(hass).profile_registry.async_set_active(call.data["profile"])
 
+    async def _create_profile(call: ServiceCall) -> None:
+        name = call.data["name"].strip()
+        if not name:
+            raise ServiceValidationError("Profile name cannot be empty")
+        try:
+            await _data(hass).profile_registry.async_create(name, call.data["description"])
+        except ValueError as err:
+            raise ServiceValidationError(str(err)) from err
+
+    async def _clone_profile(call: ServiceCall) -> None:
+        target = call.data["target"].strip()
+        source = call.data["source"]
+        if not target:
+            raise ServiceValidationError("Target profile name cannot be empty")
+        try:
+            await _data(hass).profile_registry.async_clone(
+                source, target, call.data["description"]
+            )
+        except (KeyError, ValueError) as err:
+            raise ServiceValidationError(str(err)) from err
+
+    async def _rename_profile(call: ServiceCall) -> None:
+        new = call.data["new"].strip()
+        old = call.data["old"]
+        if not new:
+            raise ServiceValidationError("New profile name cannot be empty")
+        try:
+            await _data(hass).profile_registry.async_rename(old, new)
+        except (KeyError, ValueError) as err:
+            raise ServiceValidationError(str(err)) from err
+
+    async def _delete_profile(call: ServiceCall) -> None:
+        try:
+            await _data(hass).profile_registry.async_delete(call.data["name"])
+        except ValueError as err:
+            raise ServiceValidationError(str(err)) from err
+
     async def _import_legacy(call: ServiceCall) -> None:
         zone_name = call.data["zone"]
         source = call.data["source_zone_name"]
@@ -296,4 +361,16 @@ async def async_register_services(hass: HomeAssistant) -> None:
     )
     hass.services.async_register(
         DOMAIN, SERVICE_IMPORT_LEGACY, _import_legacy, schema=_IMPORT_LEGACY_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_CREATE_PROFILE, _create_profile, schema=_CREATE_PROFILE_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_CLONE_PROFILE, _clone_profile, schema=_CLONE_PROFILE_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_RENAME_PROFILE, _rename_profile, schema=_RENAME_PROFILE_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_DELETE_PROFILE, _delete_profile, schema=_DELETE_PROFILE_SCHEMA
     )

--- a/custom_components/comfort_band/services.py
+++ b/custom_components/comfort_band/services.py
@@ -290,6 +290,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
     async def _clone_profile(call: ServiceCall) -> None:
         source = call.data["source"].strip()
         target = call.data["target"].strip()
+        if not source:
+            raise ServiceValidationError("Source profile name cannot be empty")
         if not target:
             raise ServiceValidationError("Target profile name cannot be empty")
         try:
@@ -302,6 +304,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
     async def _rename_profile(call: ServiceCall) -> None:
         old = call.data["old"].strip()
         new = call.data["new"].strip()
+        if not old:
+            raise ServiceValidationError("Old profile name cannot be empty")
         if not new:
             raise ServiceValidationError("New profile name cannot be empty")
         try:

--- a/custom_components/comfort_band/services.py
+++ b/custom_components/comfort_band/services.py
@@ -1,12 +1,17 @@
 """Service registration.
 
-Eight services, all keyed by zone *slug* (not entity_id) so the call site
-matches the storage key. Schemas use voluptuous + entity selectors so
-Developer Tools renders sensible UI.
+Twelve services: schedule mutators (set/add/update/remove transition),
+override control (start/cancel), legacy importer, profile switch, and
+profile CRUD (create/clone/rename/delete). All zone-scoped services are
+keyed by zone *slug* (not entity_id) so the call site matches the
+storage key. Schemas use voluptuous + entity selectors so Developer
+Tools renders sensible UI.
 
 Schedule mutators all run a normalize pass before persisting; they raise
 ServiceValidationError on malformed input rather than letting the user
-write garbage to the store.
+write garbage to the store. Profile-CRUD handlers wrap (KeyError,
+ValueError) from the registry/store as ServiceValidationError so users
+see a consistent error class regardless of which layer rejected.
 """
 
 from __future__ import annotations
@@ -189,7 +194,7 @@ async def _refresh_zone_if_active(hass: HomeAssistant, zone_name: str) -> None:
 
 
 async def async_register_services(hass: HomeAssistant) -> None:
-    """Idempotently register all 8 services."""
+    """Idempotently register all 12 services."""
     if hass.services.has_service(DOMAIN, SERVICE_SET_SCHEDULE):
         return
 
@@ -284,7 +289,10 @@ async def async_register_services(hass: HomeAssistant) -> None:
             raise ServiceValidationError("Profile name cannot be empty")
         try:
             await _data(hass).profile_registry.async_create(name, call.data["description"])
-        except ValueError as err:
+        except (KeyError, ValueError) as err:
+            # async_add_profile only raises ValueError today; broad catch
+            # mirrors the other three CRUD handlers and is defensive
+            # against future storage changes.
             raise ServiceValidationError(str(err)) from err
 
     async def _clone_profile(call: ServiceCall) -> None:

--- a/custom_components/comfort_band/services.py
+++ b/custom_components/comfort_band/services.py
@@ -103,29 +103,35 @@ _IMPORT_LEGACY_SCHEMA = vol.Schema(
     }
 )
 
+# Length caps prevent a malicious / accidental LAN client from bloating
+# the .storage file with a multi-MB profile name. 64 chars is well over
+# the human-readable range; 256 for descriptions allows a sentence.
+_PROFILE_NAME = vol.All(cv.string, vol.Length(min=1, max=64))
+_PROFILE_DESCRIPTION = vol.All(cv.string, vol.Length(max=256))
+
 _CREATE_PROFILE_SCHEMA = vol.Schema(
     {
-        vol.Required("name"): cv.string,
-        vol.Optional("description", default=""): cv.string,
+        vol.Required("name"): _PROFILE_NAME,
+        vol.Optional("description", default=""): _PROFILE_DESCRIPTION,
     }
 )
 
 _CLONE_PROFILE_SCHEMA = vol.Schema(
     {
-        vol.Required("source"): cv.string,
-        vol.Required("target"): cv.string,
-        vol.Optional("description", default=""): cv.string,
+        vol.Required("source"): _PROFILE_NAME,
+        vol.Required("target"): _PROFILE_NAME,
+        vol.Optional("description", default=""): _PROFILE_DESCRIPTION,
     }
 )
 
 _RENAME_PROFILE_SCHEMA = vol.Schema(
     {
-        vol.Required("old"): cv.string,
-        vol.Required("new"): cv.string,
+        vol.Required("old"): _PROFILE_NAME,
+        vol.Required("new"): _PROFILE_NAME,
     }
 )
 
-_DELETE_PROFILE_SCHEMA = vol.Schema({vol.Required("name"): cv.string})
+_DELETE_PROFILE_SCHEMA = vol.Schema({vol.Required("name"): _PROFILE_NAME})
 
 
 def _data(hass: HomeAssistant) -> ComfortBandData:
@@ -282,8 +288,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
             raise ServiceValidationError(str(err)) from err
 
     async def _clone_profile(call: ServiceCall) -> None:
+        source = call.data["source"].strip()
         target = call.data["target"].strip()
-        source = call.data["source"]
         if not target:
             raise ServiceValidationError("Target profile name cannot be empty")
         try:
@@ -294,8 +300,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
             raise ServiceValidationError(str(err)) from err
 
     async def _rename_profile(call: ServiceCall) -> None:
+        old = call.data["old"].strip()
         new = call.data["new"].strip()
-        old = call.data["old"]
         if not new:
             raise ServiceValidationError("New profile name cannot be empty")
         try:
@@ -305,8 +311,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
 
     async def _delete_profile(call: ServiceCall) -> None:
         try:
-            await _data(hass).profile_registry.async_delete(call.data["name"])
-        except ValueError as err:
+            await _data(hass).profile_registry.async_delete(call.data["name"].strip())
+        except (KeyError, ValueError) as err:
             raise ServiceValidationError(str(err)) from err
 
     async def _import_legacy(call: ServiceCall) -> None:
@@ -319,8 +325,10 @@ async def async_register_services(hass: HomeAssistant) -> None:
             transitions = read_legacy_hourly_schedule(hass, source)
         except ValueError as err:
             raise ServiceValidationError(str(err)) from err
-        # Importer writes to "home" profile; baseline + current both seeded.
-        await store.async_set_zone_schedule(zone_name, "home", _to_stored(transitions))
+        # Importer writes to the default profile (originally "home"; tracks
+        # renames so this still works after the user renames home → weekday).
+        default = _data(hass).profile_registry.default
+        await store.async_set_zone_schedule(zone_name, default, _to_stored(transitions))
         LOGGER.info(
             "Imported legacy schedule for %s from input_number.%s_hour_*: %d transitions",
             zone_name,

--- a/custom_components/comfort_band/services.yaml
+++ b/custom_components/comfort_band/services.yaml
@@ -208,7 +208,7 @@ import_legacy:
 
 create_profile:
   name: Create profile
-  description: Create a new (empty) profile. Zone schedules can be added afterward.
+  description: Create a new (empty) profile. Zone schedules can be added afterward. Limit: 50 profiles per install.
   fields:
     name:
       name: Name
@@ -227,7 +227,7 @@ create_profile:
 
 clone_profile:
   name: Clone profile
-  description: Create a new profile by copying all per-zone schedules from an existing one.
+  description: Create a new profile by copying all per-zone schedules from an existing one. Limit: 50 profiles per install.
   fields:
     source:
       name: Source

--- a/custom_components/comfort_band/services.yaml
+++ b/custom_components/comfort_band/services.yaml
@@ -208,7 +208,7 @@ import_legacy:
 
 create_profile:
   name: Create profile
-  description: Create a new (empty) profile. Zone schedules can be added afterward. Limit: 50 profiles per install.
+  description: "Create a new (empty) profile. Zone schedules can be added afterward. Limit: 50 profiles per install."
   fields:
     name:
       name: Name
@@ -227,7 +227,7 @@ create_profile:
 
 clone_profile:
   name: Clone profile
-  description: Create a new profile by copying all per-zone schedules from an existing one. Limit: 50 profiles per install.
+  description: "Create a new profile by copying all per-zone schedules from an existing one. Limit: 50 profiles per install."
   fields:
     source:
       name: Source

--- a/custom_components/comfort_band/services.yaml
+++ b/custom_components/comfort_band/services.yaml
@@ -11,7 +11,7 @@ set_schedule:
         text:
     profile:
       name: Profile
-      description: Profile name (e.g. "home", "away", "sleep")
+      description: Profile name (e.g. "home", "away")
       required: true
       example: home
       selector:
@@ -203,5 +203,77 @@ import_legacy:
       description: Slug of the zone in the legacy YAML (often the same as `zone`).
       required: true
       example: office
+      selector:
+        text:
+
+create_profile:
+  name: Create profile
+  description: Create a new (empty) profile. Zone schedules can be added afterward.
+  fields:
+    name:
+      name: Name
+      description: Profile name (unique).
+      required: true
+      example: weekend
+      selector:
+        text:
+    description:
+      name: Description
+      description: Optional human-readable description.
+      required: false
+      example: Relaxed band for weekend mornings.
+      selector:
+        text:
+
+clone_profile:
+  name: Clone profile
+  description: Create a new profile by copying all per-zone schedules from an existing one.
+  fields:
+    source:
+      name: Source
+      description: Existing profile to copy from.
+      required: true
+      example: home
+      selector:
+        text:
+    target:
+      name: Target
+      description: New profile name.
+      required: true
+      example: weekend
+      selector:
+        text:
+    description:
+      name: Description
+      description: Optional description for the new profile.
+      required: false
+      selector:
+        text:
+
+rename_profile:
+  name: Rename profile
+  description: Rename a profile. The active and default pointers update if they reference it.
+  fields:
+    old:
+      name: Old name
+      required: true
+      example: home
+      selector:
+        text:
+    new:
+      name: New name
+      required: true
+      example: weekday
+      selector:
+        text:
+
+delete_profile:
+  name: Delete profile
+  description: Delete a profile. Refuses to delete the default profile. If the active profile is deleted, the default becomes active.
+  fields:
+    name:
+      name: Name
+      required: true
+      example: trip
       selector:
         text:

--- a/custom_components/comfort_band/services.yaml
+++ b/custom_components/comfort_band/services.yaml
@@ -256,12 +256,14 @@ rename_profile:
   fields:
     old:
       name: Old name
+      description: Current name of the profile to rename.
       required: true
       example: home
       selector:
         text:
     new:
       name: New name
+      description: New name for the profile. Must not already exist.
       required: true
       example: weekday
       selector:
@@ -273,6 +275,7 @@ delete_profile:
   fields:
     name:
       name: Name
+      description: Profile to delete. Cannot be the default profile.
       required: true
       example: trip
       selector:

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -332,7 +332,10 @@ class ComfortBandStore:
         if name == self._data["default_profile"]:
             raise ValueError(f"Cannot delete the default profile {name!r}")
         if name not in self._data["profiles"]:
-            return
+            # Consistent with the sibling mutators (clone/rename) which both
+            # raise KeyError on unknown names. ProfileRegistry catches and
+            # re-raises as ServiceValidationError for the service layer.
+            raise KeyError(name)
         del self._data["profiles"][name]
         # Clean up orphan per-zone schedules — otherwise dead-weight on disk.
         for zone in self._data["zones"].values():

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -295,9 +295,7 @@ class ComfortBandStore:
         self._data["profiles"][name] = {"name": name, "description": description}
         await self.async_save()
 
-    async def async_clone_profile(
-        self, source: str, target: str, description: str = ""
-    ) -> None:
+    async def async_clone_profile(self, source: str, target: str, description: str = "") -> None:
         if source not in self._data["profiles"]:
             raise KeyError(source)
         if target in self._data["profiles"]:

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -164,6 +164,13 @@ class ComfortBandStore:
                 }
                 raw["default_profile"] = DEFAULT_PROFILE
             migrated = True
+        # Defensive: if active_profile points at a profile that no longer
+        # exists (corruption, hand-edited .storage), fall back to the default
+        # so subsequent `extra_state_attributes` / coordinator reads don't
+        # raise KeyError on every state push.
+        if raw.get("active_profile") not in raw.get("profiles", {}):
+            raw["active_profile"] = raw["default_profile"]
+            migrated = True
         if migrated:
             await self._store.async_save(self._data)
         self._loaded = True

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -38,6 +38,7 @@ from .const import (
     DEFAULT_MIN_CYCLE_MINUTES,
     DEFAULT_OVERRIDE_HOURS,
     DEFAULT_PROFILE,
+    MAX_PROFILES,
     SIGNAL_ZONE_SCHEDULE_CHANGED,
     STORAGE_KEY,
     STORAGE_VERSION,
@@ -279,6 +280,11 @@ class ComfortBandStore:
     async def async_add_profile(self, name: str, description: str = "") -> None:
         if name in self._data["profiles"]:
             raise ValueError(f"Profile {name!r} already exists")
+        if len(self._data["profiles"]) >= MAX_PROFILES:
+            raise ValueError(
+                f"Cannot create more than {MAX_PROFILES} profiles "
+                f"(currently {len(self._data['profiles'])})"
+            )
         self._data["profiles"][name] = {"name": name, "description": description}
         await self.async_save()
 
@@ -289,6 +295,11 @@ class ComfortBandStore:
             raise KeyError(source)
         if target in self._data["profiles"]:
             raise ValueError(f"Profile {target!r} already exists")
+        if len(self._data["profiles"]) >= MAX_PROFILES:
+            raise ValueError(
+                f"Cannot create more than {MAX_PROFILES} profiles "
+                f"(currently {len(self._data['profiles'])})"
+            )
         self._data["profiles"][target] = {"name": target, "description": description}
         for zone in self._data["zones"].values():
             src_schedule = zone["schedules"].get(source)

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -81,12 +81,16 @@ class StoredData(TypedDict):
     zones: dict[str, StoredZone]
     profiles: dict[str, StoredProfile]
     active_profile: str
+    # Rename-aware fallback target. Initialised to DEFAULT_PROFILE on first
+    # load; updated when that profile is renamed. Used by `async_remove_profile`
+    # to refuse deletion and by `ProfileRegistry.async_delete` to fall back to
+    # when the active profile is removed.
+    default_profile: str
 
 
 _BUILTIN_DESCRIPTIONS: dict[str, str] = {
     "home": "Default schedule when the house is occupied.",
     "away": "Cooler heating / warmer cooling for an empty house.",
-    "sleep": "Overnight schedule.",
 }
 
 
@@ -98,6 +102,7 @@ def _default_data() -> StoredData:
             for name in BUILTIN_PROFILES
         },
         "active_profile": DEFAULT_PROFILE,
+        "default_profile": DEFAULT_PROFILE,
     }
 
 
@@ -129,12 +134,37 @@ class ComfortBandStore:
         self._loaded = False
 
     async def async_load(self) -> None:
-        """Read from disk; default skeleton on first run. Idempotent."""
+        """Read from disk; default skeleton on first run. Idempotent.
+
+        Old payloads (v0.1) didn't have `default_profile`. If it's missing we
+        seed it from DEFAULT_PROFILE if that profile still exists; otherwise
+        fall back to the alphabetically-first profile and persist.
+        """
         if self._loaded:
             return
         loaded = await self._store.async_load()
         if loaded is not None:
             self._data = loaded
+        # `loaded` may be a v0.1 payload that doesn't have all fields of
+        # StoredData yet — cast to a plain dict to check + patch.
+        raw = cast(dict[str, Any], self._data)
+        migrated = False
+        if "default_profile" not in raw:
+            profiles = raw.get("profiles") or {}
+            if DEFAULT_PROFILE in profiles:
+                raw["default_profile"] = DEFAULT_PROFILE
+            elif profiles:
+                raw["default_profile"] = sorted(profiles.keys())[0]
+            else:
+                # Empty profile list is a corrupted store; reseed builtins.
+                raw["profiles"] = {
+                    name: {"name": name, "description": _BUILTIN_DESCRIPTIONS.get(name, "")}
+                    for name in BUILTIN_PROFILES
+                }
+                raw["default_profile"] = DEFAULT_PROFILE
+            migrated = True
+        if migrated:
+            await self._store.async_save(self._data)
         self._loaded = True
 
     async def async_save(self) -> None:
@@ -227,9 +257,18 @@ class ComfortBandStore:
     def list_profiles(self) -> list[str]:
         return sorted(self._data["profiles"].keys())
 
+    def get_profile(self, name: str) -> StoredProfile:
+        if name not in self._data["profiles"]:
+            raise KeyError(name)
+        return copy.deepcopy(self._data["profiles"][name])
+
     @property
     def active_profile(self) -> str:
         return self._data["active_profile"]
+
+    @property
+    def default_profile(self) -> str:
+        return self._data["default_profile"]
 
     async def async_set_active_profile(self, name: str) -> None:
         if name not in self._data["profiles"]:
@@ -243,10 +282,50 @@ class ComfortBandStore:
         self._data["profiles"][name] = {"name": name, "description": description}
         await self.async_save()
 
+    async def async_clone_profile(
+        self, source: str, target: str, description: str = ""
+    ) -> None:
+        if source not in self._data["profiles"]:
+            raise KeyError(source)
+        if target in self._data["profiles"]:
+            raise ValueError(f"Profile {target!r} already exists")
+        self._data["profiles"][target] = {"name": target, "description": description}
+        for zone in self._data["zones"].values():
+            src_schedule = zone["schedules"].get(source)
+            if src_schedule is not None:
+                zone["schedules"][target] = copy.deepcopy(src_schedule)
+        await self.async_save()
+
+    async def async_rename_profile(self, old: str, new: str) -> None:
+        if old not in self._data["profiles"]:
+            raise KeyError(old)
+        if old == new:
+            return
+        if new in self._data["profiles"]:
+            raise ValueError(f"Profile {new!r} already exists")
+        profile = self._data["profiles"].pop(old)
+        profile["name"] = new
+        self._data["profiles"][new] = profile
+        for zone in self._data["zones"].values():
+            if old in zone["schedules"]:
+                zone["schedules"][new] = zone["schedules"].pop(old)
+        if self._data["active_profile"] == old:
+            self._data["active_profile"] = new
+        if self._data["default_profile"] == old:
+            self._data["default_profile"] = new
+        await self.async_save()
+
     async def async_remove_profile(self, name: str) -> None:
-        if name == DEFAULT_PROFILE:
-            raise ValueError(f"Cannot delete the default profile {DEFAULT_PROFILE!r}")
-        self._data["profiles"].pop(name, None)
+        # `default_profile` is the rename-aware fallback target. It moves with
+        # renames, so this check works whether or not "home" still exists.
+        if name == self._data["default_profile"]:
+            raise ValueError(f"Cannot delete the default profile {name!r}")
+        if name not in self._data["profiles"]:
+            return
+        del self._data["profiles"][name]
+        # Clean up orphan per-zone schedules — otherwise dead-weight on disk.
+        for zone in self._data["zones"].values():
+            zone["schedules"].pop(name, None)
         if self._data["active_profile"] == name:
-            self._data["active_profile"] = DEFAULT_PROFILE
+            self._data["active_profile"] = self._data["default_profile"]
         await self.async_save()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -91,6 +91,34 @@ async def test_well_above_band_decides_cool(
     assert state.decision.target_temp == 22.5
 
 
+async def test_schedule_fallback_follows_renamed_default_profile(
+    hass: HomeAssistant, coordinator: ZoneCoordinator
+) -> None:
+    """When the active profile has no schedule, fall back to the *default
+    profile's* schedule — even after that profile has been renamed."""
+    # Seed a schedule on "home" then rename home -> weekday. The active
+    # profile is still "home" (now renamed), so the active key also
+    # changes; switch active to "away" (which has no schedule) to exercise
+    # the fallback path.
+    store = coordinator._store
+    await store.async_set_zone_schedule(
+        "office", "home", [{"at": "00:00", "low": 21.0, "high": 23.0}]
+    )
+    await store.async_rename_profile("home", "weekday")
+    await store.async_set_active_profile("away")  # away has no schedule
+    hass.states.async_set(TEMP_ENTITY, "22.0", {})
+    try:
+        state = await coordinator._async_update_data()
+        # Should fall back to "weekday" (the renamed default), not the manual band.
+        assert state.effective_low == 21.0
+        assert state.effective_high == 23.0
+    finally:
+        # The schedule update schedules a transition-timer; cancel it so
+        # pytest-homeassistant-custom-component's "lingering timer" guard
+        # doesn't trip in teardown.
+        await coordinator.async_unload()
+
+
 async def test_shadow_mode_does_not_call_climate(
     hass: HomeAssistant, coordinator: ZoneCoordinator
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -64,6 +64,34 @@ async def test_profile_manager_entry_creates_select(
     assert "occupied" in descriptions["home"].lower()
 
 
+async def test_select_entity_attributes_track_rename(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    profile_manager_entry: MockConfigEntry,
+) -> None:
+    """End-to-end: renaming the default profile updates the select entity's
+    `default_profile` and `descriptions` attributes (via the new
+    SIGNAL_PROFILE_LIST_CHANGED → async_write_ha_state path)."""
+    profile_manager_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(profile_manager_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "comfort_band",
+        "rename_profile",
+        {"old": "home", "new": "weekday"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.comfort_band_profiles_active_profile")
+    assert state is not None
+    assert state.state == "weekday"  # active also followed the rename
+    assert sorted(state.attributes["options"]) == ["away", "weekday"]
+    assert state.attributes["default_profile"] == "weekday"
+    assert set(state.attributes["descriptions"].keys()) == {"away", "weekday"}
+
+
 async def test_zone_room_temp_sensor_mirrors_external(
     hass: HomeAssistant, hass_storage: dict[str, Any], make_zone_entry: Any
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -56,7 +56,12 @@ async def test_profile_manager_entry_creates_select(
     state = hass.states.get("select.comfort_band_profiles_active_profile")
     assert state is not None
     assert state.state == "home"
-    assert sorted(state.attributes["options"]) == ["away", "home", "sleep"]
+    assert sorted(state.attributes["options"]) == ["away", "home"]
+    assert state.attributes["default_profile"] == "home"
+    # Per-profile descriptions exposed alongside options for the card.
+    descriptions = state.attributes["descriptions"]
+    assert set(descriptions.keys()) == {"away", "home"}
+    assert "occupied" in descriptions["home"].lower()
 
 
 async def test_zone_room_temp_sensor_mirrors_external(

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -23,7 +23,7 @@ def test_manifest_shape() -> None:
     assert manifest["integration_type"] == "helper"
     assert manifest["iot_class"] == "local_push"
     assert manifest["codeowners"] == ["@dpretty"]
-    assert manifest["version"] == "0.2.0"
+    assert manifest["version"] == "0.3.0"
     assert manifest["documentation"].startswith("https://")
     assert manifest["issue_tracker"].startswith("https://")
     assert manifest["requirements"] == []

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -246,3 +246,30 @@ async def test_delete_fires_list_signal(
     finally:
         unsub()
     assert len(received) == 1
+
+
+async def test_delete_active_after_default_rename_signals_new_default(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Regression test for the rename-aware default-profile fallback:
+    after `home` is renamed to `weekday`, deleting whichever profile is
+    active should fall back to `weekday`, NOT to the literal `home`."""
+    registry = await _make_registry(hass)
+    await registry.async_rename("home", "weekday")
+    await registry.async_create("trip")
+    await registry.async_set_active("trip")
+
+    received: list[str] = []
+
+    @callback
+    def on_change(name: str) -> None:
+        received.append(name)
+
+    unsub = async_dispatcher_connect(hass, SIGNAL_ACTIVE_PROFILE_CHANGED, on_change)
+    try:
+        await registry.async_delete("trip")
+    finally:
+        unsub()
+
+    assert received == ["weekday"]
+    assert registry.active == "weekday"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -28,7 +28,7 @@ async def test_active_starts_at_default(hass: HomeAssistant, hass_storage: dict[
     assert registry.default == "home"
     assert "home" in registry.names
     assert "away" in registry.names
-    assert "sleep" not in registry.names  # dropped from built-ins in v0.2
+    assert "sleep" not in registry.names  # dropped from built-ins in v0.3
 
 
 async def test_set_active_dispatches_signal(

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -8,7 +8,10 @@ import pytest
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from custom_components.comfort_band.const import SIGNAL_ACTIVE_PROFILE_CHANGED
+from custom_components.comfort_band.const import (
+    SIGNAL_ACTIVE_PROFILE_CHANGED,
+    SIGNAL_PROFILE_LIST_CHANGED,
+)
 from custom_components.comfort_band.profiles import ProfileRegistry
 from custom_components.comfort_band.storage import ComfortBandStore
 
@@ -22,9 +25,10 @@ async def _make_registry(hass: HomeAssistant) -> ProfileRegistry:
 async def test_active_starts_at_default(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
     registry = await _make_registry(hass)
     assert registry.active == "home"
+    assert registry.default == "home"
     assert "home" in registry.names
     assert "away" in registry.names
-    assert "sleep" in registry.names
+    assert "sleep" not in registry.names  # dropped from built-ins in v0.2
 
 
 async def test_set_active_dispatches_signal(
@@ -103,3 +107,142 @@ async def test_delete_active_profile_falls_back_and_signals(
 
     assert registry.active == "home"
     assert received == ["home"]
+
+
+# ----- list-changed signal -----
+
+
+async def test_create_fires_list_signal(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    registry = await _make_registry(hass)
+    received: list[None] = []
+
+    @callback
+    def on_change() -> None:
+        received.append(None)
+
+    unsub = async_dispatcher_connect(hass, SIGNAL_PROFILE_LIST_CHANGED, on_change)
+    try:
+        await registry.async_create("weekend", "Saturday + Sunday")
+    finally:
+        unsub()
+    assert len(received) == 1
+
+
+async def test_clone_copies_schedules_and_fires_list_signal(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    registry = await _make_registry(hass)
+    # Seed home with a schedule for one zone so the clone copies it.
+    await registry._store.async_add_zone("office")
+    await registry._store.async_set_zone_schedule(
+        "office", "home", [{"at": "06:00", "low": 20.0, "high": 23.0}]
+    )
+
+    received: list[None] = []
+
+    @callback
+    def on_change() -> None:
+        received.append(None)
+
+    unsub = async_dispatcher_connect(hass, SIGNAL_PROFILE_LIST_CHANGED, on_change)
+    try:
+        await registry.async_clone("home", "weekend", "Saturdays + Sundays")
+    finally:
+        unsub()
+
+    assert "weekend" in registry.names
+    assert registry.description("weekend") == "Saturdays + Sundays"
+    cloned = registry._store.get_zone_schedule("office", "weekend")
+    assert cloned is not None
+    assert cloned["baseline"][0]["at"] == "06:00"
+    assert len(received) == 1
+
+
+async def test_rename_non_active_fires_list_signal_only(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    registry = await _make_registry(hass)
+    list_signals: list[None] = []
+    active_signals: list[str] = []
+
+    @callback
+    def on_list_only() -> None:
+        list_signals.append(None)
+
+    @callback
+    def on_active_capture(name: str) -> None:
+        active_signals.append(name)
+
+    unsub_list = async_dispatcher_connect(hass, SIGNAL_PROFILE_LIST_CHANGED, on_list_only)
+    unsub_active = async_dispatcher_connect(
+        hass, SIGNAL_ACTIVE_PROFILE_CHANGED, on_active_capture
+    )
+    try:
+        await registry.async_rename("away", "trip")  # active is "home"
+    finally:
+        unsub_list()
+        unsub_active()
+
+    assert len(list_signals) == 1
+    assert active_signals == []  # not the active profile
+
+
+async def test_rename_active_fires_both_signals(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    registry = await _make_registry(hass)
+    await registry.async_set_active("away")
+    list_signals: list[None] = []
+    active_signals: list[str] = []
+
+    @callback
+    def on_list() -> None:
+        list_signals.append(None)
+
+    @callback
+    def on_active(name: str) -> None:
+        active_signals.append(name)
+
+    unsub_list = async_dispatcher_connect(hass, SIGNAL_PROFILE_LIST_CHANGED, on_list)
+    unsub_active = async_dispatcher_connect(hass, SIGNAL_ACTIVE_PROFILE_CHANGED, on_active)
+    try:
+        await registry.async_rename("away", "trip")
+    finally:
+        unsub_list()
+        unsub_active()
+
+    assert len(list_signals) == 1
+    assert active_signals == ["trip"]
+    assert registry.active == "trip"
+
+
+async def test_rename_default_moves_default_pointer(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    registry = await _make_registry(hass)
+    await registry.async_rename("home", "weekday")
+    assert registry.default == "weekday"
+    # Renamed default still cannot be deleted.
+    with pytest.raises(ValueError, match="Cannot delete the default profile"):
+        await registry.async_delete("weekday")
+
+
+async def test_delete_fires_list_signal(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    registry = await _make_registry(hass)
+    await registry.async_create("vacation")
+    received: list[None] = []
+
+    @callback
+    def on_change() -> None:
+        received.append(None)
+
+    unsub = async_dispatcher_connect(hass, SIGNAL_PROFILE_LIST_CHANGED, on_change)
+    try:
+        await registry.async_delete("vacation")
+    finally:
+        unsub()
+    assert len(received) == 1

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -112,9 +112,7 @@ async def test_delete_active_profile_falls_back_and_signals(
 # ----- list-changed signal -----
 
 
-async def test_create_fires_list_signal(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
-) -> None:
+async def test_create_fires_list_signal(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
     registry = await _make_registry(hass)
     received: list[None] = []
 
@@ -176,9 +174,7 @@ async def test_rename_non_active_fires_list_signal_only(
         active_signals.append(name)
 
     unsub_list = async_dispatcher_connect(hass, SIGNAL_PROFILE_LIST_CHANGED, on_list_only)
-    unsub_active = async_dispatcher_connect(
-        hass, SIGNAL_ACTIVE_PROFILE_CHANGED, on_active_capture
-    )
+    unsub_active = async_dispatcher_connect(hass, SIGNAL_ACTIVE_PROFILE_CHANGED, on_active_capture)
     try:
         await registry.async_rename("away", "trip")  # active is "home"
     finally:
@@ -229,9 +225,7 @@ async def test_rename_default_moves_default_pointer(
         await registry.async_delete("weekday")
 
 
-async def test_delete_fires_list_signal(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
-) -> None:
+async def test_delete_fires_list_signal(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
     registry = await _make_registry(hass)
     await registry.async_create("vacation")
     received: list[None] = []

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -40,6 +40,10 @@ async def test_all_services_registered(
         "cancel_override",
         "set_profile",
         "import_legacy",
+        "create_profile",
+        "clone_profile",
+        "rename_profile",
+        "delete_profile",
     }
     for service in expected:
         assert hass.services.has_service(DOMAIN, service), f"missing service: {service}"
@@ -213,4 +217,149 @@ async def test_import_legacy_missing_source_helpers_raises(
             "import_legacy",
             {"zone": "office", "source_zone_name": "office"},
             blocking=True,
+        )
+
+
+# ----- profile CRUD services -----
+
+
+async def test_create_profile_service(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    await hass.services.async_call(
+        DOMAIN,
+        "create_profile",
+        {"name": "weekend", "description": "Saturdays + Sundays"},
+        blocking=True,
+    )
+    registry = hass.data[DOMAIN].profile_registry
+    assert "weekend" in registry.names
+    assert registry.description("weekend") == "Saturdays + Sundays"
+
+
+async def test_create_profile_blank_name_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError, match="cannot be empty"):
+        await hass.services.async_call(
+            DOMAIN, "create_profile", {"name": "   "}, blocking=True
+        )
+
+
+async def test_create_profile_duplicate_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError, match="already exists"):
+        await hass.services.async_call(
+            DOMAIN, "create_profile", {"name": "home"}, blocking=True
+        )
+
+
+async def test_clone_profile_service(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    # Seed a schedule on home so the clone has something to copy.
+    await hass.services.async_call(
+        DOMAIN,
+        "set_schedule",
+        {
+            "zone": "office",
+            "profile": "home",
+            "transitions": [{"at": "06:00", "low": 20.0, "high": 23.0}],
+        },
+        blocking=True,
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        "clone_profile",
+        {"source": "home", "target": "weekend"},
+        blocking=True,
+    )
+    store = hass.data[DOMAIN].store
+    cloned = store.get_zone_schedule("office", "weekend")
+    assert cloned is not None
+    assert cloned["baseline"][0]["at"] == "06:00"
+
+
+async def test_clone_profile_unknown_source_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "clone_profile",
+            {"source": "ghost", "target": "new"},
+            blocking=True,
+        )
+
+
+async def test_clone_profile_duplicate_target_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError, match="already exists"):
+        await hass.services.async_call(
+            DOMAIN,
+            "clone_profile",
+            {"source": "home", "target": "away"},
+            blocking=True,
+        )
+
+
+async def test_rename_profile_service(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    await hass.services.async_call(
+        DOMAIN,
+        "rename_profile",
+        {"old": "away", "new": "trip"},
+        blocking=True,
+    )
+    registry = hass.data[DOMAIN].profile_registry
+    assert "trip" in registry.names
+    assert "away" not in registry.names
+
+
+async def test_rename_profile_blank_new_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError, match="cannot be empty"):
+        await hass.services.async_call(
+            DOMAIN,
+            "rename_profile",
+            {"old": "away", "new": "   "},
+            blocking=True,
+        )
+
+
+async def test_rename_profile_unknown_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "rename_profile",
+            {"old": "ghost", "new": "new"},
+            blocking=True,
+        )
+
+
+async def test_delete_profile_service(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    await hass.services.async_call(
+        DOMAIN, "create_profile", {"name": "vacation"}, blocking=True
+    )
+    await hass.services.async_call(
+        DOMAIN, "delete_profile", {"name": "vacation"}, blocking=True
+    )
+    registry = hass.data[DOMAIN].profile_registry
+    assert "vacation" not in registry.names
+
+
+async def test_delete_default_profile_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError, match="Cannot delete the default profile"):
+        await hass.services.async_call(
+            DOMAIN, "delete_profile", {"name": "home"}, blocking=True
         )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -241,18 +241,14 @@ async def test_create_profile_blank_name_raises(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:
     with pytest.raises(ServiceValidationError, match="cannot be empty"):
-        await hass.services.async_call(
-            DOMAIN, "create_profile", {"name": "   "}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, "create_profile", {"name": "   "}, blocking=True)
 
 
 async def test_create_profile_duplicate_raises(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:
     with pytest.raises(ServiceValidationError, match="already exists"):
-        await hass.services.async_call(
-            DOMAIN, "create_profile", {"name": "home"}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, "create_profile", {"name": "home"}, blocking=True)
 
 
 async def test_clone_profile_service(
@@ -346,12 +342,8 @@ async def test_rename_profile_unknown_raises(
 async def test_delete_profile_service(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:
-    await hass.services.async_call(
-        DOMAIN, "create_profile", {"name": "vacation"}, blocking=True
-    )
-    await hass.services.async_call(
-        DOMAIN, "delete_profile", {"name": "vacation"}, blocking=True
-    )
+    await hass.services.async_call(DOMAIN, "create_profile", {"name": "vacation"}, blocking=True)
+    await hass.services.async_call(DOMAIN, "delete_profile", {"name": "vacation"}, blocking=True)
     registry = hass.data[DOMAIN].profile_registry
     assert "vacation" not in registry.names
 
@@ -360,9 +352,7 @@ async def test_delete_default_profile_raises(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:
     with pytest.raises(ServiceValidationError, match="Cannot delete the default profile"):
-        await hass.services.async_call(
-            DOMAIN, "delete_profile", {"name": "home"}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, "delete_profile", {"name": "home"}, blocking=True)
 
 
 async def test_delete_unknown_profile_raises(
@@ -372,9 +362,7 @@ async def test_delete_unknown_profile_raises(
     # mutators; the service catches (KeyError, ValueError) and wraps as
     # ServiceValidationError. The name is echoed in the wrapped message.
     with pytest.raises(ServiceValidationError, match="ghost"):
-        await hass.services.async_call(
-            DOMAIN, "delete_profile", {"name": "ghost"}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, "delete_profile", {"name": "ghost"}, blocking=True)
 
 
 async def test_create_profile_name_length_capped(
@@ -385,9 +373,7 @@ async def test_create_profile_name_length_capped(
     from voluptuous import MultipleInvalid
 
     with pytest.raises((MultipleInvalid, ServiceValidationError)):
-        await hass.services.async_call(
-            DOMAIN, "create_profile", {"name": "x" * 65}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, "create_profile", {"name": "x" * 65}, blocking=True)
 
 
 async def test_create_profile_at_cap_raises_via_service_layer(
@@ -400,9 +386,7 @@ async def test_create_profile_at_cap_raises_via_service_layer(
 
     # Fill up to cap (2 builtins already exist).
     for i in range(MAX_PROFILES - 2):
-        await hass.services.async_call(
-            DOMAIN, "create_profile", {"name": f"p{i}"}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, "create_profile", {"name": f"p{i}"}, blocking=True)
     with pytest.raises(ServiceValidationError, match=f"more than {MAX_PROFILES}"):
         await hass.services.async_call(
             DOMAIN, "create_profile", {"name": "one_too_many"}, blocking=True
@@ -417,9 +401,7 @@ async def test_clone_profile_at_cap_raises_via_service_layer(
     from custom_components.comfort_band.const import MAX_PROFILES
 
     for i in range(MAX_PROFILES - 2):
-        await hass.services.async_call(
-            DOMAIN, "create_profile", {"name": f"p{i}"}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, "create_profile", {"name": f"p{i}"}, blocking=True)
     with pytest.raises(ServiceValidationError, match=f"more than {MAX_PROFILES}"):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -363,3 +363,47 @@ async def test_delete_default_profile_raises(
         await hass.services.async_call(
             DOMAIN, "delete_profile", {"name": "home"}, blocking=True
         )
+
+
+async def test_delete_unknown_profile_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError, match="does not exist"):
+        await hass.services.async_call(
+            DOMAIN, "delete_profile", {"name": "ghost"}, blocking=True
+        )
+
+
+async def test_create_profile_name_length_capped(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    # voluptuous Length validator raises MultipleInvalid before our handler
+    # ever sees the value; HA wraps that into ServiceValidationError.
+    from voluptuous import MultipleInvalid
+
+    with pytest.raises((MultipleInvalid, ServiceValidationError)):
+        await hass.services.async_call(
+            DOMAIN, "create_profile", {"name": "x" * 65}, blocking=True
+        )
+
+
+async def test_import_legacy_writes_to_default_after_home_rename(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """Importer should follow the renamed `home` (default_profile), not the
+    literal "home" string. Regression guard for the rename-aware fallback."""
+    _seed_legacy(hass, "office", 20.0, 23.0)
+    # Rename home → weekday before importing.
+    await hass.services.async_call(
+        DOMAIN, "rename_profile", {"old": "home", "new": "weekday"}, blocking=True
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        "import_legacy",
+        {"zone": "office", "source_zone_name": "office"},
+        blocking=True,
+    )
+    store = hass.data[DOMAIN].store
+    # Schedule landed on the renamed default, not on the now-absent "home".
+    assert store.get_zone_schedule("office", "weekday") is not None
+    assert store.get_zone_schedule("office", "home") is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -387,6 +387,27 @@ async def test_create_profile_name_length_capped(
         )
 
 
+async def test_clone_profile_empty_source_raises_clear_error(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError, match="Source profile name cannot be empty"):
+        await hass.services.async_call(
+            DOMAIN,
+            "clone_profile",
+            {"source": "   ", "target": "weekend"},
+            blocking=True,
+        )
+
+
+async def test_rename_profile_empty_old_raises_clear_error(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    with pytest.raises(ServiceValidationError, match="Old profile name cannot be empty"):
+        await hass.services.async_call(
+            DOMAIN, "rename_profile", {"old": "  ", "new": "trip"}, blocking=True
+        )
+
+
 async def test_import_legacy_writes_to_default_after_home_rename(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -390,6 +390,25 @@ async def test_create_profile_name_length_capped(
         )
 
 
+async def test_create_profile_at_cap_raises_via_service_layer(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """The cap is enforced at the storage layer; verify the error
+    propagates through the service handler as ServiceValidationError so
+    the card surfaces it via the existing error-handling path."""
+    from custom_components.comfort_band.const import MAX_PROFILES
+
+    # Fill up to cap (2 builtins already exist).
+    for i in range(MAX_PROFILES - 2):
+        await hass.services.async_call(
+            DOMAIN, "create_profile", {"name": f"p{i}"}, blocking=True
+        )
+    with pytest.raises(ServiceValidationError, match=f"more than {MAX_PROFILES}"):
+        await hass.services.async_call(
+            DOMAIN, "create_profile", {"name": "one_too_many"}, blocking=True
+        )
+
+
 async def test_clone_profile_empty_source_raises_clear_error(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -409,6 +409,26 @@ async def test_create_profile_at_cap_raises_via_service_layer(
         )
 
 
+async def test_clone_profile_at_cap_raises_via_service_layer(
+    hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
+) -> None:
+    """Symmetric to test_create_profile_at_cap — clone hits the same
+    storage-level cap and must surface ServiceValidationError."""
+    from custom_components.comfort_band.const import MAX_PROFILES
+
+    for i in range(MAX_PROFILES - 2):
+        await hass.services.async_call(
+            DOMAIN, "create_profile", {"name": f"p{i}"}, blocking=True
+        )
+    with pytest.raises(ServiceValidationError, match=f"more than {MAX_PROFILES}"):
+        await hass.services.async_call(
+            DOMAIN,
+            "clone_profile",
+            {"source": "home", "target": "extra"},
+            blocking=True,
+        )
+
+
 async def test_clone_profile_empty_source_raises_clear_error(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -368,7 +368,10 @@ async def test_delete_default_profile_raises(
 async def test_delete_unknown_profile_raises(
     hass: HomeAssistant, hass_storage: dict[str, Any], setup_zone: None
 ) -> None:
-    with pytest.raises(ServiceValidationError, match="does not exist"):
+    # Storage raises KeyError(name) consistent with the clone/rename
+    # mutators; the service catches (KeyError, ValueError) and wraps as
+    # ServiceValidationError. The name is echoed in the wrapped message.
+    with pytest.raises(ServiceValidationError, match="ghost"):
         await hass.services.async_call(
             DOMAIN, "delete_profile", {"name": "ghost"}, blocking=True
         )

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -444,6 +444,36 @@ async def test_clone_profile_without_source_schedule_creates_empty_target(
     assert store.get_zone_schedule("office", "weekend") is None
 
 
+async def test_add_profile_count_cap(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Cap on total profile count guards against unbounded growth of the
+    .storage file from a misbehaving caller."""
+    from custom_components.comfort_band.const import MAX_PROFILES
+
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    # Built-ins already use 2 slots; fill up to MAX_PROFILES.
+    for i in range(MAX_PROFILES - 2):
+        await store.async_add_profile(f"p{i}")
+    assert len(store.list_profiles()) == MAX_PROFILES
+    with pytest.raises(ValueError, match=f"more than {MAX_PROFILES}"):
+        await store.async_add_profile("one_too_many")
+
+
+async def test_clone_profile_count_cap(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    from custom_components.comfort_band.const import MAX_PROFILES
+
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    for i in range(MAX_PROFILES - 2):
+        await store.async_add_profile(f"p{i}")
+    with pytest.raises(ValueError, match=f"more than {MAX_PROFILES}"):
+        await store.async_clone_profile("home", "extra")
+
+
 async def test_set_zone_schedule_fires_signal(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -314,9 +314,7 @@ async def test_rename_to_existing_name_raises(
         await store.async_rename_profile("away", "home")
 
 
-async def test_rename_unknown_raises(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
-) -> None:
+async def test_rename_unknown_raises(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
     store = ComfortBandStore(hass)
     await store.async_load()
     with pytest.raises(KeyError):
@@ -444,9 +442,7 @@ async def test_clone_profile_without_source_schedule_creates_empty_target(
     assert store.get_zone_schedule("office", "weekend") is None
 
 
-async def test_add_profile_count_cap(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
-) -> None:
+async def test_add_profile_count_cap(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
     """Cap on total profile count guards against unbounded growth of the
     .storage file from a misbehaving caller."""
     from custom_components.comfort_band.const import MAX_PROFILES
@@ -461,9 +457,7 @@ async def test_add_profile_count_cap(
         await store.async_add_profile("one_too_many")
 
 
-async def test_clone_profile_count_cap(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
-) -> None:
+async def test_clone_profile_count_cap(hass: HomeAssistant, hass_storage: dict[str, Any]) -> None:
     from custom_components.comfort_band.const import MAX_PROFILES
 
     store = ComfortBandStore(hass)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -20,8 +20,9 @@ async def test_first_load_returns_default_skeleton(
     store = ComfortBandStore(hass)
     await store.async_load()
     assert store.list_zones() == []
-    assert store.list_profiles() == ["away", "home", "sleep"]
+    assert store.list_profiles() == ["away", "home"]
     assert store.active_profile == "home"
+    assert store.default_profile == "home"
 
 
 async def test_default_zone_has_sane_initial_values(
@@ -195,6 +196,198 @@ async def test_set_zone_schedule_independent_lists(
     schedule = store.get_zone_schedule("office", "home")
     assert schedule is not None
     assert schedule["baseline"][0]["low"] == 20.0
+
+
+# ----- profile CRUD: clone / rename / migration -----
+
+
+async def test_get_profile_returns_deep_copy(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    profile = store.get_profile("home")
+    profile["description"] = "tampered"
+    assert store.get_profile("home")["description"] != "tampered"
+
+
+async def test_get_profile_unknown_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    with pytest.raises(KeyError):
+        store.get_profile("vacation")
+
+
+async def test_clone_profile_copies_per_zone_schedules(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_add_zone("office")
+    baseline = [{"at": "06:00", "low": 20.0, "high": 23.0}]
+    await store.async_set_zone_schedule("office", "home", baseline)
+
+    await store.async_clone_profile("home", "weekend", "Saturdays + Sundays")
+
+    assert "weekend" in store.list_profiles()
+    assert store.get_profile("weekend")["description"] == "Saturdays + Sundays"
+    cloned = store.get_zone_schedule("office", "weekend")
+    assert cloned is not None
+    assert cloned["baseline"] == baseline
+    # Mutate the source schedule; cloned must be independent.
+    await store.async_set_zone_schedule(
+        "office", "home", [{"at": "07:00", "low": 21.0, "high": 22.0}]
+    )
+    cloned_after = store.get_zone_schedule("office", "weekend")
+    assert cloned_after is not None
+    assert cloned_after["baseline"] == baseline
+
+
+async def test_clone_to_existing_target_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    with pytest.raises(ValueError, match="already exists"):
+        await store.async_clone_profile("home", "away")
+
+
+async def test_clone_from_unknown_source_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    with pytest.raises(KeyError):
+        await store.async_clone_profile("ghost", "new")
+
+
+async def test_rename_profile_renames_in_profiles_and_zones(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_add_zone("office")
+    await store.async_set_zone_schedule(
+        "office", "away", [{"at": "06:00", "low": 18.0, "high": 21.0}]
+    )
+
+    await store.async_rename_profile("away", "trip")
+
+    assert "trip" in store.list_profiles()
+    assert "away" not in store.list_profiles()
+    assert store.get_profile("trip")["name"] == "trip"
+    # Schedule key followed the rename.
+    assert store.get_zone_schedule("office", "trip") is not None
+    assert store.get_zone_schedule("office", "away") is None
+
+
+async def test_rename_active_profile_updates_active_pointer(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_set_active_profile("away")
+    await store.async_rename_profile("away", "trip")
+    assert store.active_profile == "trip"
+
+
+async def test_rename_default_profile_updates_default_pointer(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_rename_profile("home", "weekday")
+    assert store.default_profile == "weekday"
+    # And deletion of the new default name is now refused.
+    with pytest.raises(ValueError, match="Cannot delete the default profile"):
+        await store.async_remove_profile("weekday")
+
+
+async def test_rename_to_existing_name_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    with pytest.raises(ValueError, match="already exists"):
+        await store.async_rename_profile("away", "home")
+
+
+async def test_rename_unknown_raises(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    with pytest.raises(KeyError):
+        await store.async_rename_profile("ghost", "new")
+
+
+async def test_rename_noop_returns_quickly(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_rename_profile("home", "home")  # no-op
+    assert store.list_profiles() == ["away", "home"]
+
+
+async def test_remove_profile_strips_zone_schedules(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_add_zone("office")
+    await store.async_set_zone_schedule(
+        "office", "away", [{"at": "06:00", "low": 18.0, "high": 21.0}]
+    )
+    assert store.get_zone_schedule("office", "away") is not None
+    await store.async_remove_profile("away")
+    # Orphan schedule cleaned up.
+    assert store.get_zone_schedule("office", "away") is None
+
+
+async def test_remove_profile_after_default_rename_uses_new_name(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Rename of `home` to e.g. `weekday` should leave `weekday` undeletable
+    (because it's still the default). The literal string "home" is no longer
+    privileged after a rename."""
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_rename_profile("home", "weekday")
+    # Re-create a profile named "home" — should now be deletable, since it
+    # is no longer the default.
+    await store.async_add_profile("home", "user-recreated")
+    await store.async_remove_profile("home")
+    assert "home" not in store.list_profiles()
+
+
+async def test_load_legacy_data_without_default_profile_migrates(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """A v0.1 payload (no `default_profile` key) should migrate to `home`."""
+    hass_storage["comfort_band.data"] = {
+        "version": 1,
+        "data": {
+            "zones": {},
+            "profiles": {
+                "home": {"name": "home", "description": ""},
+                "away": {"name": "away", "description": ""},
+                "sleep": {"name": "sleep", "description": "Overnight schedule."},
+            },
+            "active_profile": "home",
+            # NB: no `default_profile` key.
+        },
+    }
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    assert store.default_profile == "home"
+    # The legacy "sleep" profile survives as a normal user profile.
+    assert "sleep" in store.list_profiles()
+    # And is deletable now (no longer a built-in, not the default).
+    await store.async_remove_profile("sleep")
+    assert "sleep" not in store.list_profiles()
 
 
 async def test_set_zone_schedule_fires_signal(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -390,6 +390,60 @@ async def test_load_legacy_data_without_default_profile_migrates(
     assert "sleep" not in store.list_profiles()
 
 
+async def test_load_legacy_data_without_home_uses_first_alphabetical(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """If `home` doesn't exist on legacy load, fall back to the first
+    alphabetical profile as the new default."""
+    hass_storage["comfort_band.data"] = {
+        "version": 1,
+        "data": {
+            "zones": {},
+            "profiles": {
+                "zulu": {"name": "zulu", "description": ""},
+                "alpha": {"name": "alpha", "description": ""},
+            },
+            "active_profile": "zulu",
+        },
+    }
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    assert store.default_profile == "alpha"
+
+
+async def test_load_legacy_data_with_empty_profiles_reseeds_builtins(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """If the legacy payload has an empty profiles dict (corruption case),
+    reseed the built-ins and set default_profile to home."""
+    hass_storage["comfort_band.data"] = {
+        "version": 1,
+        "data": {
+            "zones": {},
+            "profiles": {},
+            "active_profile": "home",
+        },
+    }
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    assert store.default_profile == "home"
+    assert set(store.list_profiles()) == {"home", "away"}
+
+
+async def test_clone_profile_without_source_schedule_creates_empty_target(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Cloning a profile when the source has no schedule for a zone leaves
+    the zone with no schedule for the target either — not an error."""
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    await store.async_add_zone("office")
+    # No schedule seeded on "home" for office.
+    await store.async_clone_profile("home", "weekend")
+    assert "weekend" in store.list_profiles()
+    assert store.get_zone_schedule("office", "weekend") is None
+
+
 async def test_set_zone_schedule_fires_signal(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:


### PR DESCRIPTION
## Summary

Implements [#4](https://github.com/dpretty/ha-comfort-band/issues/4) — adds the four CRUD services that back the card's new Profiles-tab UI (Clone / Rename / Delete via per-row overflow menu; **+ New profile** at the top of the list).

Cross-repo: the card-side changes ship in [dpretty/ha-comfort-band-card](https://github.com/dpretty/ha-comfort-band-card) v0.6.0 (PR linked below).

## Changes

- **Storage** (`storage.py`):
  - Adds `default_profile` field — a rename-aware "always-exists" fallback target. Replaces the hardcoded `DEFAULT_PROFILE = "home"` literal for delete-protection and active-fallback logic.
  - `async_rename_profile`, `async_clone_profile` (deep-copies per-zone schedules), `get_profile`.
  - `async_remove_profile` now strips orphan per-zone schedules.
  - Migration on load: v0.1 payloads (no `default_profile`) get seeded with `home` and persisted.
- **Built-ins narrowed to `home` + `away`** — `sleep` was redundant (each profile is a full 24-hour schedule). Existing `sleep` profiles on upgraded installs are preserved as normal user profiles; they can be renamed or deleted via the new UI.
- **ProfileRegistry** (`profiles.py`): four async wrappers + dispatch a new `SIGNAL_PROFILE_LIST_CHANGED` on every mutation. Rename of the active profile also fires `SIGNAL_ACTIVE_PROFILE_CHANGED` with the new name.
- **Select entity** (`select.py`, `entity.py`): subscribes to both signals; exposes `default_profile` + per-profile `descriptions` via `extra_state_attributes` so the card has everything it needs from a single entity push.
- **Services** (`services.py`, `services.yaml`): `comfort_band.create_profile`, `clone_profile`, `rename_profile`, `delete_profile`. Validation errors surface as `ServiceValidationError`.

## Test plan

- [x] `pytest tests/ -q` — 142 passed (up from 121; +21 new tests).
- [x] `mypy custom_components/comfort_band` — clean.
- [x] `ruff check .` — clean.
- [x] 10× test loop stability check passes.
- [ ] Live HA: HACS update → reload dashboard → Profiles tab; create, clone, rename, delete; verify the active-fallback (default) cannot be deleted; verify rename of `home` moves the fallback target with it.

## Migration notes

- New `default_profile` field auto-seeds to `home` on load if missing.
- `sleep` is no longer a built-in but existing `sleep` profiles persist.
- Bumps manifest to **v0.3.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)