### PR TITLE
Cross-mode min-cycle dwell (v0.5.0) (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Each zone gets its own band, override, and per-profile schedule. A **profile** (
 
 ## Status
 
-**v0.4.0.** Adds apparent-temperature support: a per-zone optional **humidity sensor** (configurable via ConfigFlow or a new OptionsFlow on existing zones), a new `sensor.{zone}_apparent_temperature` (Steadman 1994 simplified; equals room temp when no humidity is configured), and a per-zone `switch.{zone}_use_apparent_temperature` toggle that feeds the apparent value into hysteresis decisions instead of the raw room reading. Decisions fall back to the raw reading automatically when the humidity sensor is unavailable. Also adds `switch.{zone}_learning_enabled` — a master gate for the v0.4+ learning cluster (#9, #11); no decision effect today but the storage field is wired so future PRs read it directly.
+**v0.5.0.** Adds **cross-mode min-cycle dwell** to suppress rapid `heat ↔ cool` mode flips ([#16](https://github.com/dpretty/ha-comfort-band/issues/16)). New per-zone `number.{zone}_cross_mode_min_minutes` defaults to the zone's current `min_cycle_minutes` (8 by default) — `heat → cool` and `cool → heat` transitions now wait that many minutes after the last action. Idle releases (`heat → idle`, `cool → idle`) still fire immediately so a heat or cool cycle can always stop. **Behaviour change for existing users:** mode flips previously fired instantly; set the new entity to `0` to restore that.
+
+**v0.4.0** added apparent-temperature support: a per-zone optional **humidity sensor** (configurable via ConfigFlow or a new OptionsFlow on existing zones), a new `sensor.{zone}_apparent_temperature` (Steadman 1994 simplified; equals room temp when no humidity is configured), and a per-zone `switch.{zone}_use_apparent_temperature` toggle that feeds the apparent value into hysteresis decisions instead of the raw room reading. Decisions fall back to the raw reading automatically when the humidity sensor is unavailable. Also adds `switch.{zone}_learning_enabled` — a master gate for the v0.4+ learning cluster (#9, #11); no decision effect today but the storage field is wired so future PRs read it directly.
 
 **v0.3.0** added full profile CRUD: four new services (`create_profile`, `clone_profile`, `rename_profile`, `delete_profile`) and a new `SIGNAL_PROFILE_LIST_CHANGED` dispatcher signal so the singleton select entity (and any subscribed cards) re-render on every profile mutation. The `default_profile` is now tracked per-store and survives renames — whatever profile holds that role cannot be deleted. Built-in profiles narrowed from `home / away / sleep` to **`home` + `away`**; existing installs keep any `sleep` profile they had as a normal user profile that can now be renamed or deleted.
 
@@ -44,7 +46,7 @@ A Lovelace card lives in a separate repo: **[dpretty/ha-comfort-band-card](https
 | Platform | Entity | Notes |
 |---|---|---|
 | `number` | `manual_low`, `manual_high` | UI writes start an override |
-| `number` | `override_hours`, `deadband_below`, `deadband_above`, `min_cycle_minutes` | Tunables |
+| `number` | `override_hours`, `deadband_below`, `deadband_above`, `min_cycle_minutes`, `cross_mode_min_minutes` | Tunables |
 | `sensor` | `effective_low`, `effective_high` | Active band (override or schedule) |
 | `sensor` | `room_temperature` | Diagnostic mirror of the source sensor. Carries `humidity_sensor` (the configured entity_id, or null) as a state attribute. |
 | `sensor` | `apparent_temperature` | Steadman 1994 "feels like". Equals room temp when no humidity sensor is configured. |

--- a/custom_components/comfort_band/const.py
+++ b/custom_components/comfort_band/const.py
@@ -30,6 +30,7 @@ CONF_OVERRIDE_HOURS: Final = "override_hours"
 DEFAULT_DEADBAND_BELOW: Final = 0.3
 DEFAULT_DEADBAND_ABOVE: Final = 0.5
 DEFAULT_MIN_CYCLE_MINUTES: Final = 8
+DEFAULT_CROSS_MODE_MIN_MINUTES: Final = DEFAULT_MIN_CYCLE_MINUTES
 DEFAULT_OVERRIDE_HOURS: Final = 3
 
 # Number entity bounds (matches the legacy input_number ranges).

--- a/custom_components/comfort_band/coordinator.py
+++ b/custom_components/comfort_band/coordinator.py
@@ -460,13 +460,19 @@ class ZoneCoordinator(DataUpdateCoordinator[ZoneState]):
 
         # Cross-mode min-cycle: don't flip between heat and cool too quickly.
         # The hysteresis decider never returns heat → cool directly — it
-        # always releases through idle first — so by the time we see the
-        # flip-to-cool, `last_action` is `idle`. Look back at the action
-        # before idle via `previous_action`. `last_action_at` is the time
-        # the current (idle) action was committed, which equals the time
-        # the prior heat/cool ended — exactly the timestamp the dwell
-        # should be measured against. Idle/unknown prior actions don't
-        # trigger the gate (no prior commitment to dwell after).
+        # always releases through idle first — so on the normal path
+        # `last_action` is `idle` and we look back at the action before
+        # idle via `previous_action`. `last_action_at` is the time the
+        # current (idle) action was committed, which equals the time the
+        # prior heat/cool ended — exactly the timestamp the dwell should
+        # be measured against. Idle/unknown prior actions don't trigger
+        # the gate (no prior commitment to dwell after).
+        #
+        # The `last_action in (HEAT, COOL)` branch is defensive: it
+        # cannot fire if the always-through-idle invariant in
+        # hysteresis.py holds, but it ensures the gate still triggers if
+        # that invariant is ever violated rather than silently allowing
+        # a direct flip.
         prior_active_action = (
             last_action if last_action in (ACTION_HEAT, ACTION_COOL) else zone["previous_action"]
         )

--- a/custom_components/comfort_band/coordinator.py
+++ b/custom_components/comfort_band/coordinator.py
@@ -33,6 +33,8 @@ from homeassistant.util import dt as dt_util
 
 from . import apparent_temp, hysteresis, schedule
 from .const import (
+    ACTION_COOL,
+    ACTION_HEAT,
     ACTION_UNKNOWN,
     LOGGER,
     SIGNAL_ACTIVE_PROFILE_CHANGED,
@@ -154,8 +156,8 @@ class ZoneCoordinator(DataUpdateCoordinator[ZoneState]):
         return self._store.get_zone(self.zone_name)
 
     async def async_set_param(self, field: str, value: Any) -> None:
-        """Update a tunable (deadband_*, override_hours, min_cycle_minutes)
-        without triggering an override.
+        """Update a tunable (deadband_*, override_hours, min_cycle_minutes,
+        cross_mode_min_minutes) without triggering an override.
 
         Uses `async_request_refresh` (queued + deduped) rather than
         `async_refresh` because Number entities can fire rapid-fire writes
@@ -418,8 +420,10 @@ class ZoneCoordinator(DataUpdateCoordinator[ZoneState]):
         """Translate the decision into climate.set_hvac_mode + set_temperature.
 
         Skipped entirely when `enabled=False` (shadow mode -- log only).
-        Min-cycle suppression filters re-issue of the *same* action; mode
-        flips fire immediately so heat+cool can't deadlock.
+        Min-cycle suppression filters re-issue of the *same* action;
+        cross-mode-cycle suppression blocks heat↔cool flips within a short
+        dwell. Idle releases (heat→idle, cool→idle) pass through unchecked
+        so a heat or cool cycle can always stop.
         """
         if not enabled:
             LOGGER.debug(
@@ -437,12 +441,50 @@ class ZoneCoordinator(DataUpdateCoordinator[ZoneState]):
         last_action = zone["last_action"]
         last_action_at = _parse_iso(zone["last_action_at"])
         now_utc = dt_util.utcnow()
+        elapsed_s = (
+            (now_utc - last_action_at).total_seconds() if last_action_at is not None else None
+        )
 
+        # Same-mode min-cycle: don't re-issue the same action too quickly.
         if (
             last_action == decision.action
-            and last_action_at is not None
-            and (now_utc - last_action_at).total_seconds() < zone["min_cycle_minutes"] * 60
+            and elapsed_s is not None
+            and elapsed_s < zone["min_cycle_minutes"] * 60
         ):
+            return
+
+        # Cross-mode min-cycle: don't flip between heat and cool too quickly.
+        # The hysteresis decider never returns heat → cool directly — it
+        # always releases through idle first — so by the time we see the
+        # flip-to-cool, `last_action` is `idle`. Look back at the action
+        # before idle via `previous_action`. `last_action_at` is the time
+        # the current (idle) action was committed, which equals the time
+        # the prior heat/cool ended — exactly the timestamp the dwell
+        # should be measured against. Idle/unknown prior actions don't
+        # trigger the gate (no prior commitment to dwell after).
+        prior_active_action = (
+            last_action if last_action in (ACTION_HEAT, ACTION_COOL) else zone["previous_action"]
+        )
+        is_cross_mode_flip = (
+            prior_active_action in (ACTION_HEAT, ACTION_COOL)
+            and decision.action in (ACTION_HEAT, ACTION_COOL)
+            and prior_active_action != decision.action
+        )
+        if (
+            is_cross_mode_flip
+            and elapsed_s is not None
+            and elapsed_s < zone["cross_mode_min_minutes"] * 60
+        ):
+            LOGGER.debug(
+                "%s: cross-mode min-cycle suppressed %s → %s "
+                "(prior=%s elapsed=%.0fs, threshold=%dmin)",
+                self.zone_name,
+                last_action,
+                decision.action,
+                prior_active_action,
+                elapsed_s,
+                zone["cross_mode_min_minutes"],
+            )
             return
 
         await self.hass.services.async_call(
@@ -461,10 +503,19 @@ class ZoneCoordinator(DataUpdateCoordinator[ZoneState]):
                 },
                 blocking=True,
             )
+        # Roll `previous_action` forward on real transitions; leave it alone
+        # on same-mode re-commits (after the min-cycle window expires the
+        # coordinator re-issues the same hvac_mode — that's a refresh, not
+        # a transition, and the prior non-idle action shouldn't be
+        # overwritten by a same-action self-reference).
+        new_previous_action = (
+            last_action if last_action != decision.action else zone["previous_action"]
+        )
         await self._store.async_update_zone(
             self.zone_name,
             last_action=decision.action,
             last_action_at=now_utc.isoformat(),
+            previous_action=new_previous_action,
         )
 
 

--- a/custom_components/comfort_band/coordinator.py
+++ b/custom_components/comfort_band/coordinator.py
@@ -441,6 +441,11 @@ class ZoneCoordinator(DataUpdateCoordinator[ZoneState]):
         last_action = zone["last_action"]
         last_action_at = _parse_iso(zone["last_action_at"])
         now_utc = dt_util.utcnow()
+        # `elapsed_s` is None for a fresh-from-restart zone (no action has
+        # ever been committed). Both gates below short-circuit on `None`
+        # via their `elapsed_s is not None` guards, so neither suppresses
+        # the first heat or cool — correct: there's no committed action
+        # to dwell after.
         elapsed_s = (
             (now_utc - last_action_at).total_seconds() if last_action_at is not None else None
         )
@@ -477,11 +482,11 @@ class ZoneCoordinator(DataUpdateCoordinator[ZoneState]):
         ):
             LOGGER.debug(
                 "%s: cross-mode min-cycle suppressed %s → %s "
-                "(prior=%s elapsed=%.0fs, threshold=%dmin)",
+                "(via=%s elapsed=%.0fs, threshold=%dmin)",
                 self.zone_name,
-                last_action,
-                decision.action,
                 prior_active_action,
+                decision.action,
+                last_action,
                 elapsed_s,
                 zone["cross_mode_min_minutes"],
             )

--- a/custom_components/comfort_band/hysteresis.py
+++ b/custom_components/comfort_band/hysteresis.py
@@ -3,13 +3,22 @@
 `decide()` is a single-shot pure function: given the current room temperature,
 the effective band, the per-side deadbands, and the action currently in progress,
 it returns the desired terminal state. The coordinator handles the side effects
-(min-cycle suppression, dispatching to climate.set_hvac_mode + set_temperature).
+(same-mode and cross-mode min-cycle suppression, dispatching to
+climate.set_hvac_mode + set_temperature).
 
 Hysteresis loop:
   - Enter heat at room < low - deadband_below; release at room >= low.
   - Enter cool at room > high + deadband_above; release at room <= high.
   - In band -> idle (fan_only).
   - room is None -> unknown (caller does not write to climate).
+
+Mode transitions always pass through idle: from a heating state the only
+non-heat outcome is idle (when room >= low), and from a cooling state the
+only non-cool outcome is idle (when room <= high). The decider never
+returns cool directly from a heating state or heat directly from a cooling
+state. The coordinator's cross-mode-cycle gate relies on this invariant —
+if the routing rule changes here, the gate's `previous_action` logic must
+be revisited.
 """
 
 from __future__ import annotations

--- a/custom_components/comfort_band/manifest.json
+++ b/custom_components/comfort_band/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/dpretty/ha-comfort-band/issues",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/custom_components/comfort_band/number.py
+++ b/custom_components/comfort_band/number.py
@@ -1,10 +1,11 @@
 """Per-zone number entities.
 
-Six tunables are exposed as `number.{zone}_<key>`. Two of them
+Seven tunables are exposed as `number.{zone}_<key>`. Two of them
 (`manual_low`, `manual_high`) trigger an override on every UI write,
 matching the legacy automation's "context.user_id is not none" semantics.
-The other four (`override_hours`, `deadband_below`, `deadband_above`,
-`min_cycle_minutes`) are simple persisted tunables.
+The other five (`override_hours`, `deadband_below`, `deadband_above`,
+`min_cycle_minutes`, `cross_mode_min_minutes`) are simple persisted
+tunables.
 """
 
 from __future__ import annotations
@@ -82,6 +83,14 @@ _SPECS: tuple[_NumberSpec, ...] = (
     _NumberSpec(
         key="min_cycle_minutes",
         field="min_cycle_minutes",
+        min_value=0,
+        max_value=60,
+        step=1,
+        unit=UnitOfTime.MINUTES,
+    ),
+    _NumberSpec(
+        key="cross_mode_min_minutes",
+        field="cross_mode_min_minutes",
         min_value=0,
         max_value=60,
         step=1,

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -33,6 +33,7 @@ __all__ = [
 
 from .const import (
     BUILTIN_PROFILES,
+    DEFAULT_CROSS_MODE_MIN_MINUTES,
     DEFAULT_DEADBAND_ABOVE,
     DEFAULT_DEADBAND_BELOW,
     DEFAULT_MIN_CYCLE_MINUTES,
@@ -68,6 +69,15 @@ class StoredZone(TypedDict):
     deadband_below: float
     deadband_above: float
     min_cycle_minutes: int
+    # Dwell between heat↔cool flips. Default tracks `min_cycle_minutes` at
+    # zone creation but is independently tunable. Set to 0 to restore the
+    # pre-v0.5 "mode flips fire immediately" behaviour.
+    cross_mode_min_minutes: int
+    # The action that was current immediately before `last_action`. Needed
+    # to detect cross-mode flips that go through idle (heat → idle → cool),
+    # since by the time the predictor sees the flip-to-cool, the persisted
+    # `last_action` is already `idle`.
+    previous_action: str | None
     enabled: bool
     # Gate for the v0.4+ learning cluster (apparent-temp-aware nudges,
     # predictive control). Not consumed by anything yet — wired so future
@@ -127,6 +137,8 @@ def _default_zone(zone_name: str) -> StoredZone:
         "deadband_below": DEFAULT_DEADBAND_BELOW,
         "deadband_above": DEFAULT_DEADBAND_ABOVE,
         "min_cycle_minutes": DEFAULT_MIN_CYCLE_MINUTES,
+        "cross_mode_min_minutes": DEFAULT_CROSS_MODE_MIN_MINUTES,
+        "previous_action": None,
         "enabled": False,
         "learning_enabled": False,
         "use_apparent_temperature": False,
@@ -197,6 +209,19 @@ class ComfortBandStore:
                 migrated = True
             if "use_apparent_temperature" not in zone:
                 zone["use_apparent_temperature"] = False
+                migrated = True
+            # v0.4 → v0.5: default the cross-mode dwell to the zone's
+            # existing min_cycle_minutes so users who tuned same-mode dwell
+            # carry that preference into cross-mode automatically. Falls
+            # back to DEFAULT_MIN_CYCLE_MINUTES only if min_cycle_minutes
+            # is itself somehow absent (paranoid).
+            if "cross_mode_min_minutes" not in zone:
+                zone["cross_mode_min_minutes"] = zone.get(
+                    "min_cycle_minutes", DEFAULT_MIN_CYCLE_MINUTES
+                )
+                migrated = True
+            if "previous_action" not in zone:
+                zone["previous_action"] = None
                 migrated = True
         if migrated:
             await self._store.async_save(self._data)

--- a/custom_components/comfort_band/storage.py
+++ b/custom_components/comfort_band/storage.py
@@ -75,7 +75,7 @@ class StoredZone(TypedDict):
     cross_mode_min_minutes: int
     # The action that was current immediately before `last_action`. Needed
     # to detect cross-mode flips that go through idle (heat → idle → cool),
-    # since by the time the predictor sees the flip-to-cool, the persisted
+    # since by the time the coordinator sees the flip-to-cool, the persisted
     # `last_action` is already `idle`.
     previous_action: str | None
     enabled: bool

--- a/custom_components/comfort_band/strings.json
+++ b/custom_components/comfort_band/strings.json
@@ -72,6 +72,9 @@
       },
       "min_cycle_minutes": {
         "name": "Minimum cycle minutes"
+      },
+      "cross_mode_min_minutes": {
+        "name": "Cross-mode minimum minutes"
       }
     },
     "select": {

--- a/custom_components/comfort_band/translations/en.json
+++ b/custom_components/comfort_band/translations/en.json
@@ -72,6 +72,9 @@
       },
       "min_cycle_minutes": {
         "name": "Minimum cycle minutes"
+      },
+      "cross_mode_min_minutes": {
+        "name": "Cross-mode minimum minutes"
       }
     },
     "select": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -380,6 +380,190 @@ async def test_override_starts_then_expires(
     await coordinator.async_unload()
 
 
+async def test_cross_mode_min_cycle_suppresses_heat_to_cool(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    climate_calls: list[tuple[str, dict[str, Any]]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """heat → idle (release) → cool gets suppressed when the gap is shorter
+    than `cross_mode_min_minutes`. The hysteresis decider always routes
+    through idle (decide() returns idle once the room hits the band edge),
+    so cross-mode tracking relies on `previous_action`: by the time the
+    flip-to-cool is evaluated, `last_action` is `idle`."""
+    freezer.move_to("2026-04-25 10:00:00+00:00")
+    coordinator = await _setup_enabled_zone(hass, climate_calls)
+
+    # Heat fires (room well below low=19.5).
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Release to idle (room hits low band edge).
+    hass.states.async_set(TEMP_ENTITY, "20.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Within the 8-min default window, the room overshoots well above
+    # high+deadband_above=23.0. Cross-mode gate should suppress cool.
+    climate_calls.clear()
+    hass.states.async_set(TEMP_ENTITY, "24.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    set_modes = _calls_for(climate_calls, "set_hvac_mode")
+    cool_calls = [c for c in set_modes if c["hvac_mode"] == "cool"]
+    assert cool_calls == [], f"Cross-mode dwell should suppress cool, got {set_modes}"
+    await coordinator.async_unload()
+
+
+async def test_cross_mode_min_cycle_suppresses_cool_to_heat(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    climate_calls: list[tuple[str, dict[str, Any]]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Symmetric to heat→cool: cool → idle → heat suppressed within window."""
+    freezer.move_to("2026-04-25 10:00:00+00:00")
+    coordinator = await _setup_enabled_zone(hass, climate_calls)
+
+    # Cool fires (room well above high+deadband_above=23.0).
+    hass.states.async_set(TEMP_ENTITY, "24.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Release to idle.
+    hass.states.async_set(TEMP_ENTITY, "22.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Within window, room undershoots below low-deadband_below=19.2.
+    climate_calls.clear()
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    set_modes = _calls_for(climate_calls, "set_hvac_mode")
+    heat_calls = [c for c in set_modes if c["hvac_mode"] == "heat"]
+    assert heat_calls == [], f"Cross-mode dwell should suppress heat, got {set_modes}"
+    await coordinator.async_unload()
+
+
+async def test_cross_mode_min_cycle_allows_flip_after_window(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    climate_calls: list[tuple[str, dict[str, Any]]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """After `cross_mode_min_minutes` elapses since release, the flip fires."""
+    freezer.move_to("2026-04-25 10:00:00+00:00")
+    coordinator = await _setup_enabled_zone(hass, climate_calls)
+
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    hass.states.async_set(TEMP_ENTITY, "20.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Tick past the 8-min cross-mode window.
+    freezer.tick(timedelta(minutes=10))
+
+    climate_calls.clear()
+    hass.states.async_set(TEMP_ENTITY, "24.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    set_modes = _calls_for(climate_calls, "set_hvac_mode")
+    cool_calls = [c for c in set_modes if c["hvac_mode"] == "cool"]
+    assert cool_calls, f"Cool should fire after the window, got {set_modes}"
+    await coordinator.async_unload()
+
+
+async def test_cross_mode_min_cycle_zero_disables_gate(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    climate_calls: list[tuple[str, dict[str, Any]]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Setting cross_mode_min_minutes to 0 restores pre-v0.5 instant-flip behaviour."""
+    freezer.move_to("2026-04-25 10:00:00+00:00")
+    coordinator = await _setup_enabled_zone(hass, climate_calls)
+    # Disable the gate before any actions.
+    await coordinator._store.async_update_zone("office", cross_mode_min_minutes=0)
+
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    hass.states.async_set(TEMP_ENTITY, "20.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    climate_calls.clear()
+    hass.states.async_set(TEMP_ENTITY, "24.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    set_modes = _calls_for(climate_calls, "set_hvac_mode")
+    cool_calls = [c for c in set_modes if c["hvac_mode"] == "cool"]
+    assert cool_calls, f"With cross_mode=0 the flip should fire immediately, got {set_modes}"
+    await coordinator.async_unload()
+
+
+async def test_cross_mode_min_cycle_does_not_block_first_action(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    climate_calls: list[tuple[str, dict[str, Any]]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Fresh-from-restart zone has no previous_action; the gate must not
+    block the first heat. Regression guard against treating None as a flip."""
+    freezer.move_to("2026-04-25 10:00:00+00:00")
+    coordinator = await _setup_enabled_zone(hass, climate_calls)
+
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    set_modes = _calls_for(climate_calls, "set_hvac_mode")
+    heat_calls = [c for c in set_modes if c["hvac_mode"] == "heat"]
+    assert heat_calls, f"First heat must fire (no prior action), got {set_modes}"
+    await coordinator.async_unload()
+
+
+async def test_previous_action_records_prior_non_idle_through_idle_release(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    climate_calls: list[tuple[str, dict[str, Any]]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The cross-mode gate above is the consumer; this pins the underlying
+    storage invariant so a future refactor of `_maybe_apply_action`'s commit
+    step that drops `previous_action` tracking gets caught here, not in the
+    behavioural tests where the failure is harder to localise."""
+    freezer.move_to("2026-04-25 10:00:00+00:00")
+    coordinator = await _setup_enabled_zone(hass, climate_calls)
+    store = coordinator._store
+
+    # Heat fires: previous_action is still None (was None before).
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    zone = store.get_zone("office")
+    assert zone["last_action"] == "heating"
+    assert zone["previous_action"] is None
+
+    # Heat → idle: previous_action becomes heating.
+    hass.states.async_set(TEMP_ENTITY, "20.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    zone = store.get_zone("office")
+    assert zone["last_action"] == "idle"
+    assert zone["previous_action"] == "heating"
+    await coordinator.async_unload()
+
+
 async def test_cancel_override_immediately_clears_it(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -532,6 +532,86 @@ async def test_cross_mode_min_cycle_does_not_block_first_action(
     await coordinator.async_unload()
 
 
+async def test_cross_mode_gate_does_not_suppress_same_mode_bounce(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    climate_calls: list[tuple[str, dict[str, Any]]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """heat → idle → heat (room re-cools within the cross-mode window) is
+    NOT a cross-mode flip — both the prior and the new active action are
+    `heating`. The gate's `prior_active_action != decision.action` guard
+    must let this through. Sanity-check against a future refactor that
+    drops the inequality check and starts suppressing same-mode bounces."""
+    freezer.move_to("2026-04-25 10:00:00+00:00")
+    coordinator = await _setup_enabled_zone(hass, climate_calls)
+    # Drop min_cycle_minutes to 0 so the same-mode dwell is out of the way —
+    # this test isolates the cross-mode gate's inequality guard. Keep
+    # cross_mode_min_minutes at its default 8 so the gate would fire if it
+    # incorrectly treated same-mode bounces as flips.
+    await coordinator._store.async_update_zone("office", min_cycle_minutes=0)
+
+    # Heat fires, then releases to idle.
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    hass.states.async_set(TEMP_ENTITY, "20.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    # Within the 8-min cross-mode window (tick 2 min — well inside), the
+    # room cools again and re-triggers heat. The cross-mode gate sees
+    # prior_active_action=heating, decision.action=heating, and must let
+    # this through because they're the same mode.
+    freezer.tick(timedelta(minutes=2))
+    climate_calls.clear()
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    set_modes = _calls_for(climate_calls, "set_hvac_mode")
+    heat_calls = [c for c in set_modes if c["hvac_mode"] == "heat"]
+    assert heat_calls, "Same-mode bounce (heat→idle→heat) must not be gated as a cross-mode flip"
+    await coordinator.async_unload()
+
+
+async def test_previous_action_preserved_across_same_mode_re_commits(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    climate_calls: list[tuple[str, dict[str, Any]]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A same-mode re-issue (heat is still appropriate after the min-cycle
+    window expires) must NOT overwrite `previous_action`. Otherwise after
+    `heat → idle → heat → idle → cool` the cross-mode gate would lose
+    track of the first heat and treat the second heat→idle→cool sequence
+    as the first one. Pins the `last_action != decision.action` guard at
+    the commit site so a future refactor that drops it gets caught."""
+    freezer.move_to("2026-04-25 10:00:00+00:00")
+    coordinator = await _setup_enabled_zone(hass, climate_calls)
+    store = coordinator._store
+
+    # First heat: previous_action becomes None (was None before).
+    hass.states.async_set(TEMP_ENTITY, "18.0", {})
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert store.get_zone("office")["previous_action"] is None
+
+    # Tick past the same-mode min-cycle window (default 8 min) and refresh
+    # with the same heat-triggering temperature. The coordinator re-issues
+    # the heat command. Critically, `previous_action` must stay None — it
+    # was None before and the re-issue isn't a real transition.
+    freezer.tick(timedelta(minutes=10))
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    zone = store.get_zone("office")
+    assert zone["last_action"] == "heating"
+    assert zone["previous_action"] is None, (
+        "Same-mode re-issue must not overwrite previous_action with self-reference"
+    )
+    await coordinator.async_unload()
+
+
 async def test_previous_action_records_prior_non_idle_through_idle_release(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -23,7 +23,7 @@ def test_manifest_shape() -> None:
     assert manifest["integration_type"] == "helper"
     assert manifest["iot_class"] == "local_push"
     assert manifest["codeowners"] == ["@dpretty"]
-    assert manifest["version"] == "0.4.0"
+    assert manifest["version"] == "0.5.0"
     assert manifest["documentation"].startswith("https://")
     assert manifest["issue_tracker"].startswith("https://")
     assert manifest["requirements"] == []

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -34,9 +34,11 @@ async def test_default_zone_has_sane_initial_values(
     assert zone["enabled"] is False  # shadow-mode default
     assert zone["override_until"] is None
     assert zone["last_action"] is None
+    assert zone["previous_action"] is None
     assert zone["deadband_below"] == 0.3
     assert zone["deadband_above"] == 0.5
     assert zone["min_cycle_minutes"] == 8
+    assert zone["cross_mode_min_minutes"] == 8
     assert zone["override_hours"] == 3
     assert zone["manual_low"] < zone["manual_high"]
     assert zone["schedules"] == {}
@@ -468,9 +470,63 @@ async def test_load_legacy_v0_3_zone_backfills_new_fields(
     zone = store.get_zone("office")
     assert zone["learning_enabled"] is False
     assert zone["use_apparent_temperature"] is False
+    # The v0.4 → v0.5 backfill ran on the same load and defaulted
+    # cross_mode_min_minutes from the existing min_cycle_minutes (8).
+    # `previous_action` is added at the same time and starts unset.
+    assert zone["cross_mode_min_minutes"] == 8
+    assert zone["previous_action"] is None
     # And update_zone now works on the new field without KeyError.
     await store.async_update_zone("office", learning_enabled=True)
     assert store.get_zone("office")["learning_enabled"] is True
+
+
+async def test_load_legacy_v0_4_zone_backfills_cross_mode_from_min_cycle(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """A v0.4 zone payload (has learning_enabled / use_apparent_temperature
+    but no `cross_mode_min_minutes`) must backfill the new field from the
+    zone's own min_cycle_minutes — preserving any custom tuning the user
+    had applied to same-mode dwell."""
+    hass_storage["comfort_band.data"] = {
+        "version": 1,
+        "data": {
+            "zones": {
+                "office": {
+                    "zone_name": "office",
+                    "schedules": {},
+                    "manual_low": 19.5,
+                    "manual_high": 22.5,
+                    "override_hours": 3,
+                    "override_until": None,
+                    "deadband_below": 0.3,
+                    "deadband_above": 0.5,
+                    # User had tuned same-mode down to 4 min; cross-mode
+                    # should inherit that, not the system default of 8.
+                    "min_cycle_minutes": 4,
+                    "enabled": False,
+                    "learning_enabled": False,
+                    "use_apparent_temperature": False,
+                    # NB: no cross_mode_min_minutes.
+                    "last_action_at": None,
+                    "last_action": None,
+                }
+            },
+            "profiles": {
+                "home": {"name": "home", "description": ""},
+                "away": {"name": "away", "description": ""},
+            },
+            "active_profile": "home",
+            "default_profile": "home",
+        },
+    }
+    store = ComfortBandStore(hass)
+    await store.async_load()
+    zone = store.get_zone("office")
+    assert zone["cross_mode_min_minutes"] == 4  # inherited from min_cycle_minutes
+    assert zone["previous_action"] is None  # also backfilled in the same pass
+    # And update_zone now works on the new field without KeyError.
+    await store.async_update_zone("office", cross_mode_min_minutes=15)
+    assert store.get_zone("office")["cross_mode_min_minutes"] == 15
 
 
 async def test_clone_profile_without_source_schedule_creates_empty_target(


### PR DESCRIPTION
## Summary

Adds a per-zone `cross_mode_min_minutes` tunable that suppresses rapid `heat ↔ cool` mode flips. Closes [#16](https://github.com/dpretty/ha-comfort-band/issues/16).

**Behaviour change for existing users:** Mode flips that previously fired instantly now wait 8 minutes by default (matching the existing `min_cycle_minutes`). Set the new entity to `0` to restore the pre-v0.5 instant-flip behaviour. Idle releases (`heat → idle`, `cool → idle`) are never gated so a heat or cool cycle can always stop.

## Implementation notes

- `coordinator.py::_maybe_apply_action` extended with the cross-mode gate next to the existing same-mode min-cycle check.
- New `previous_action` field on `StoredZone`. The hysteresis decider always routes through idle on the way from heat to cool (`decide()` returns idle once the room hits the band edge), so by the time we evaluate the flip the persisted `last_action` is `idle`. The gate looks at `previous_action` for the prior non-idle action.
- `last_action_at` already records when the current action was committed, which equals when the prior action *ended* — exactly the timestamp the dwell should be measured against.
- New `number.{zone}_cross_mode_min_minutes` entity (bounds `[0, 60]`, default tracks the zone's `min_cycle_minutes` at creation).
- Storage backfill mirrors the v0.3 → v0.4 pattern at [storage.py:184-200](../blob/main/custom_components/comfort_band/storage.py#L184-L200). `STORAGE_VERSION` stays at 1 — field additions with safe defaults are forward-compatible.
- Version bumped 0.4.0 → 0.5.0 (minor, since default behaviour changes for every existing zone).

## Test plan

- [x] `pytest tests/` — 190 passed (was 182; +6 cross-mode coordinator cases, +2 storage migration cases)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict custom_components/comfort_band` clean
- [ ] After merge + v0.5.0 release, hard-restart HA and confirm:
  - `number.{zone}_cross_mode_min_minutes` exists per zone and equals the zone's `min_cycle_minutes`
  - Forcing a heat→idle→cool overshoot scenario within 8 min suppresses the cool flip (look for `cross-mode min-cycle suppressed heating → cooling` at DEBUG)
  - Setting the entity to `0` restores instant-flip behaviour
  - `heat → idle` and `cool → idle` releases still fire immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)